### PR TITLE
docs(install): add x-cmd method to install nexttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
 
         * Scoop-extra is maintained by soenggam
 
+* X-CMD
+    * [x-cmd](https://x-cmd.com) is a lightweight cross-platform package manager implemented in posix shell. Quickly download and execute `nexttrace` with a single command: [`x nexttrace`](https://x-cmd.com/pkg/nexttrace)
+        * You can also install `nexttrace` in the user level without requiring root privileges.
+             ```shell
+             x env use nexttrace
+             ```
+
 Please note, the repositories for all of the above installation methods are maintained by open source enthusiasts. Availability and timely updates are not guaranteed. If you encounter problems, please contact the repository maintainer to solve them, or use the binary packages provided by the official build of this project.
 
 ### Manual Install

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -120,6 +120,14 @@ Document Language: [English](README.md) | 简体中文
 
      * scoop-extra 由 soenggam 维护
 
+* X-CMD
+  * [x-cmd](https://cn.x-cmd.com) 是一个使用 posix shell 实现的轻量级跨平台包管理器。使用单个命令快速下载并执行 `nexttrace` ： [`x nexttrace`](https://cn.x-cmd.com/pkg/nexttrace)
+     * 您还可以在用户级安装 `nexttrace`，且不需要 root 权限
+
+          ```shell
+          x env use nexttrace
+          ```
+
 请注意，以上多种安装方式的仓库均由开源爱好者自行维护，不保证可用性和及时更新，如遇到问题请联系仓库维护者解决，或使用本项目官方编译提供的二进制包。
 
 ### Manual Install


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download nexttrace release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the nexttrace README.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use nexttrace
  ```

- By the way, we wrote a [nexttrace introduction article and a demo](https://www.x-cmd.com/pkg/nexttrace)
