### PR TITLE
add mips softfloat & mipsle softfloat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,12 @@ jobs:
             goarch: mipsle
           - goos: linux
             goarch: mips
+          - goos: linux
+            goarch: mipsle
+            gomips: softfloat
+          - goos: linux
+            goarch: mips
+            gomips: softfloat
           # END MIPS
           # BEGIN PPC
           - goos: linux
@@ -104,6 +110,7 @@ jobs:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
+      GOMIPS: ${{ matrix.gomips }}
       CGO_ENABLED: 0
     steps:
       - name: Checkout codebase
@@ -117,7 +124,10 @@ jobs:
           if [ "$GOOS" == "windows" ]; then
             export _NAME="$_NAME.exe"
           fi
-          echo "GOOS: $GOOS, GOARCH: $GOARCH, GOARM: $GOARM, RELEASE_NAME: $_NAME"
+          if [ "$GOMIPS" == "softfloat" ]; then
+            export _NAME="${_NAME}_softfolat"
+          fi
+          echo "GOOS: $GOOS, GOARCH: $GOARCH, GOARM: $GOARM, GOMIPS: $GOMIPS, RELEASE_NAME: $_NAME"
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
           echo "BUILD_VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV


### PR DESCRIPTION
在 workflow 中增加 mips(le) with softfloat 的编译项：
1. 编译时增加环境变量 GOMIPS=softfloat
2. 编译产物增加 softfloat 后缀

附运行测试： https://github.com/1-1-2/NTrace-core/actions/runs/6506081831

---

SoC mt7621 是 mipsle架构，保有量应该还蛮大，没有浮点单元，不支持 hardfloat。
现在我是手搓了一个 [workflow](https://github.com/1-1-2/Actions-Debug/blob/main/.github/workflows/%5BNextTrace%5DBuild%20MIPS%20Softfloat.yml) 自己在用。

last run: https://github.com/1-1-2/Actions-Debug/actions/runs/6490578208