### PR TITLE
完成了UDP/UDPv6模式的并发优化

### DIFF
--- a/.cross_compile.sh
+++ b/.cross_compile.sh
@@ -5,7 +5,7 @@ set -e
 DIST_PREFIX="nexttrace"
 DEBUG_MODE=${2}
 TARGET_DIR="dist"
-PLATFORMS="darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm64 linux/mips linux/mips64 linux/mipsle linux/mips64le windows/amd64 windows/arm64 openbsd/amd64 openbsd/arm64 freebsd/amd64 freebsd/arm64"
+PLATFORMS="linux/386 linux/amd64 linux/arm64 linux/mips linux/mips64 linux/mipsle linux/mips64le windows/amd64 windows/arm64 openbsd/amd64 openbsd/arm64 freebsd/amd64 freebsd/arm64"
 
 BUILD_VERSION="$(git describe --tags --always)"
 BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -58,4 +58,24 @@ done
                         -w -s -checklinkname=0"
     fi
 
-
+if [ "$(uname)" = "Darwin" ]; then
+  for GOARCH in amd64 arm64; do
+    export CGO_ENABLED=1
+    export GOOS=darwin
+    export TARGET=${TARGET_DIR}/${DIST_PREFIX}_${GOOS}_${GOARCH}
+    echo "build => ${TARGET}"
+    if [ "${DEBUG_MODE}" = "debug" ]; then
+      go build -trimpath -gcflags "all=-N -l" -o "${TARGET}" \
+        -ldflags "-X 'github.com/nxtrace/NTrace-core/config.Version=${BUILD_VERSION}' \
+                  -X 'github.com/nxtrace/NTrace-core/config.BuildDate=${BUILD_DATE}' \
+                  -X 'github.com/nxtrace/NTrace-core/config.CommitID=${COMMIT_SHA1}' \
+                  -w -s -checklinkname=0"
+    else
+      go build -trimpath -o "${TARGET}" \
+        -ldflags "-X 'github.com/nxtrace/NTrace-core/config.Version=${BUILD_VERSION}' \
+                  -X 'github.com/nxtrace/NTrace-core/config.BuildDate=${BUILD_DATE}' \
+                  -X 'github.com/nxtrace/NTrace-core/config.CommitID=${COMMIT_SHA1}' \
+                  -w -s -checklinkname=0"
+    fi
+  done
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,19 +25,13 @@ jobs:
     strategy:
       matrix:
         # Include amd64 on all platforms.
-        goos: [windows, freebsd, openbsd, linux, dragonfly, darwin]
+        goos: [windows, freebsd, openbsd, linux, dragonfly]
         goarch: [amd64, 386]
         exclude:
-          # Exclude i386 on darwin and dragonfly.
+          # Exclude i386 on dragonfly.
           - goarch: 386
             goos: dragonfly
-          - goarch: 386
-            goos: darwin
         include:
-          # BEIGIN MacOS ARM64
-          - goos: darwin
-            goarch: arm64
-          # END macOS ARM64
           # BEGIN Linux ARM 5 6 7
           - goos: linux
             goarch: arm
@@ -135,7 +129,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.x'
       - name: Get project dependencies
         run: go mod download
       - name: Build
@@ -156,6 +150,58 @@ jobs:
         uses: softprops/action-gh-release@v2
         with: # 将下述可执行文件 release 上去
           draft: true # Release草稿
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GT_Token }}
+
+  build-darwin:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        goarch: [ amd64, arm64 ]
+    env:
+      GOOS: darwin
+      GOARCH: ${{ matrix.goarch }}
+      CGO_ENABLED: 1
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v5
+
+      - name: Show workflow information
+        run: |
+          export _NAME="nexttrace_${GOOS}_${GOARCH}"
+          echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME=$_NAME"
+          echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
+          echo "BUILD_VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+          echo "COMMIT_SHA1=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+      - name: Get project dependencies
+        run: go mod download
+      - name: Build
+        run: |
+          go build -trimpath -o dist/${ASSET_NAME} \
+            -ldflags "-X 'github.com/nxtrace/NTrace-core/config.Version=${BUILD_VERSION}' \
+                      -X 'github.com/nxtrace/NTrace-core/config.BuildDate=${BUILD_DATE}' \
+                      -X 'github.com/nxtrace/NTrace-core/config.CommitID=${COMMIT_SHA1}' \
+                      -checklinkname=0 -w -s"
+
+      - name: Upload files to Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_NAME }}
+          path: dist/${{ env.ASSET_NAME }}
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
           files: |
             dist/*
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,16 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.x'
       - name: Checkout codebase
         uses: actions/checkout@v5
       - name: Test with unix
         if: ${{ matrix.os != 'windows-latest' }}
-        run: sudo go test -v -ldflags=-checklinkname=0 -coverprofile='coverage.out' -covermode=count ./...
+        run: |
+          sudo go env -w GOTOOLCHAIN=go1.25.0+auto
+          sudo go test -v -ldflags=-checklinkname=0 -covermode=count -coverprofile='coverage.out' ./...
       - name: Test with windows
         if: ${{ matrix.os == 'windows-latest' }}
-        run: go test -v -ldflags=-checklinkname=0 -coverprofile='coverage.out' -covermode=count ./...
+        run: |
+          go env -w GOTOOLCHAIN=go1.25.0+auto
+          go test -v -ldflags=-checklinkname=0 -covermode=count -coverprofile="coverage.out" ./...

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -238,6 +238,7 @@ func Execute() {
 
 	if *srcDev != "" {
 		dev, _ := net.InterfaceByName(*srcDev)
+		util.SrcDev = dev.Name
 		if addrs, err := dev.Addrs(); err == nil {
 			for _, addr := range addrs {
 				if (addr.(*net.IPNet).IP.To4() == nil) == (ip.To4() == nil) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -105,6 +105,11 @@ func Execute() {
 
 	domain := *str
 
+	// 仅在使用 UDP 探测时，确保 UDP 负载长度 ≥ 2
+	if *udp && *packetSize < 2 {
+		*packetSize = 2
+	}
+
 	var m trace.Method
 
 	switch {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nxtrace/NTrace-core
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/akamensky/argparse v1.4.0

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -125,7 +125,7 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 	t.res.Hops = make([][]Hop, t.MaxHops)
 	// 解析并校验用户指定的 IPv6 源地址
 	SrcAddr := net.ParseIP(t.SrcAddr)
-	if t.SrcAddr != "" && (SrcAddr == nil || SrcAddr.To4() != nil || SrcAddr.To16() == nil) {
+	if t.SrcAddr != "" && !util.IsIPv6(SrcAddr) {
 		return nil, errors.New("invalid IPv6 SrcAddr: " + t.SrcAddr)
 	}
 

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -49,13 +49,16 @@ func (t *ICMPTracerv6) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 		close(status)
 	}()
+
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
+
 	for {
 		if t.AsyncPrinter != nil {
 			t.AsyncPrinter(&t.res)
 		}
+
 		// 接收的时候检查一下是不是 3 跳都齐了
 		if ttl < len(t.res.Hops) &&
 			len(t.res.Hops[ttl]) == t.NumMeasurements {
@@ -67,6 +70,7 @@ func (t *ICMPTracerv6) PrintFunc(ctx context.Context, status chan<- bool) {
 				return
 			}
 		}
+
 		select {
 		case <-ctx.Done():
 			// 非正常退出
@@ -91,12 +95,14 @@ func (t *ICMPTracerv6) launchTTL(ctx context.Context, ttl int) {
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
+
 			t.wg.Add(1)
 			go func(ttl, i int) {
 				if err := t.send(ctx, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
 					log.Printf("send failed: ttl=%d i=%d: %v", ttl, i, err)
 				}
 			}(ttl, i)
+
 			select {
 			case <-ctx.Done():
 				return
@@ -115,20 +121,22 @@ func (t *ICMPTracerv6) initEchoID() {
 func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 	// 初始化 Echo.ID
 	t.initEchoID()
+
 	// 初始化 inflightRequest map
 	t.inflightRequest = make(map[int]chan Hop)
 
 	if len(t.res.Hops) > 0 {
 		return &t.res, ErrTracerouteExecuted
 	}
+
 	// 初始化 Result.Hops，并预分配到 MaxHops
 	t.res.Hops = make([][]Hop, t.MaxHops)
+
 	// 解析并校验用户指定的 IPv6 源地址
 	SrcAddr := net.ParseIP(t.SrcAddr)
 	if t.SrcAddr != "" && !util.IsIPv6(SrcAddr) {
 		return nil, errors.New("invalid IPv6 SrcAddr: " + t.SrcAddr)
 	}
-
 	SrcIP := ""
 	if SrcAddr != nil {
 		SrcIP = SrcAddr.String()
@@ -143,12 +151,10 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 			_ = c.Close()
 		}
 	}()
-
 	t.icmpConn = ipv6.NewPacketConn(t.icmp)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-
 	t.final.Store(-1)
 
 	t.wg.Add(1)
@@ -164,41 +170,28 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 		defer t.wg.Done()
 		// 立即启动 BeginHop 对应的 TTL 组
 		t.launchTTL(ctx, t.BeginHop)
+
 		// 之后按 TTLInterval 周期启动后续 TTL 组
 		ticker := time.NewTicker(time.Millisecond * time.Duration(t.Config.TTLInterval))
 		defer ticker.Stop()
+
 		for ttl := t.BeginHop + 1; ttl <= t.MaxHops; ttl++ {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
 			}
+
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
 				return
 			}
+
 			// 并发启动这个 TTL 的所有测量
 			t.launchTTL(ctx, ttl)
 		}
 	}()
-	// for ttl := t.BeginHop; ttl <= t.MaxHops; ttl++ {
-	// 	if t.final != -1 && ttl > t.final {
-	// 		break
-	// 	}
-	// 	for i := 0; i < t.NumMeasurements; i++ {
-	// 		t.wg.Add(1)
-	// 		go t.send(ttl)
-	// 	}
-	// 	// 一组TTL全部退出（收到应答或者超时终止）以后，再进行下一个TTL的包发送
-	// 	t.wg.Wait()
-	// 	if t.RealtimePrinter != nil {
-	// 		t.RealtimePrinter(&t.res, ttl-1)
-	// 	}
 
-	// 	if t.AsyncPrinter != nil {
-	// 		t.AsyncPrinter(&t.res)
-	// 	}
-	// }
 	normalExit := <-statusCh
 	stop()
 	t.wg.Wait()
@@ -221,14 +214,17 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 			if !ok {
 				return
 			}
+
 			if msg.N == nil {
 				continue
 			}
+
 			rm, err := icmp.ParseMessage(58, msg.Msg[:*msg.N])
 			if err != nil {
 				log.Println(err)
 				continue
 			}
+
 			var (
 				data     []byte
 				icmpType int8 // 0=TimeExceeded, 2=DestinationUnreachable
@@ -275,9 +271,11 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 				continue
 				//log.Println("received icmp message of unknown type", rm.Type)
 			}
+
 			if len(data) < 40 || data[0]>>4 != 6 {
 				continue
 			}
+
 			dstip := net.IP(data[24:40])
 			if dstip.Equal(t.DestIP) || dstip.Equal(net.IPv6zero) {
 				inner, err := util.GetICMPResponsePayload(data)
@@ -291,40 +289,8 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 				seq := int(binary.BigEndian.Uint16(inner[6:8]))
 				t.handleICMPMessage(msg, icmpType, data, seq)
 			}
-			// dstip := net.IP(msg.Msg[32:48])
-			// if binary.BigEndian.Uint16(msg.Msg[52:54]) != uint16(os.Getpid()&0xffff) {
-			// 	//	// 如果类型为应答消息，且应答消息包的进程ID与主进程相同时不跳过
-			// 	if binary.BigEndian.Uint16(msg.Msg[52:54]) != 0 {
-			// 		continue
-			// 	} else {
-			// 		if dstip.String() != "::" {
-			// 			continue
-			// 		}
-			// 		if msg.Peer.String() != t.DestIP.String() {
-			// 			continue
-			// 		}
-			// 	}
-			// }
-
-			// if dstip.Equal(t.DestIP) || dstip.Equal(net.IPv6zero) {
-			// 	rm, err := icmp.ParseMessage(58, msg.Msg[:*msg.N])
-			// 	if err != nil {
-			// 		log.Println(err)
-			// 		continue
-			// 	}
-			// 	// log.Println(msg.Peer)
-			// 	switch rm.Type {
-			// 	case ipv6.ICMPTypeTimeExceeded:
-			// 		t.handleICMPMessage(msg, 0, rm.Body.(*icmp.TimeExceeded).Data)
-			// 	case ipv6.ICMPTypeEchoReply:
-			// 		t.handleICMPMessage(msg, 1, rm.Body.(*icmp.Echo).Data)
-			// 	default:
-			// 		// log.Println("received icmp message of unknown type", rm.Type)
-			// 	}
-			// }
 		}
 	}
-
 }
 
 func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, icmpType int8, data []byte, seq int) {
@@ -335,6 +301,7 @@ func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, icmpType int8, dat
 	}
 
 	mpls := extractMPLS(msg, data)
+
 	// 取出通道后立刻解锁
 	t.inflightRequestLock.RLock()
 	ch, ok := t.inflightRequest[seq]
@@ -348,6 +315,7 @@ func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, icmpType int8, dat
 		Address: msg.Peer,
 		MPLS:    mpls,
 	}
+
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞
 	select {
 	case ch <- h:
@@ -376,6 +344,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
 		return nil
 	}
+
 	// 将 TTL 编码到高 8 位；将索引 i 编码到低 8 位
 	seq := (ttl << 8) | (i & 0xFF)
 
@@ -388,9 +357,10 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 		delete(t.inflightRequest, seq)
 		t.inflightRequestLock.Unlock()
 	}()
+
 	// 高8位放随机tag，低8位放pid低8位
 	id := int(uint16(t.echoIDTag)<<8 | uint16(t.pidLow))
-	//data := []byte{byte(ttl)}
+
 	var data []byte
 	if t.Config.PktSize < 3 {
 		data = bytes.Repeat([]byte{0}, t.Config.PktSize)
@@ -398,6 +368,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 		data = bytes.Repeat([]byte{0}, t.Config.PktSize-3)
 		data = append(data, 0x6e, 0x74, 0x72) // "ntr" 作为标识
 	}
+
 	icmpHeader := icmp.Message{
 		Type: ipv6.ICMPTypeEchoRequest, Code: 0,
 		Body: &icmp.Echo{
@@ -406,6 +377,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 			Seq:  seq,
 		},
 	}
+
 	// 串行设置 HopLimit + 发送，放在同一把锁里保证并发安全
 	t.hopLimitLock.Lock()
 	if err := t.icmpConn.SetHopLimit(ttl); err != nil {
@@ -429,6 +401,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 		return context.Canceled
 	case h := <-hopCh:
 		rtt := time.Since(start)
+
 		if f := t.final.Load(); f != -1 && ttl > int(f) {
 			return nil
 		}
@@ -451,6 +424,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 		if err := h.fetchIPData(t.Config); err != nil {
 			return err
 		}
+
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
 	case <-time.After(t.Timeout):
 		if f := t.final.Load(); f != -1 && ttl > int(f) {
@@ -464,6 +438,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 			RTT:     0,
 			Error:   ErrHopLimitTimeout,
 		}
+
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
 	}
 	return nil

--- a/trace/internal/tcp_darwin.go
+++ b/trace/internal/tcp_darwin.go
@@ -1,0 +1,86 @@
+//go:build darwin
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+func ListenTCP(ctx context.Context, _ net.PacketConn, ipv int, srcip, dstip net.IP, onACK func(ack uint32, peer net.Addr)) {
+	dev := util.FindDeviceByIP(srcip)
+	if dev == "" {
+		dev = "en0"
+	}
+
+	ipPrefix := "ip"
+	if ipv == 6 {
+		ipPrefix = "ip6"
+	}
+
+	handle, err := pcap.OpenLive(dev, 65535, true, pcap.BlockForever)
+	if err != nil {
+		log.Printf("pcap open failed on %s: %v", dev, err)
+		return
+	}
+	defer handle.Close()
+
+	// 过滤：只抓{ip/ip6}+tcp，来自 (dstip) → 本机 (srcip)，且 RST 或 SYN+ACK
+	filter := fmt.Sprintf(
+		"%s and tcp and src host %s and dst host %s and (tcp[13] & 0x04 != 0 or tcp[13] & 0x12 == 0x12)",
+		ipPrefix, dstip.String(), srcip.String(),
+	)
+	if err := handle.SetBPFFilter(filter); err != nil {
+		log.Printf("pcap set filter failed: %v", err)
+		return
+	}
+
+	src := gopacket.NewPacketSource(handle, handle.LinkType())
+	pktCh := src.Packets()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pkt, ok := <-pktCh:
+			if !ok {
+				return
+			}
+
+			// 解包
+			packet := pkt.NetworkLayer()
+			if packet == nil {
+				continue
+			}
+
+			// 从包中获取TCP layer信息
+			if tl := pkt.Layer(layers.LayerTypeTCP); tl != nil {
+				tcpL := tl.(*layers.TCP)
+				switch ipv {
+				case 4:
+					if ip4, _ := packet.(*layers.IPv4); ip4 != nil {
+						onACK(tcpL.Ack, &net.IPAddr{IP: ip4.SrcIP})
+					} else {
+						continue
+					}
+				case 6:
+					if ip6, _ := packet.(*layers.IPv6); ip6 != nil {
+						onACK(tcpL.Ack, &net.IPAddr{IP: ip6.SrcIP})
+					} else {
+						continue
+					}
+				default:
+					continue
+				}
+			}
+		}
+	}
+}

--- a/trace/internal/tcp_general.go
+++ b/trace/internal/tcp_general.go
@@ -1,0 +1,73 @@
+//go:build !darwin
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+func ListenTCP(ctx context.Context, tcp net.PacketConn, ipv int, _, dstip net.IP, onACK func(ack uint32, peer net.Addr)) {
+	if tcp == nil {
+		return
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = tcp.Close()
+	}()
+
+	buf := make([]byte, 4096)
+
+	for {
+		n, peer, err := tcp.ReadFrom(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+				return
+			}
+			continue
+		}
+		if n == 0 {
+			continue
+		}
+
+		// 仅处理来自目标 IP 的 TCP 包
+		if ip := util.AddrIP(peer); ip == nil || !ip.Equal(dstip) {
+			continue
+		}
+
+		// 拷贝出精确长度，避免 buf 复用带来的数据竞争/覆盖
+		pkt := make([]byte, n)
+		copy(pkt, buf[:n])
+
+		// 解包
+		var packet gopacket.Packet
+		if ipv == 4 {
+			packet = gopacket.NewPacket(pkt, layers.LayerTypeIPv4, gopacket.Default)
+		} else {
+			packet = gopacket.NewPacket(pkt, layers.LayerTypeIPv6, gopacket.Default)
+		}
+		if errLayer := packet.ErrorLayer(); errLayer != nil {
+			// 回退：某些内核缓冲可能直接从 TCP 头开始
+			packet = gopacket.NewPacket(pkt, layers.LayerTypeTCP, gopacket.Default)
+			if packet.ErrorLayer() != nil {
+				continue
+			}
+		}
+
+		// 从包中获取TCP layer信息
+		if tl := packet.Layer(layers.LayerTypeTCP); tl != nil {
+			tcpL := tl.(*layers.TCP)
+			if !(tcpL.RST || (tcpL.SYN && tcpL.ACK)) {
+				continue
+			}
+			onACK(tcpL.Ack, peer)
+		}
+	}
+}

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -163,9 +163,14 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		internal.ListenTCP(ctx, t.tcp, 4, t.SrcIP, t.DestIP, func(ack uint32, peer net.Addr) {
-			// 从对端返回的 ack-1 恢复出原始探测包的 seq
-			seq := int(ack - 1)
+		internal.ListenTCP(ctx, t.tcp, 4, t.SrcIP, t.DestIP, func(ack uint32, peer net.Addr, ackType int) {
+			// 依据报文类型还原原始探测 seq：1=RST+ACK => ack-1-PktSize；2=SYN+ACK => ack-1
+			var seq int
+			if ackType == 1 {
+				seq = int(ack) - 1 - t.Config.PktSize
+			} else {
+				seq = int(ack) - 1
+			}
 
 			// 取出通道后立刻解锁
 			t.inflightRequestLock.RLock()

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/nxtrace/NTrace-core/trace/internal"
 	"github.com/nxtrace/NTrace-core/util"
 )
 
@@ -48,13 +49,16 @@ func (t *TCPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 		close(status)
 	}()
+
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
+
 	for {
 		if t.AsyncPrinter != nil {
 			t.AsyncPrinter(&t.res)
 		}
+
 		// 接收的时候检查一下是不是 3 跳都齐了
 		if ttl < len(t.res.Hops) &&
 			len(t.res.Hops[ttl]) == t.NumMeasurements {
@@ -66,6 +70,7 @@ func (t *TCPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
 				return
 			}
 		}
+
 		select {
 		case <-ctx.Done():
 			// 非正常退出
@@ -90,12 +95,14 @@ func (t *TCPTracer) launchTTL(ctx context.Context, ttl int) {
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
+
 			t.wg.Add(1)
 			go func(ttl, i int) {
 				if err := t.send(ctx, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
 					log.Printf("send failed: ttl=%d i=%d: %v", ttl, i, err)
 				}
 			}(ttl, i)
+
 			select {
 			case <-ctx.Done():
 				return
@@ -112,14 +119,15 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 	if len(t.res.Hops) > 0 {
 		return &t.res, ErrTracerouteExecuted
 	}
+
 	// 初始化 Result.Hops，并预分配到 MaxHops
 	t.res.Hops = make([][]Hop, t.MaxHops)
+
 	// 解析并校验用户指定的 IPv4 源地址
 	SrcAddr := net.ParseIP(t.SrcAddr).To4()
 	if t.SrcAddr != "" && SrcAddr == nil {
 		return nil, errors.New("invalid IPv4 SrcAddr:" + t.SrcAddr)
 	}
-
 	t.SrcIP, _ = util.LocalIPPort(t.DestIP, SrcAddr, "tcp")
 	if t.SrcIP == nil {
 		return nil, errors.New("cannot determine local IPv4 address")
@@ -134,7 +142,6 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 			_ = c.Close()
 		}
 	}()
-
 	t.tcpConn = ipv4.NewPacketConn(t.tcp)
 
 	t.icmp, err = icmp.ListenPacket("ip4:icmp", t.SrcIP.String())
@@ -149,13 +156,38 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-
 	t.final.Store(-1)
 
 	t.wg.Add(1)
 	go t.listenICMP(ctx)
 	t.wg.Add(1)
-	go t.listenTCP(ctx)
+	go func() {
+		defer t.wg.Done()
+		internal.ListenTCP(ctx, t.tcp, 4, t.SrcIP, t.DestIP, func(ack uint32, peer net.Addr) {
+			// 从对端返回的 ack-1 恢复出原始探测包的 seq
+			seq := int(ack - 1)
+
+			// 取出通道后立刻解锁
+			t.inflightRequestLock.RLock()
+			ch, ok := t.inflightRequest[seq]
+			t.inflightRequestLock.RUnlock()
+			if !ok || ch == nil {
+				return
+			}
+
+			h := Hop{
+				Success: true,
+				Address: peer,
+			}
+
+			// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞
+			select {
+			case ch <- h:
+			default:
+				// 丢弃重复/迟到的相同 seq 回包，避免阻塞
+			}
+		})
+	}()
 	statusCh := make(chan bool, 1)
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, statusCh)
@@ -167,23 +199,28 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 		defer t.wg.Done()
 		// 立即启动 BeginHop 对应的 TTL 组
 		t.launchTTL(ctx, t.BeginHop)
+
 		// 之后按 TTLInterval 周期启动后续 TTL 组
 		ticker := time.NewTicker(time.Millisecond * time.Duration(t.Config.TTLInterval))
 		defer ticker.Stop()
+
 		for ttl := t.BeginHop + 1; ttl <= t.MaxHops; ttl++ {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
 			}
+
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
 				return
 			}
+
 			// 并发启动这个 TTL 的所有测量
 			t.launchTTL(ctx, ttl)
 		}
 	}()
+
 	normalExit := <-statusCh
 	stop()
 	t.wg.Wait()
@@ -206,14 +243,17 @@ func (t *TCPTracer) listenICMP(ctx context.Context) {
 			if !ok {
 				return
 			}
+
 			if msg.N == nil {
 				continue
 			}
+
 			rm, err := icmp.ParseMessage(1, msg.Msg[:*msg.N])
 			if err != nil {
 				log.Println(err)
 				continue
 			}
+
 			var data []byte
 			switch rm.Type {
 			case ipv4.ICMPTypeTimeExceeded:
@@ -232,61 +272,14 @@ func (t *TCPTracer) listenICMP(ctx context.Context) {
 				continue
 				//log.Println("received icmp message of unknown type", rm.Type)
 			}
+
 			if len(data) < 20 || data[0]>>4 != 4 {
 				continue
 			}
+
 			dstip := net.IP(data[16:20])
 			if dstip.Equal(t.DestIP) || dstip.Equal(net.IPv4zero) {
 				t.handleICMPMessage(msg, data)
-			}
-		}
-	}
-}
-
-// @title    listenTCP
-// @description   监听TCP的响应数据包
-func (t *TCPTracer) listenTCP(ctx context.Context) {
-	defer t.wg.Done()
-	lc := NewPacketListener(t.tcp)
-	go lc.Start(ctx)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case msg, ok := <-lc.Messages:
-			if !ok {
-				return
-			}
-			if msg.N == nil {
-				continue
-			}
-			if ip := util.AddrIP(msg.Peer); ip != nil && ip.Equal(t.DestIP) {
-				// 解包
-				packet := gopacket.NewPacket(msg.Msg[:*msg.N], layers.LayerTypeTCP, gopacket.Default)
-				// 从包中获取TCP layer信息
-				if tcpLayer := packet.Layer(layers.LayerTypeTCP); tcpLayer != nil {
-					tcp, _ := tcpLayer.(*layers.TCP)
-					// 从对端返回的 ACK-1 恢复出原始探测包的 seq
-					seq := int(tcp.Ack - 1)
-					// 取出通道后立刻解锁
-					t.inflightRequestLock.RLock()
-					ch, ok := t.inflightRequest[seq]
-					t.inflightRequestLock.RUnlock()
-					if !ok || ch == nil {
-						continue
-					}
-
-					h := Hop{
-						Success: true,
-						Address: msg.Peer,
-					}
-					// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞
-					select {
-					case ch <- h:
-					default:
-						// 丢弃重复/迟到的相同 seq 回包，避免阻塞
-					}
-				}
 			}
 		}
 	}
@@ -302,6 +295,7 @@ func (t *TCPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	if err != nil {
 		return
 	}
+
 	// 取出通道后立刻解锁
 	t.inflightRequestLock.RLock()
 	ch, ok := t.inflightRequest[int(seq)]
@@ -314,6 +308,7 @@ func (t *TCPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
 		Success: true,
 		Address: msg.Peer,
 	}
+
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞
 	select {
 	case ch <- h:
@@ -342,6 +337,7 @@ func (t *TCPTracer) send(ctx context.Context, ttl, i int) error {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
 		return nil
 	}
+
 	// 将 TTL 编码到高 8 位；将索引 i 编码到低 24 位
 	seq := (ttl << 24) | (i & 0xFFFFFF)
 
@@ -390,15 +386,18 @@ func (t *TCPTracer) send(ctx context.Context, ttl, i int) error {
 
 	desiredPayloadSize := t.Config.PktSize
 	payload := make([]byte, desiredPayloadSize)
+
 	// 设置随机种子
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := range payload {
 		payload[i] = byte(r.Intn(256))
 	}
-	//copy(buf.Bytes(), payload)
+
+	// 序列化 TCP 头与 payload 到缓冲区
 	if err := gopacket.SerializeLayers(buf, opts, tcpHeader, gopacket.Payload(payload)); err != nil {
 		return err
 	}
+
 	// 串行设置 TTL + 发送，放在同一把锁里保证并发安全
 	t.hopLimitLock.Lock()
 	if err := t.tcpConn.SetTTL(ttl); err != nil {
@@ -417,6 +416,7 @@ func (t *TCPTracer) send(ctx context.Context, ttl, i int) error {
 		return context.Canceled
 	case h := <-hopCh:
 		rtt := time.Since(start)
+
 		if f := t.final.Load(); f != -1 && ttl > int(f) {
 			return nil
 		}
@@ -439,6 +439,7 @@ func (t *TCPTracer) send(ctx context.Context, ttl, i int) error {
 		if err := h.fetchIPData(t.Config); err != nil {
 			return err
 		}
+
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
 	case <-time.After(t.Timeout):
 		if f := t.final.Load(); f != -1 && ttl > int(f) {
@@ -452,6 +453,7 @@ func (t *TCPTracer) send(ctx context.Context, ttl, i int) error {
 			RTT:     0,
 			Error:   ErrHopLimitTimeout,
 		}
+
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
 	}
 	return nil

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -116,7 +116,7 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 	t.res.Hops = make([][]Hop, t.MaxHops)
 	// 解析并校验用户指定的 IPv6 源地址
 	SrcAddr := net.ParseIP(t.SrcAddr)
-	if t.SrcAddr != "" && (SrcAddr == nil || SrcAddr.To4() != nil || SrcAddr.To16() == nil) {
+	if t.SrcAddr != "" && !util.IsIPv6(SrcAddr) {
 		return nil, errors.New("invalid IPv6 SrcAddr: " + t.SrcAddr)
 	}
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -135,7 +135,7 @@ func isValidHop(h Hop) bool {
 	return h.Success && h.Address != nil
 }
 
-// 新版 add：带审计/限容
+// add 带审计/限容
 // - N = numMeasurements（每个 TTL 组的最小输出条数）
 // - M = maxAttempts（每个 TTL 组的最大尝试条数）
 // 规则：前 N-1 条无条件放行；第 N 条进行审计（已有有效 / 当次有效 / 达到最后一次尝试 任一成立即放行）；超过 N 条一律忽略
@@ -175,18 +175,6 @@ func (s *Result) add(hop Hop, attemptIdx, numMeasurements, maxAttempts int) {
 		// 已经有 N 条：忽略后续尝试
 		return
 	}
-}
-
-// 旧版 addLegacy
-func (s *Result) addLegacy(hop Hop) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	k := hop.TTL - 1
-	for len(s.Hops) < hop.TTL {
-		s.Hops = append(s.Hops, make([]Hop, 0))
-	}
-	s.Hops[k] = append(s.Hops[k], hop)
 }
 
 func (s *Result) reduce(final int) {

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -48,9 +48,11 @@ func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 		close(status)
 	}()
+
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
+
 	for {
 		if t.AsyncPrinter != nil {
 			t.AsyncPrinter(&t.res)
@@ -171,8 +173,8 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 
 		// 之后按 TTLInterval 周期启动后续 TTL 组
 		ticker := time.NewTicker(time.Millisecond * time.Duration(t.Config.TTLInterval))
-
 		defer ticker.Stop()
+
 		for ttl := t.BeginHop + 1; ttl <= t.MaxHops; ttl++ {
 			select {
 			case <-ctx.Done():
@@ -351,6 +353,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, ttl, i int) error {
 
 	desiredPayloadSize := t.Config.PktSize
 	payload := make([]byte, desiredPayloadSize)
+
 	// 设置随机种子
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for k := 2; k < desiredPayloadSize; k++ {
@@ -364,6 +367,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, ttl, i int) error {
 		return err
 	}
 
+	// 序列化 UDP 头与 payload 到缓冲区
 	if err := gopacket.SerializeLayers(buf, opts, udpHeader, gopacket.Payload(payload)); err != nil {
 		return err
 	}
@@ -409,6 +413,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, ttl, i int) error {
 		if err := h.fetchIPData(t.Config); err != nil {
 			return err
 		}
+
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
 	case <-time.After(t.Timeout):
 		if f := t.final.Load(); f != -1 && ttl > int(f) {
@@ -422,6 +427,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, ttl, i int) error {
 			RTT:     0,
 			Error:   ErrHopLimitTimeout,
 		}
+
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
 	}
 	return nil

--- a/util/trace.go
+++ b/util/trace.go
@@ -99,9 +99,9 @@ func GetTCPSeq(data []byte) (uint32, error) {
 }
 
 func GetUDPSeq(data []byte) (uint16, error) {
-	if len(data) < 6 {
-		return 0, errors.New("inner IPv4 header too short")
+	if len(data) < 8 {
+		return 0, errors.New("length of udp header too short")
 	}
-	seqBytes := data[4:6]
+	seqBytes := data[6:8]
 	return binary.BigEndian.Uint16(seqBytes), nil
 }


### PR DESCRIPTION
已完成任务：
1. 升级项目Go版本至1.25.0
2. 更换了原先UDP模式代码中seq信息的位置，将其“存储”在了UDP头部的Checksum字段部分（将Checksum作为已知结果，通过算法计算出所需的2 bytes长的payload，使得最终的UDP.Checksum恰好为所需的seq信息），依然保持高8位为TTL，低8位为索引i。由于未修改IPv4/IPv6头部信息，所以其跨平台可用性得到了显著提升，已确认可在linux、mac平台上使用
3. 修改了UDPv6的代码，移除了udpMutex，显著提升了trace时的运行速度，并使之与目前的UDP代码相统一


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 更快更稳定的并发探测与实时进度回显（ICMP/TCP/UDP 多协议），按 TTL 分组并引入限流与并发控制
  - 自动识别并记录源网卡（新增公开 SrcDev 与按 IP 查找设备）
  - 新增公开的校验和与载荷调节工具，提升应答匹配率

- 修复
  - 强化 IPv4/IPv6 源地址校验与绑定可靠性
  - 在 UDP 模式下强制最小负载长度为 2，避免无效报文

- Chores
  - 升级 Go 工具链与 CI 到 1.25.x，新增 macOS 原生构建与监听支持
<!-- end of auto-generated comment: release notes by coderabbit.ai -->