### PR TITLE
为TCP/UDP等模式引入MPLS Label支持

### DIFF
--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -226,8 +226,7 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 			}
 
 			var (
-				data     []byte
-				icmpType int8 // 0=TimeExceeded, 2=DestinationUnreachable
+				data []byte
 			)
 			switch rm.Type {
 			case ipv6.ICMPTypeEchoReply:
@@ -250,7 +249,7 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 					if ttl < t.BeginHop || ttl > t.MaxHops {
 						continue
 					}
-					t.handleICMPMessage(msg, 1, data, seq)
+					t.handleICMPMessage(msg, seq)
 				}
 				continue
 			case ipv6.ICMPTypeTimeExceeded:
@@ -259,14 +258,12 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 					continue
 				}
 				data = body.Data
-				icmpType = 0
 			case ipv6.ICMPTypeDestinationUnreachable:
 				body, ok := rm.Body.(*icmp.DstUnreach)
 				if !ok || body == nil {
 					continue
 				}
 				data = body.Data
-				icmpType = 2
 			default:
 				continue
 				//log.Println("received icmp message of unknown type", rm.Type)
@@ -287,20 +284,14 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 					continue
 				}
 				seq := int(binary.BigEndian.Uint16(inner[6:8]))
-				t.handleICMPMessage(msg, icmpType, data, seq)
+				t.handleICMPMessage(msg, seq)
 			}
 		}
 	}
 }
 
-func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, icmpType int8, data []byte, seq int) {
-	if icmpType == 2 {
-		if ip := util.AddrIP(msg.Peer); ip == nil || !ip.Equal(t.DestIP) {
-			return
-		}
-	}
-
-	mpls := extractMPLS(msg, data)
+func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, seq int) {
+	mpls := extractMPLS(msg)
 
 	// 取出通道后立刻解锁
 	t.inflightRequestLock.RLock()

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -291,6 +291,8 @@ func (t *TCPTracer) listenICMP(ctx context.Context) {
 }
 
 func (t *TCPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -312,6 +314,7 @@ func (t *TCPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -291,6 +291,8 @@ func (t *TCPTracerIPv6) listenICMP(ctx context.Context) {
 }
 
 func (t *TCPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -312,6 +314,7 @@ func (t *TCPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -378,7 +378,7 @@ func (h *Hop) fetchIPData(c Config) (err error) {
 	return <-ipGeoCh
 }
 
-func extractMPLS(msg ReceivedMessage, data []byte) []string {
+func extractMPLS(msg ReceivedMessage) []string {
 	if util.DisableMPLS {
 		return nil
 	}

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -257,6 +257,8 @@ func (t *UDPTracer) listenICMP(ctx context.Context) {
 }
 
 func (t *UDPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -278,6 +280,7 @@ func (t *UDPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -257,6 +257,8 @@ func (t *UDPTracerIPv6) listenICMP(ctx context.Context) {
 }
 
 func (t *UDPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -278,6 +280,7 @@ func (t *UDPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞


### PR DESCRIPTION
为TCP/UDP等模式引入MPLS Label支持，并移除了handleICMPMessage()函数中(ICMP/ICMPv6)一些无意义的判断和参数

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 路由跟踪结果新增每跳 MPLS 标签展示，适用于 IPv4/IPv6 的 TCP 与 UDP 模式，便于识别 MPLS 转发路径。
- 重构
  - 统一并简化 ICMP 回复处理逻辑，改用序列号关联请求与响应，提升对多样化网络返回报文的兼容性与稳定性，可能识别到更多中间节点。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->