### PR TITLE
Potential fix for code scanning alert no. 49: Client-side cross-site scripting

### DIFF
--- a/server/web/assets/app.js
+++ b/server/web/assets/app.js
@@ -265,15 +265,6 @@ function clearResult(resetState = false) {
   }
 }
 
-function escapeHTML(str) {
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 function renderMeta(summary = {}) {
   const rows = [];
   if (summary.resolved_ip) {

--- a/server/web/assets/app.js
+++ b/server/web/assets/app.js
@@ -265,22 +265,32 @@ function clearResult(resetState = false) {
   }
 }
 
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function renderMeta(summary = {}) {
   const rows = [];
   if (summary.resolved_ip) {
-    rows.push(`${t('metaResolved')}：<strong>${summary.resolved_ip}</strong>`);
+    rows.push(`${t('metaResolved')}：<strong>${escapeHTML(summary.resolved_ip)}</strong>`);
   }
   if (summary.data_provider) {
-    rows.push(`${t('metaProvider')}：<strong>${summary.data_provider}</strong>`);
+    rows.push(`${t('metaProvider')}：<strong>${escapeHTML(summary.data_provider)}</strong>`);
   }
   if (summary.duration_ms !== undefined) {
-    rows.push(`${t('metaDuration')}：<strong>${summary.duration_ms} ms</strong>`);
+    rows.push(`${t('metaDuration')}：<strong>${escapeHTML(summary.duration_ms)} ms</strong>`);
   }
   if (summary.iteration) {
-    rows.push(`${t('metaIterations')}：<strong>${summary.iteration}</strong>`);
+    rows.push(`${t('metaIterations')}：<strong>${escapeHTML(summary.iteration)}</strong>`);
   }
   if (summary.trace_map_url) {
-    rows.push(`${t('metaMap')}：<a href="${summary.trace_map_url}" target="_blank" rel="noreferrer">${t('mapOpen')}</a>`);
+    // t('mapOpen') is assumed not user-supplied; escape only the URL
+    rows.push(`${t('metaMap')}：<a href="${escapeHTML(summary.trace_map_url)}" target="_blank" rel="noreferrer">${t('mapOpen')}</a>`);
   }
   if (rows.length === 0) {
     resultMetaNode.classList.add('hidden');


### PR DESCRIPTION
Potential fix for [https://github.com/nxtrace/NTrace-V1/security/code-scanning/49](https://github.com/nxtrace/NTrace-V1/security/code-scanning/49)

The best way to fix this is to ensure all untrusted data interpolated into the DOM is properly escaped/encoded for the HTML context. Rather than interpolating values directly into HTML strings (e.g., `<strong>${summary.resolved_ip}</strong>`), each value should be sanitized or, ideally, the DOM should be constructed in a way that does not require using `.innerHTML` with user-supplied strings.

We can achieve this by:
- Escaping each value before interpolation with a robust escaping function.
- Alternately, constructing the DOM nodes directly, but since the app uses template strings and `.innerHTML`, escaping is more appropriate and less disruptive.

We will add a small utility function `escapeHTML` in the file (if one does not already exist) and wrap every user-supplied value interpolated into the markup sent to `.innerHTML` in `renderMeta`. We will not escape static text (`t('metaResolved')`, etc.), but only the values (e.g., `summary.resolved_ip`, `summary.data_provider`, `summary.duration_ms`, `summary.iteration`, `summary.trace_map_url`).

For any anchor element's `href`, use the same approach—escape the value, though in practice this is less safe if the base value is attacker-controlled (as in `href="${summary.trace_map_url}"`), but at minimum escape.

We will define `escapeHTML` at the top of the file (or a shared util region), and use it for all dynamic interpolations in `renderMeta`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了对页面中元信息和外部链接的转义处理，增强了展示内容（如IP、数据来源、耗时、迭代次数）与地图链接的安全性，减少注入或显示异常风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->