### PR TITLE
升级Go至1.25.4并优化MPLS提取、geoip错误处理和RFC1918显示

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,11 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
-          sudo go env -w GOTOOLCHAIN=go1.25.1+auto
+          sudo go env -w GOTOOLCHAIN=go1.25.4+auto
           sudo go test -v -ldflags=-checklinkname=0 -covermode=count -coverprofile='coverage.out' ./...
 
       - name: Test with windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          go env -w GOTOOLCHAIN=go1.25.1+auto
+          go env -w GOTOOLCHAIN=go1.25.4+auto
           go test -v -ldflags=-checklinkname=0 -covermode=count -coverprofile="coverage.out" ./...

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ nexttrace --ipv6 g.co
 # IPv6 ICMP Trace
 nexttrace 2606:4700:4700::1111
 
-# Developer mode: set the ENV variable NEXTTRACE_DEVMODE=1 to make fatal errors panic with a stack trace.
+# Developer mode: set the ENV variable NEXTTRACE_DEVMODE=1 to make fatal errors panic with a stack trace
 export NEXTTRACE_DEVMODE=1
 
 # Disable Path Visualization With the -M parameter
@@ -254,10 +254,11 @@ nexttrace --tcp --source-port 14514 www.bing.com
 #### `NextTrace` also supports some advanced functions, such as ttl control, concurrent probe packet count control, mode switching, etc.
 
 ```bash
-# Send 2 probe packets per hop
+# Display 2 latency samples per hop
 nexttrace --queries 2 www.hkix.net
 
-# Set the maximum attempts per TTL
+# Allow up to 10 probe packets per hop to collect those samples
+# (NextTrace stops earlier if it has already got the replies requested by --queries)
 nexttrace --max-attempts 10 www.hkix.net
 # or use the ENV variable NEXTTRACE_MAXATTEMPTS to persist across runs
 export NEXTTRACE_MAXATTEMPTS=10
@@ -364,11 +365,11 @@ All NextTrace IP geolocation `API DEMO` can refer to [here](https://github.com/n
 ### For full usage list, please refer to the usage menu
 
 ```shell
-Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
+usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
                  [-U|--udp] [-F|--fast-trace] [-p|--port <integer>]
                  [--icmp-mode <integer>] [-q|--queries <integer>]
-                 [--parallel-requests <integer>] [-m|--max-hops <integer>]
-                 [--max-attempts <integer>] [-d|--data-provider
+                 [--max-attempts <integer>] [--parallel-requests <integer>]
+                 [-m|--max-hops <integer>] [-d|--data-provider
                  (IP.SB|ip.sb|IPInfo|ipinfo|IPInsight|ipinsight|IPAPI.com|ip-api.com|IPInfoLocal|ipinfolocal|chunzhen|LeoMoeAPI|leomoeapi|ipdb.one|disable-geoip)]
                  [--pow-provider (api.nxtrace.org|sakura)] [-n|--no-rdns]
                  [-a|--always-rdns] [-P|--route-path] [-r|--report] [--dn42]
@@ -381,6 +382,8 @@ Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
                  [_positionalArg_nexttrace_38 "<value>"] [--dot-server
                  (dnssb|aliyun|dnspod|google|cloudflare)] [-g|--language
                  (en|cn)] [--file "<value>"] [-C|--no-color] [--from "<value>"]
+
+                 An open source visual route tracking CLI tool
 
 Arguments:
 
@@ -399,15 +402,15 @@ Arguments:
       --icmp-mode                    Windows ONLY: Choose the method to listen
                                      for ICMP packets (1=Socket, 2=PCAP;
                                      0=Auto)
-  -q  --queries                      Set the number of probes per each hop.
-                                     Default: 3
+  -q  --queries                      Set the number of latency samples to
+                                     display for each hop. Default: 3
+      --max-attempts                 Set the maximum number of probe packets
+                                     per hop (instead of a fixed auto value)
       --parallel-requests            Set ParallelRequests number. It should be
                                      1 when there is a multi-routing. Default:
                                      18
   -m  --max-hops                     Set the max number of hops (max TTL to be
                                      reached). Default: 30
-      --max-attempts                 Set the max number of attempts per TTL
-                                     (instead of a fixed auto value)
   -d  --data-provider                Choose IP Geograph Data Provider [IP.SB,
                                      IPInfo, IPInsight, IP-API.com,
                                      IPInfoLocal, CHUNZHEN, disable-geoip].

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -347,11 +347,11 @@ export GLOBALPING_TOKEN=your_token_here
 ### 全部用法详见 Usage 菜单
 
 ```shell
-Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
+usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
                  [-U|--udp] [-F|--fast-trace] [-p|--port <integer>]
                  [--icmp-mode <integer>] [-q|--queries <integer>]
-                 [--parallel-requests <integer>] [-m|--max-hops <integer>]
-                 [--max-attempts <integer>] [-d|--data-provider
+                 [--max-attempts <integer>] [--parallel-requests <integer>]
+                 [-m|--max-hops <integer>] [-d|--data-provider
                  (IP.SB|ip.sb|IPInfo|ipinfo|IPInsight|ipinsight|IPAPI.com|ip-api.com|IPInfoLocal|ipinfolocal|chunzhen|LeoMoeAPI|leomoeapi|ipdb.one|disable-geoip)]
                  [--pow-provider (api.nxtrace.org|sakura)] [-n|--no-rdns]
                  [-a|--always-rdns] [-P|--route-path] [-r|--report] [--dn42]
@@ -364,6 +364,8 @@ Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
                  [_positionalArg_nexttrace_38 "<value>"] [--dot-server
                  (dnssb|aliyun|dnspod|google|cloudflare)] [-g|--language
                  (en|cn)] [--file "<value>"] [-C|--no-color] [--from "<value>"]
+
+                 An open source visual route tracking CLI tool
 
 Arguments:
 
@@ -382,15 +384,15 @@ Arguments:
       --icmp-mode                    Windows ONLY: Choose the method to listen
                                      for ICMP packets (1=Socket, 2=PCAP;
                                      0=Auto)
-  -q  --queries                      Set the number of probes per each hop.
-                                     Default: 3
+  -q  --queries                      Set the number of latency samples to
+                                     display for each hop. Default: 3
+      --max-attempts                 Set the maximum number of probe packets
+                                     per hop (instead of a fixed auto value)
       --parallel-requests            Set ParallelRequests number. It should be
                                      1 when there is a multi-routing. Default:
                                      18
   -m  --max-hops                     Set the max number of hops (max TTL to be
                                      reached). Default: 30
-      --max-attempts                 Set the max number of attempts per TTL
-                                     (instead of a fixed auto value)
   -d  --data-provider                Choose IP Geograph Data Provider [IP.SB,
                                      IPInfo, IPInsight, IP-API.com,
                                      IPInfoLocal, CHUNZHEN, disable-geoip].

--- a/assets/windivert/divert.go
+++ b/assets/windivert/divert.go
@@ -44,12 +44,12 @@ func PrepareWinDivertRuntime() error {
 	}
 
 	// DLL
-	if err = writeIfChecksumDiff(filepath.Join(exeDir, "WinDivert.dll"), dllBytes); err != nil {
+	if err := writeIfChecksumDiff(filepath.Join(exeDir, "WinDivert.dll"), dllBytes); err != nil {
 		return err
 	}
 
 	// SYS
-	if err = writeIfChecksumDiff(filepath.Join(exeDir, sysName), sysBytes); err != nil {
+	if err := writeIfChecksumDiff(filepath.Join(exeDir, sysName), sysBytes); err != nil {
 		return err
 	}
 	return nil
@@ -63,7 +63,7 @@ func writeIfChecksumDiff(dst string, data []byte) error {
 	}
 
 	hash := sha256.New()
-	if _, err = io.Copy(hash, file); err != nil {
+	if _, err := io.Copy(hash, file); err != nil {
 		_ = file.Close()                      // 先关再写，避免 Windows 共享冲突
 		return os.WriteFile(dst, data, 0o644) // 读失败，则尝试覆盖
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -172,10 +172,10 @@ func Execute() {
 	fast_trace := parser.Flag("F", "fast-trace", &argparse.Options{Help: "One-Key Fast Trace to China ISPs"})
 	port := parser.Int("p", "port", &argparse.Options{Help: "Set the destination port to use. With default of 80 for \"tcp\", 33494 for \"udp\""})
 	icmpMode := parser.Int("", "icmp-mode", &argparse.Options{Help: "Windows ONLY: Choose the method to listen for ICMP packets (1=Socket, 2=PCAP; 0=Auto)"})
-	numMeasurements := parser.Int("q", "queries", &argparse.Options{Default: 3, Help: "Set the number of probes per each hop"})
+	numMeasurements := parser.Int("q", "queries", &argparse.Options{Default: 3, Help: "Set the number of latency samples to display for each hop"})
+	maxAttempts := parser.Int("", "max-attempts", &argparse.Options{Help: "Set the maximum number of probe packets per hop (instead of a fixed auto value)"})
 	parallelRequests := parser.Int("", "parallel-requests", &argparse.Options{Default: 18, Help: "Set ParallelRequests number. It should be 1 when there is a multi-routing"})
 	maxHops := parser.Int("m", "max-hops", &argparse.Options{Default: 30, Help: "Set the max number of hops (max TTL to be reached)"})
-	maxAttempts := parser.Int("", "max-attempts", &argparse.Options{Help: "Set the max number of attempts per TTL (instead of a fixed auto value)"})
 	dataOrigin := parser.Selector("d", "data-provider", []string{"IP.SB", "ip.sb", "IPInfo", "ipinfo", "IPInsight", "ipinsight", "IPAPI.com", "ip-api.com", "IPInfoLocal", "ipinfolocal", "chunzhen", "LeoMoeAPI", "leomoeapi", "ipdb.one", "disable-geoip"}, &argparse.Options{Default: "LeoMoeAPI",
 		Help: "Choose IP Geograph Data Provider [IP.SB, IPInfo, IPInsight, IP-API.com, IPInfoLocal, CHUNZHEN, disable-geoip]"})
 	powProvider := parser.Selector("", "pow-provider", []string{"api.nxtrace.org", "sakura"}, &argparse.Options{Default: "api.nxtrace.org",
@@ -300,18 +300,19 @@ func Execute() {
 		}
 	}
 
-	if *maxAttempts > 255 {
-		fmt.Println("MaxAttempts 最大值为 255，已自动调整为 255")
-		*maxAttempts = 255
+	if !*tcp {
+		if *numMeasurements > 255 {
+			fmt.Println("Query 最大值为 255，已自动调整为 255")
+			*numMeasurements = 255
+		}
+
+		if *maxAttempts > 255 {
+			fmt.Println("MaxAttempt 最大值为 255，已自动调整为 255")
+			*maxAttempts = 255
+		}
 	}
 
 	domain := *str
-
-	// 仅在使用 UDP 探测时，确保 UDP 负载长度 ≥ 2
-	if *udp && *packetSize < 2 {
-		fmt.Println("UDP 模式下，数据包长度不能小于 2，已自动调整为 2")
-		*packetSize = 2
-	}
 
 	var m trace.Method
 	switch {
@@ -332,6 +333,7 @@ func Execute() {
 			DstPort:        *port,
 			BeginHop:       *beginHop,
 			MaxHops:        *maxHops,
+			MaxAttempts:    *maxAttempts,
 			RDNS:           !*norDNS,
 			AlwaysWaitRDNS: *alwaysrDNS,
 			Lang:           *lang,
@@ -489,6 +491,12 @@ func Execute() {
 				}
 			}
 		}
+	}
+
+	// 仅在使用 UDPv6 探测时，确保 UDP 负载长度 ≥ 2
+	if *udp && util.IsIPv6(ip) && *packetSize < 2 {
+		fmt.Println("UDPv6 模式下，数据包长度不能小于 2，已自动调整为 2")
+		*packetSize = 2
 	}
 
 	if !*jsonPrint {

--- a/fast_trace/basic.go
+++ b/fast_trace/basic.go
@@ -50,48 +50,48 @@ var Beijing = BackBoneCollection{
 	Location: "北京",
 	CT163: ISPCollection{
 		ISPName: CT163,
-		IP:      "ipv4.pek-4134.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.pek-4134.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-4134.endpoint.nxtrace.org",
+		IPv6:    "ipv6.pek-4134.endpoint.nxtrace.org",
 	},
 
 	CTCN2: ISPCollection{
 		ISPName: CTCN2,
-		IP:      "ipv4.pek-4809.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-4809.endpoint.nxtrace.org",
 	},
 
 	CU169: ISPCollection{
 		ISPName: CU169,
-		IP:      "ipv4.pek-4837.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.pek-4837.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-4837.endpoint.nxtrace.org",
+		IPv6:    "ipv6.pek-4837.endpoint.nxtrace.org",
 	},
 
 	CU9929: ISPCollection{
 		ISPName: CU9929,
-		IP:      "ipv4.pek-9929.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-9929.endpoint.nxtrace.org",
 	},
 
 	CM: ISPCollection{
 		ISPName: CM,
-		IP:      "ipv4.pek-9808.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.pek-9808.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-9808.endpoint.nxtrace.org",
+		IPv6:    "ipv6.pek-9808.endpoint.nxtrace.org",
 	},
 
 	CMIN2: ISPCollection{
 		ISPName: CMIN2,
-		IP:      "ipv4.pek-58807.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-58807.endpoint.nxtrace.org",
 	},
 
 	EDU: ISPCollection{
 		ISPName: EDU,
-		IP:      "ipv4.pek-4538.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.pek-4538.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-4538.endpoint.nxtrace.org",
+		IPv6:    "ipv6.pek-4538.endpoint.nxtrace.org",
 	},
 
 	// 中科院
 	CST: ISPCollection{
 		ISPName: CST,
-		IP:      "ipv4.pek-7497.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.pek-7497.endpoint.nxtrace.org.",
+		IP:      "ipv4.pek-7497.endpoint.nxtrace.org",
+		IPv6:    "ipv6.pek-7497.endpoint.nxtrace.org",
 	},
 }
 
@@ -99,42 +99,42 @@ var Shanghai = BackBoneCollection{
 	Location: "上海",
 	CT163: ISPCollection{
 		ISPName: CT163,
-		IP:      "ipv4.sha-4134.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.sha-4134.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-4134.endpoint.nxtrace.org",
+		IPv6:    "ipv6.sha-4134.endpoint.nxtrace.org",
 	},
 
 	CTCN2: ISPCollection{
 		ISPName: CTCN2,
-		IP:      "ipv4.sha-4809.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-4809.endpoint.nxtrace.org",
 	},
 
 	CU169: ISPCollection{
 		ISPName: CU169,
-		IP:      "ipv4.sha-4837.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.sha-4837.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-4837.endpoint.nxtrace.org",
+		IPv6:    "ipv6.sha-4837.endpoint.nxtrace.org",
 	},
 
 	CU9929: ISPCollection{
 		ISPName: CU9929,
-		IP:      "ipv4.sha-9929.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.sha-9929.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-9929.endpoint.nxtrace.org",
+		IPv6:    "ipv6.sha-9929.endpoint.nxtrace.org",
 	},
 
 	CM: ISPCollection{
 		ISPName: CM,
-		IP:      "ipv4.sha-9808.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.sha-9808.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-9808.endpoint.nxtrace.org",
+		IPv6:    "ipv6.sha-9808.endpoint.nxtrace.org",
 	},
 
 	CMIN2: ISPCollection{
 		ISPName: CMIN2,
-		IP:      "ipv4.sha-58807.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-58807.endpoint.nxtrace.org",
 	},
 
 	EDU: ISPCollection{
 		ISPName: EDU,
-		IP:      "ipv4.sha-4538.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.sha-4538.endpoint.nxtrace.org.",
+		IP:      "ipv4.sha-4538.endpoint.nxtrace.org",
+		IPv6:    "ipv6.sha-4538.endpoint.nxtrace.org",
 	},
 }
 
@@ -142,42 +142,42 @@ var Guangzhou = BackBoneCollection{
 	Location: "广州",
 	CT163: ISPCollection{
 		ISPName: CT163,
-		IP:      "ipv4.can-4134.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.can-4134.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-4134.endpoint.nxtrace.org",
+		IPv6:    "ipv6.can-4134.endpoint.nxtrace.org",
 	},
 
 	CTCN2: ISPCollection{
 		ISPName: CTCN2,
-		IP:      "ipv4.can-4809.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-4809.endpoint.nxtrace.org",
 	},
 
 	CU169: ISPCollection{
 		ISPName: CU169,
-		IP:      "ipv4.can-4837.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.can-4837.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-4837.endpoint.nxtrace.org",
+		IPv6:    "ipv6.can-4837.endpoint.nxtrace.org",
 	},
 
 	CU9929: ISPCollection{
 		ISPName: CU9929,
-		IP:      "ipv4.can-9929.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-9929.endpoint.nxtrace.org",
 	},
 
 	CM: ISPCollection{
 		ISPName: CM,
-		IP:      "ipv4.can-9808.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.can-9808.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-9808.endpoint.nxtrace.org",
+		IPv6:    "ipv6.can-9808.endpoint.nxtrace.org",
 	},
 
 	CMIN2: ISPCollection{
 		ISPName: CMIN2,
-		IP:      "ipv4.can-58807.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-58807.endpoint.nxtrace.org",
 	},
 
 	// 中山大学
 	EDU: ISPCollection{
 		ISPName: EDU,
-		IP:      "ipv4.can-4538.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.can-4538.endpoint.nxtrace.org.",
+		IP:      "ipv4.can-4538.endpoint.nxtrace.org",
+		IPv6:    "ipv6.can-4538.endpoint.nxtrace.org",
 	},
 }
 
@@ -185,24 +185,24 @@ var Hangzhou = BackBoneCollection{
 	Location: "杭州",
 	CT163: ISPCollection{
 		ISPName: CT163,
-		IP:      "ipv4.hgh-4134.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.hgh-4134.endpoint.nxtrace.org.",
+		IP:      "ipv4.hgh-4134.endpoint.nxtrace.org",
+		IPv6:    "ipv6.hgh-4134.endpoint.nxtrace.org",
 	},
 	CU169: ISPCollection{
 		ISPName: CU169,
-		IP:      "ipv4.hgh-4837.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.hgh-4837.endpoint.nxtrace.org.",
+		IP:      "ipv4.hgh-4837.endpoint.nxtrace.org",
+		IPv6:    "ipv6.hgh-4837.endpoint.nxtrace.org",
 	},
 	CM: ISPCollection{
 		ISPName: CM,
-		IP:      "ipv4.hgh-9808.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.hgh-9808.endpoint.nxtrace.org.",
+		IP:      "ipv4.hgh-9808.endpoint.nxtrace.org",
+		IPv6:    "ipv6.hgh-9808.endpoint.nxtrace.org",
 	},
 	// 浙江大学 教育网
 	EDU: ISPCollection{
 		ISPName: EDU,
-		IP:      "ipv4.hgh-4538.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.hgh-4538.endpoint.nxtrace.org.",
+		IP:      "ipv4.hgh-4538.endpoint.nxtrace.org",
+		IPv6:    "ipv6.hgh-4538.endpoint.nxtrace.org",
 	},
 }
 
@@ -211,12 +211,12 @@ var Hefei = BackBoneCollection{
 	// 中国科学技术大学 教育网
 	EDU: ISPCollection{
 		ISPName: EDU,
-		IP:      "ipv4.hfe-4538.endpoint.nxtrace.org.",
-		IPv6:    "ipv6.hfe-4538.endpoint.nxtrace.org.",
+		IP:      "ipv4.hfe-4538.endpoint.nxtrace.org",
+		IPv6:    "ipv6.hfe-4538.endpoint.nxtrace.org",
 	},
 	// 中国科学技术大学 科技网
 	CST: ISPCollection{
 		ISPName: CST,
-		IP:      "ipv4.hfe-7497.endpoint.nxtrace.org.",
+		IP:      "ipv4.hfe-7497.endpoint.nxtrace.org",
 	},
 }

--- a/fast_trace/fast_trace ipv6.go
+++ b/fast_trace/fast_trace ipv6.go
@@ -36,6 +36,7 @@ func (f *FastTracer) tracert_v6(location string, ispCollection ISPCollection) {
 		DstPort:          f.ParamsFastTrace.DstPort,
 		MaxHops:          f.ParamsFastTrace.MaxHops,
 		NumMeasurements:  3,
+		MaxAttempts:      f.ParamsFastTrace.MaxAttempts,
 		ParallelRequests: 18,
 		RDNS:             f.ParamsFastTrace.RDNS,
 		AlwaysWaitRDNS:   f.ParamsFastTrace.AlwaysWaitRDNS,
@@ -149,6 +150,12 @@ func FastTestv6(traceMode trace.Method, outEnable bool, paramsFastTrace ParamsFa
 	_, err := fmt.Scanln(&c)
 	if err != nil {
 		c = "1"
+	}
+
+	// 仅在使用 UDPv6 探测时，确保 UDP 负载长度 ≥ 2
+	if traceMode == trace.UDPTrace && paramsFastTrace.PktSize < 2 {
+		fmt.Println("UDPv6 模式下，数据包长度不能小于 2，已自动调整为 2")
+		paramsFastTrace.PktSize = 2
 	}
 
 	ft := FastTracer{

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -33,6 +33,7 @@ type ParamsFastTrace struct {
 	DstPort        int
 	BeginHop       int
 	MaxHops        int
+	MaxAttempts    int
 	RDNS           bool
 	AlwaysWaitRDNS bool
 	Lang           string
@@ -67,6 +68,7 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 		DstPort:          f.ParamsFastTrace.DstPort,
 		MaxHops:          f.ParamsFastTrace.MaxHops,
 		NumMeasurements:  3,
+		MaxAttempts:      f.ParamsFastTrace.MaxAttempts,
 		ParallelRequests: 18,
 		RDNS:             f.ParamsFastTrace.RDNS,
 		AlwaysWaitRDNS:   f.ParamsFastTrace.AlwaysWaitRDNS,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nxtrace/NTrace-core
 
-go 1.25.1
+go 1.25.4
 
 require (
 	github.com/akamensky/argparse v1.4.0

--- a/printer/basic.go
+++ b/printer/basic.go
@@ -78,7 +78,7 @@ func PrintTraceRouteNav(ip net.IP, domain string, dataOrigin string, maxHops int
 
 func applyLangSetting(h *trace.Hop) {
 	if len(h.Geo.Country) <= 1 {
-		//打印h.geo
+		// 打印 h.Geo
 		if h.Geo.Whois != "" {
 			h.Geo.Country = h.Geo.Whois
 		} else {
@@ -94,11 +94,12 @@ func applyLangSetting(h *trace.Hop) {
 
 	if h.Lang == "en" {
 		if h.Geo.Country == "Anycast" {
-
 		} else if h.Geo.Prov == "骨干网" {
 			h.Geo.Prov = "BackBone"
 		} else if h.Geo.ProvEn == "" {
-			h.Geo.Country = h.Geo.CountryEn
+			if h.Geo.CountryEn != "" {
+				h.Geo.Country = h.Geo.CountryEn
+			}
 		} else {
 			if h.Geo.CityEn == "" {
 				h.Geo.Country = h.Geo.ProvEn
@@ -111,5 +112,4 @@ func applyLangSetting(h *trace.Hop) {
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
已完成任务：
1. 升级项目Go版本至1.25.4
2. 优化了MPLS Label的提取函数
3. 更新workflow文件，以适配go1.25.4
4. 修复了英文模式下无法显示RFC1918等信息的bug
5. 完善了geoip查询失败时的错误处理
6. 修改了README，并完善了一些参数的说明和处理


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `--max-attempts` 参数，用于设置每跳的探测包数量上限。

* **错误修复**
  * 改进 UDP/IPv6 探测安全检查。
  * 增强 MPLS 数据解析逻辑。

* **文档**
  * 更新参数说明，`--queries` 改为展示每跳延迟样本数。
  * 调整使用文档和参数顺序。

* **其他**
  * 升级 Go 工具链版本至 1.25.4。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->