### PR TITLE
docs: Clarify the steps in the installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,15 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
     After installing Go >= 1.20 yourself, you can use the following command to install
 
     ```shell
-    go install github.com/nxtrace/Ntrace-V1@latest
+    go install github.com/nxtrace/NTrace-core@latest
     ```
+    *because of the version constraints conflict, you can not install  `NTrace-V1` by this*
     After installation, the executable is in the `$GOPATH/bin` directory. If you have not set `GOPATH`, it is in the `$HOME/go/bin` directory.
-
+    The binary file name is consistent with the project name. You need to replace the `nexttrace` command below with `NTrace-core`.
+     If you want to be consistent with the commands below, you can rename the binary after executing the `go install` command
+    ```shell
+    mv  $GOPATH/bin/NTrace-core $GOPATH/bin/nexttrace
+    ``` 
 
 ### Get Started
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -131,9 +131,16 @@ Document Language: [English](README.md) | 简体中文
     您可在自行安装Go >= 1.20后，使用以下命令安装
 
     ```shell
-    go install github.com/nxtrace/Ntrace-V1@latest
+    go install github.com/nxtrace/NTrace-core@latest
     ```
-    安装后可执行文件在`$GOPATH/bin`目录下，如果您没有设置`GOPATH`，则在`$HOME/go/bin`目录下。
+    *由于go.mod文件声明和文件目录冲突的问题，你不能用go install命令安装  `NTrace-V1` 版本*
+    安装后可执行文件在`$GOPATH/bin`目录下，如果您没有设置`GOPATH`，则在`$HOME/go/bin`目录下。 
+    安装后二进制文件名称与项目名称保持一致，你需要将下文中的 `nexttrace` 命令替换为 `NTrace-core` 使用
+    如果你希望与下文命令保持一致，可以在执行 `go install` 命令后重命名二进制文件
+
+    ```shell
+    mv  $GOPATH/bin/NTrace-core $GOPATH/bin/nexttrace
+    ``` 
 
 
 ### Get Started


### PR DESCRIPTION
在文档中加入了对以下问题的说明：

1.文档中关于从源码安装的部分项目名称写错啦hh

2.由于go.mod文件的路径冲突，不能用这种方式直接安装V1版本`

```shell
❯ go install github.com/nxtrace/NTrace-V1@latest
go: downloading github.com/nxtrace/NTrace-V1 v1.2.4
go: github.com/nxtrace/NTrace-V1@latest: version constraints conflict:
	github.com/nxtrace/NTrace-V1@v1.2.4: parsing go.mod:
	module declares its path as: github.com/nxtrace/NTrace-core
	        but was required as: github.com/nxtrace/NTrace-V1
```

3. 安装后二进制文件为项目名称，需要改一下名可以正常使用