### PR TITLE
移除了PrintFunc中的status通道，使用WithCancelCause区分中断退出

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -329,12 +329,11 @@ func Execute() {
 
 	res, err := trace.Traceroute(m, conf)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if !errors.Is(err, context.Canceled) {
 			// 用户主动中断：跳过后续的正常收尾
 			// os.Exit(130)
-			return
+			fmt.Println(err)
 		}
-		fmt.Println(err)
 		return
 	}
 

--- a/trace/icmp_ipv4.go
+++ b/trace/icmp_ipv4.go
@@ -38,17 +38,8 @@ type ICMPTracer struct {
 	sem                 *semaphore.Weighted
 }
 
-func (t *ICMPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
+func (t *ICMPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
 	defer t.wg.Done()
-	// 默认认为是正常退出，只有在 ctx 取消时改为 false
-	normalExit := true
-	defer func() {
-		select {
-		case status <- normalExit:
-		default:
-		}
-		close(status)
-	}()
 
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
@@ -60,21 +51,19 @@ func (t *ICMPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 
 		// 接收的时候检查一下是不是 3 跳都齐了
-		if ttl < len(t.res.Hops) &&
-			len(t.res.Hops[ttl]) == t.NumMeasurements {
+		if t.ttlComp(ttl + 1) {
 			if t.RealtimePrinter != nil {
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
 			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+				cancel(errNaturalDone) // 标记“自然完成”
 				return
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			// 非正常退出
-			normalExit = false
 			return
 		case <-ticker.C:
 		}
@@ -126,7 +115,7 @@ func (t *ICMPTracer) Execute() (res *Result, err error) {
 	t.inflightRequest = make(map[int]chan Hop)
 
 	if len(t.res.Hops) > 0 {
-		return &t.res, ErrTracerouteExecuted
+		return &t.res, errTracerouteExecuted
 	}
 
 	// 初始化 Result.Hops，并预分配到 MaxHops
@@ -153,15 +142,14 @@ func (t *ICMPTracer) Execute() (res *Result, err error) {
 	}()
 	t.icmpConn = ipv4.NewPacketConn(t.icmp)
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancelCause(sigCtx)
 	t.final.Store(-1)
 
 	t.wg.Add(1)
 	go t.listenICMP(ctx)
-	statusCh := make(chan bool, 1)
 	t.wg.Add(1)
-	go t.PrintFunc(ctx, statusCh)
+	go t.PrintFunc(ctx, cancel)
 
 	t.sem = semaphore.NewWeighted(int64(t.ParallelRequests))
 
@@ -192,12 +180,18 @@ func (t *ICMPTracer) Execute() (res *Result, err error) {
 		}
 	}()
 
-	normalExit := <-statusCh
+	<-ctx.Done()
 	stop()
 	t.wg.Wait()
-	t.res.reduce(int(t.final.Load()))
-	if !normalExit {
-		return &t.res, context.Canceled
+
+	bound := int(t.final.Load())
+	if bound == -1 {
+		bound = t.MaxHops
+	}
+	t.res.reduce(bound)
+
+	if cause := context.Cause(ctx); !errors.Is(cause, errNaturalDone) {
+		return &t.res, cause
 	}
 	return &t.res, nil
 }
@@ -234,7 +228,7 @@ func (t *ICMPTracer) listenICMP(ctx context.Context) {
 				if !ok || echo == nil {
 					continue
 				}
-				data = echo.Data
+
 				// 只在 Peer 是目的地址时分发，用 seq 作为通道 key
 				if ip := util.AddrIP(msg.Peer); ip != nil && ip.Equal(t.DestIP) {
 					id := uint16(echo.ID)
@@ -427,7 +421,7 @@ func (t *ICMPTracer) send(ctx context.Context, ttl, i int) error {
 			Address: nil,
 			TTL:     ttl,
 			RTT:     0,
-			Error:   ErrHopLimitTimeout,
+			Error:   errHopLimitTimeout,
 		}
 
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -38,17 +38,8 @@ type ICMPTracerv6 struct {
 	sem                 *semaphore.Weighted
 }
 
-func (t *ICMPTracerv6) PrintFunc(ctx context.Context, status chan<- bool) {
+func (t *ICMPTracerv6) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
 	defer t.wg.Done()
-	// 默认认为是正常退出，只有在 ctx 取消时改为 false
-	normalExit := true
-	defer func() {
-		select {
-		case status <- normalExit:
-		default:
-		}
-		close(status)
-	}()
 
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
@@ -60,21 +51,19 @@ func (t *ICMPTracerv6) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 
 		// 接收的时候检查一下是不是 3 跳都齐了
-		if ttl < len(t.res.Hops) &&
-			len(t.res.Hops[ttl]) == t.NumMeasurements {
+		if t.ttlComp(ttl + 1) {
 			if t.RealtimePrinter != nil {
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
 			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+				cancel(errNaturalDone) // 标记“自然完成”
 				return
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			// 非正常退出
-			normalExit = false
 			return
 		case <-ticker.C:
 		}
@@ -126,7 +115,7 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 	t.inflightRequest = make(map[int]chan Hop)
 
 	if len(t.res.Hops) > 0 {
-		return &t.res, ErrTracerouteExecuted
+		return &t.res, errTracerouteExecuted
 	}
 
 	// 初始化 Result.Hops，并预分配到 MaxHops
@@ -153,15 +142,14 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 	}()
 	t.icmpConn = ipv6.NewPacketConn(t.icmp)
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancelCause(sigCtx)
 	t.final.Store(-1)
 
 	t.wg.Add(1)
 	go t.listenICMP(ctx)
-	statusCh := make(chan bool, 1)
 	t.wg.Add(1)
-	go t.PrintFunc(ctx, statusCh)
+	go t.PrintFunc(ctx, cancel)
 
 	t.sem = semaphore.NewWeighted(int64(t.ParallelRequests))
 
@@ -192,12 +180,18 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 		}
 	}()
 
-	normalExit := <-statusCh
+	<-ctx.Done()
 	stop()
 	t.wg.Wait()
-	t.res.reduce(int(t.final.Load()))
-	if !normalExit {
-		return &t.res, context.Canceled
+
+	bound := int(t.final.Load())
+	if bound == -1 {
+		bound = t.MaxHops
+	}
+	t.res.reduce(bound)
+
+	if cause := context.Cause(ctx); !errors.Is(cause, errNaturalDone) {
+		return &t.res, cause
 	}
 	return &t.res, nil
 }
@@ -234,7 +228,7 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 				if !ok || echo == nil {
 					continue
 				}
-				data = echo.Data
+
 				// 只在 Peer 是目的地址时分发，用 seq 作为通道 key
 				if ip := util.AddrIP(msg.Peer); ip != nil && ip.Equal(t.DestIP) {
 					id := uint16(echo.ID)
@@ -427,7 +421,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, ttl, i int) error {
 			Address: nil,
 			TTL:     ttl,
 			RTT:     0,
-			Error:   ErrHopLimitTimeout,
+			Error:   errHopLimitTimeout,
 		}
 
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -226,8 +226,7 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 			}
 
 			var (
-				data     []byte
-				icmpType int8 // 0=TimeExceeded, 2=DestinationUnreachable
+				data []byte
 			)
 			switch rm.Type {
 			case ipv6.ICMPTypeEchoReply:
@@ -250,7 +249,7 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 					if ttl < t.BeginHop || ttl > t.MaxHops {
 						continue
 					}
-					t.handleICMPMessage(msg, 1, data, seq)
+					t.handleICMPMessage(msg, seq)
 				}
 				continue
 			case ipv6.ICMPTypeTimeExceeded:
@@ -259,14 +258,12 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 					continue
 				}
 				data = body.Data
-				icmpType = 0
 			case ipv6.ICMPTypeDestinationUnreachable:
 				body, ok := rm.Body.(*icmp.DstUnreach)
 				if !ok || body == nil {
 					continue
 				}
 				data = body.Data
-				icmpType = 2
 			default:
 				continue
 				//log.Println("received icmp message of unknown type", rm.Type)
@@ -287,20 +284,14 @@ func (t *ICMPTracerv6) listenICMP(ctx context.Context) {
 					continue
 				}
 				seq := int(binary.BigEndian.Uint16(inner[6:8]))
-				t.handleICMPMessage(msg, icmpType, data, seq)
+				t.handleICMPMessage(msg, seq)
 			}
 		}
 	}
 }
 
-func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, icmpType int8, data []byte, seq int) {
-	if icmpType == 2 {
-		if ip := util.AddrIP(msg.Peer); ip == nil || !ip.Equal(t.DestIP) {
-			return
-		}
-	}
-
-	mpls := extractMPLS(msg, data)
+func (t *ICMPTracerv6) handleICMPMessage(msg ReceivedMessage, seq int) {
+	mpls := extractMPLS(msg)
 
 	// 取出通道后立刻解锁
 	t.inflightRequestLock.RLock()

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -291,6 +291,8 @@ func (t *TCPTracer) listenICMP(ctx context.Context) {
 }
 
 func (t *TCPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -312,6 +314,7 @@ func (t *TCPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -38,17 +38,8 @@ type TCPTracer struct {
 	sem                 *semaphore.Weighted
 }
 
-func (t *TCPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
+func (t *TCPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
 	defer t.wg.Done()
-	// 默认认为是正常退出，只有在 ctx 取消时改为 false
-	normalExit := true
-	defer func() {
-		select {
-		case status <- normalExit:
-		default:
-		}
-		close(status)
-	}()
 
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
@@ -60,21 +51,19 @@ func (t *TCPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 
 		// 接收的时候检查一下是不是 3 跳都齐了
-		if ttl < len(t.res.Hops) &&
-			len(t.res.Hops[ttl]) == t.NumMeasurements {
+		if t.ttlComp(ttl + 1) {
 			if t.RealtimePrinter != nil {
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
 			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+				cancel(errNaturalDone) // 标记“自然完成”
 				return
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			// 非正常退出
-			normalExit = false
 			return
 		case <-ticker.C:
 		}
@@ -117,7 +106,7 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 	t.inflightRequest = make(map[int]chan Hop)
 
 	if len(t.res.Hops) > 0 {
-		return &t.res, ErrTracerouteExecuted
+		return &t.res, errTracerouteExecuted
 	}
 
 	// 初始化 Result.Hops，并预分配到 MaxHops
@@ -154,8 +143,8 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 		}
 	}()
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancelCause(sigCtx)
 	t.final.Store(-1)
 
 	t.wg.Add(1)
@@ -193,9 +182,8 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 			}
 		})
 	}()
-	statusCh := make(chan bool, 1)
 	t.wg.Add(1)
-	go t.PrintFunc(ctx, statusCh)
+	go t.PrintFunc(ctx, cancel)
 
 	t.sem = semaphore.NewWeighted(int64(t.ParallelRequests))
 
@@ -226,12 +214,18 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 		}
 	}()
 
-	normalExit := <-statusCh
+	<-ctx.Done()
 	stop()
 	t.wg.Wait()
-	t.res.reduce(int(t.final.Load()))
-	if !normalExit {
-		return &t.res, context.Canceled
+
+	bound := int(t.final.Load())
+	if bound == -1 {
+		bound = t.MaxHops
+	}
+	t.res.reduce(bound)
+
+	if cause := context.Cause(ctx); !errors.Is(cause, errNaturalDone) {
+		return &t.res, cause
 	}
 	return &t.res, nil
 }
@@ -459,7 +453,7 @@ func (t *TCPTracer) send(ctx context.Context, ttl, i int) error {
 			Address: nil,
 			TTL:     ttl,
 			RTT:     0,
-			Error:   ErrHopLimitTimeout,
+			Error:   errHopLimitTimeout,
 		}
 
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -291,6 +291,8 @@ func (t *TCPTracerIPv6) listenICMP(ctx context.Context) {
 }
 
 func (t *TCPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -312,6 +314,7 @@ func (t *TCPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -378,7 +378,7 @@ func (h *Hop) fetchIPData(c Config) (err error) {
 	return <-ipGeoCh
 }
 
-func extractMPLS(msg ReceivedMessage, data []byte) []string {
+func extractMPLS(msg ReceivedMessage) []string {
 	if util.DisableMPLS {
 		return nil
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -19,9 +19,10 @@ import (
 )
 
 var (
-	ErrInvalidMethod      = errors.New("invalid method")
-	ErrTracerouteExecuted = errors.New("traceroute already executed")
-	ErrHopLimitTimeout    = errors.New("hop timeout")
+	errHopLimitTimeout    = errors.New("hop timeout")
+	errInvalidMethod      = errors.New("invalid method")
+	errNaturalDone        = errors.New("trace natural done")
+	errTracerouteExecuted = errors.New("traceroute already executed")
 	geoCache              = sync.Map{}
 	ipGeoSF               singleflight.Group
 	rdnsSF                singleflight.Group
@@ -115,7 +116,7 @@ func Traceroute(method Method, config Config) (*Result, error) {
 			tracer = &TCPTracerIPv6{Config: config}
 		}
 	default:
-		return &Result{}, ErrInvalidMethod
+		return &Result{}, errInvalidMethod
 	}
 	result, err := tracer.Execute()
 	if err != nil && errors.Is(err, syscall.EPERM) {

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -257,6 +257,8 @@ func (t *UDPTracer) listenICMP(ctx context.Context) {
 }
 
 func (t *UDPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -278,6 +280,7 @@ func (t *UDPTracer) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -37,17 +37,8 @@ type UDPTracer struct {
 	sem                 *semaphore.Weighted
 }
 
-func (t *UDPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
+func (t *UDPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
 	defer t.wg.Done()
-	// 默认认为是正常退出，只有在 ctx 取消时改为 false
-	normalExit := true
-	defer func() {
-		select {
-		case status <- normalExit:
-		default:
-		}
-		close(status)
-	}()
 
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
@@ -59,21 +50,19 @@ func (t *UDPTracer) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 
 		// 接收的时候检查一下是不是 3 跳都齐了
-		if ttl < len(t.res.Hops) &&
-			len(t.res.Hops[ttl]) == t.NumMeasurements {
+		if t.ttlComp(ttl + 1) {
 			if t.RealtimePrinter != nil {
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
 			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+				cancel(errNaturalDone) // 标记“自然完成”
 				return
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			// 非正常退出
-			normalExit = false
 			return
 		case <-ticker.C:
 		}
@@ -116,7 +105,7 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 	t.inflightRequest = make(map[int]chan Hop)
 
 	if len(t.res.Hops) > 0 {
-		return &t.res, ErrTracerouteExecuted
+		return &t.res, errTracerouteExecuted
 	}
 
 	// 初始化 Result.Hops，并预分配到 MaxHops
@@ -153,15 +142,14 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 		}
 	}()
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancelCause(sigCtx)
 	t.final.Store(-1)
 
 	t.wg.Add(1)
 	go t.listenICMP(ctx)
-	statusCh := make(chan bool, 1)
 	t.wg.Add(1)
-	go t.PrintFunc(ctx, statusCh)
+	go t.PrintFunc(ctx, cancel)
 
 	t.sem = semaphore.NewWeighted(int64(t.ParallelRequests))
 
@@ -192,12 +180,18 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 		}
 	}()
 
-	normalExit := <-statusCh
+	<-ctx.Done()
 	stop()
 	t.wg.Wait()
-	t.res.reduce(int(t.final.Load()))
-	if !normalExit {
-		return &t.res, context.Canceled
+
+	bound := int(t.final.Load())
+	if bound == -1 {
+		bound = t.MaxHops
+	}
+	t.res.reduce(bound)
+
+	if cause := context.Cause(ctx); !errors.Is(cause, errNaturalDone) {
+		return &t.res, cause
 	}
 	return &t.res, nil
 }
@@ -435,7 +429,7 @@ func (t *UDPTracer) send(ctx context.Context, ttl, i int) error {
 			Address: nil,
 			TTL:     ttl,
 			RTT:     0,
-			Error:   ErrHopLimitTimeout,
+			Error:   errHopLimitTimeout,
 		}
 
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -37,17 +37,8 @@ type UDPTracerIPv6 struct {
 	sem                 *semaphore.Weighted
 }
 
-func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, status chan<- bool) {
+func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
 	defer t.wg.Done()
-	// 默认认为是正常退出，只有在 ctx 取消时改为 false
-	normalExit := true
-	defer func() {
-		select {
-		case status <- normalExit:
-		default:
-		}
-		close(status)
-	}()
 
 	ttl := t.Config.BeginHop - 1
 	ticker := time.NewTicker(200 * time.Millisecond)
@@ -59,21 +50,19 @@ func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, status chan<- bool) {
 		}
 
 		// 接收的时候检查一下是不是 3 跳都齐了
-		if ttl < len(t.res.Hops) &&
-			len(t.res.Hops[ttl]) == t.NumMeasurements {
+		if t.ttlComp(ttl + 1) {
 			if t.RealtimePrinter != nil {
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
 			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+				cancel(errNaturalDone) // 标记“自然完成”
 				return
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			// 非正常退出
-			normalExit = false
 			return
 		case <-ticker.C:
 		}
@@ -116,7 +105,7 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 	t.inflightRequest = make(map[int]chan Hop)
 
 	if len(t.res.Hops) > 0 {
-		return &t.res, ErrTracerouteExecuted
+		return &t.res, errTracerouteExecuted
 	}
 
 	// 初始化 Result.Hops，并预分配到 MaxHops
@@ -153,15 +142,14 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 		}
 	}()
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancelCause(sigCtx)
 	t.final.Store(-1)
 
 	t.wg.Add(1)
 	go t.listenICMP(ctx)
-	statusCh := make(chan bool, 1)
 	t.wg.Add(1)
-	go t.PrintFunc(ctx, statusCh)
+	go t.PrintFunc(ctx, cancel)
 
 	t.sem = semaphore.NewWeighted(int64(t.ParallelRequests))
 
@@ -192,12 +180,18 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 		}
 	}()
 
-	normalExit := <-statusCh
+	<-ctx.Done()
 	stop()
 	t.wg.Wait()
-	t.res.reduce(int(t.final.Load()))
-	if !normalExit {
-		return &t.res, context.Canceled
+
+	bound := int(t.final.Load())
+	if bound == -1 {
+		bound = t.MaxHops
+	}
+	t.res.reduce(bound)
+
+	if cause := context.Cause(ctx); !errors.Is(cause, errNaturalDone) {
+		return &t.res, cause
 	}
 	return &t.res, nil
 }
@@ -428,7 +422,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, ttl, i int) error {
 			Address: nil,
 			TTL:     ttl,
 			RTT:     0,
-			Error:   ErrHopLimitTimeout,
+			Error:   errHopLimitTimeout,
 		}
 
 		t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -257,6 +257,8 @@ func (t *UDPTracerIPv6) listenICMP(ctx context.Context) {
 }
 
 func (t *UDPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
+	mpls := extractMPLS(msg)
+
 	header, err := util.GetICMPResponsePayload(data)
 	if err != nil {
 		return
@@ -278,6 +280,7 @@ func (t *UDPTracerIPv6) handleICMPMessage(msg ReceivedMessage, data []byte) {
 	h := Hop{
 		Success: true,
 		Address: msg.Peer,
+		MPLS:    mpls,
 	}
 
 	// 非阻塞发送，避免重复回包把缓冲塞满导致阻塞


### PR DESCRIPTION
移除了PrintFunc中的status通道，使用WithCancelCause区分中断退出

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 改善 traceroute 自然完成与中断体验：执行完成更平滑，结果收敛更一致。
- Bug 修复
  - CLI 对非取消错误仅打印一次；因用户取消时安静退出，不再噪声输出。
- 重构
  - 全面改用基于上下文的取消与原因传播，移除状态通道。
  - ICMP/TCP/UDP（IPv4/IPv6）PrintFunc 方法签名调整为接收取消函数。
  - 结果裁剪与完成判定逻辑统一，TTL 进度判断重构。
  - 对外错误常量改为内部符号，API 更加内聚。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->