### PR TITLE
feat: fetch built DN42 data online by default

### DIFF
--- a/config/viper.go
+++ b/config/viper.go
@@ -23,21 +23,12 @@ func InitConfig() {
 	viper.AddConfigPath(".")
 
 	// 配置默认值
-	viper.SetDefault("ptrPath", "./ptr.csv")
-	viper.SetDefault("geoFeedPath", "./geofeed.csv")
+	viper.SetDefault("ptrPath", "https://cryolitia.github.io/Next-Trace-DN42-Feeder/ptr.csv")
+	viper.SetDefault("geoFeedPath", "https://cryolitia.github.io/Next-Trace-DN42-Feeder/geofeed.csv")
 
 	// 开始查找并读取配置文件
 	err := viper.ReadInConfig() // Find and read the config file
 	if err != nil {             // Handle errors reading the config file
-		fmt.Println("未能找到配置文件，我们将在您的运行目录为您创建 nt_config.yaml 默认配置")
-		err := viper.SafeWriteConfigAs("./nt_config.yaml")
-		if err != nil {
-			return
-		}
-	}
-
-	err = viper.ReadInConfig()
-	if err != nil {
-		return
+		fmt.Println("未能找到配置文件，我们将加载默认配置……")
 	}
 }

--- a/dn42/ptr.go
+++ b/dn42/ptr.go
@@ -4,9 +4,13 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"log"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -30,19 +34,39 @@ func matchesPattern(prefix string, s string) bool {
 	return r.MatchString(s)
 }
 
-func FindPtrRecord(ptr string) (PtrRow, error) {
+var getPtr = sync.OnceValues(func() ([][]string, error) {
 	path := viper.Get("ptrPath").(string)
-	f, err := os.Open(path)
-	if err != nil {
-		return PtrRow{}, err
+	var r *csv.Reader
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		client := &http.Client{
+			// 10 秒超时
+			Timeout: time.Duration(10) * time.Second,
+		}
+		req, _ := http.NewRequest("GET", path, nil)
+		content, err := client.Do(req)
+		if err != nil {
+			log.Println("DN42数据请求超时，请更换其他数据源或使用本地数据")
+			return nil, err
+		}
+		defer content.Body.Close()
+		r = csv.NewReader(content.Body)
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		r = csv.NewReader(f)
 	}
-	defer f.Close()
+	return r.ReadAll()
+})
 
-	r := csv.NewReader(f)
-	rows, err := r.ReadAll()
+func FindPtrRecord(ptr string) (PtrRow, error) {
+	rows, err := getPtr()
 	if err != nil {
 		return PtrRow{}, err
 	}
+
 	// 转小写
 	ptr = strings.ToLower(ptr)
 	// 先查城市名

--- a/nt_config.yaml
+++ b/nt_config.yaml
@@ -1,2 +1,0 @@
-geofeedpath: ./geofeed.csv
-ptrpath: ./ptr.csv


### PR DESCRIPTION
~~内核工程师没有使用任何AI一晚上速成go的故事~~

将 DN42 模式的默认行为更改为联网下载预构建的数据库，两个库都只有200kb左右所以直接把整个下载下来应该是比较合适的。

暂时用了我的GitHub Pages，或许可以把这个预构建仓库transfer到组织里然后用你们的GitHub Pages或可能存在的什么分发网络，建议不要直接用我的地址合并

<img width="1087" height="565" alt="图片" src="https://github.com/user-attachments/assets/0286aa37-2cf2-4026-9f34-2bb711dffad8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加从远程源加载地理位置反馈和PTR数据的支持

* **改进**
  * 默认配置源已更新为远程URL，而非本地文件路径
  * 简化缺失配置文件时的处理流程，不再自动生成默认配置文件

* **配置变更**
  * 本地配置文件中移除了地理位置反馈和PTR数据路径条目

<!-- end of auto-generated comment: release notes by coderabbit.ai -->