### PR TITLE
fix: close when `createWsConn` failed

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
 	"log"
 	"net"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
 
 	"github.com/akamensky/argparse"
 	"github.com/nxtrace/NTrace-core/config"
@@ -114,7 +115,7 @@ func Excute() {
 			Timeout:        time.Duration(*timeout) * time.Millisecond,
 			File:           *file,
 			DontFragment:   *dontFragment,
-			Dot:			*dot,
+			Dot:            *dot,
 		}
 
 		fastTrace.FastTest(*tcp, *output, paramsFastTrace)
@@ -186,7 +187,9 @@ func Excute() {
 			w.Interrupt = make(chan os.Signal, 1)
 			signal.Notify(w.Interrupt, os.Interrupt)
 			defer func() {
-				w.Conn.Close()
+				if w.Conn != nil {
+					w.Conn.Close()
+				}
 			}()
 		}
 	}


### PR DESCRIPTION
```console
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1029e8708]

goroutine 1 [running]:
github.com/gorilla/websocket.(*Conn).Close(0x14000192180?)
        github.com/gorilla/websocket@v1.5.2/conn.go:344 +0x18
github.com/nxtrace/NTrace-core/cmd.Excute.func1()
        github.com/nxtrace/NTrace-core/cmd/cmd.go:188 +0x24
github.com/nxtrace/NTrace-core/cmd.Excute()
        github.com/nxtrace/NTrace-core/cmd/cmd.go:359 +0x1d34
main.main()
        github.com/nxtrace/NTrace-core/main.go:8 +0x1c
```