### PR TITLE
fix(dn42): fill Owner field from IPWhois instead of Whois

### DIFF
--- a/ipgeo/dn42.go
+++ b/ipgeo/dn42.go
@@ -31,7 +31,7 @@ func DN42(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
 		data.Country = geo.LtdCode
 		data.City = geo.City
 		data.Asnumber = geo.ASN
-		data.Whois = geo.IPWhois
+		data.Owner = geo.IPWhois
 	}
 	// 如果没找到，查找 PTR
 	if len(ipTmp) > 1 {


### PR DESCRIPTION
So that it could be displayed correctly

<img width="1123" height="556" alt="image" src="https://github.com/user-attachments/assets/50119fa9-4169-41f0-93a5-8d8e60f62f97" />

Tested with https://github.com/Cryolitia/Next-Trace-DN42-Feeder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 优化了DN42地理定位数据的组织结构，改进了所有者信息的存储和管理方式，提升了数据的清晰度和可用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->