### PR TITLE
Add linux/loong64 target

### DIFF
--- a/.cross_compile.sh
+++ b/.cross_compile.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 DIST_PREFIX="nexttrace"
 DEBUG_MODE="${1:-}"                # 支持 ./script.sh debug
 TARGET_DIR="dist"
-PLATFORMS="linux/386 linux/amd64 linux/arm64 linux/mips linux/mips64 linux/mipsle linux/mips64le windows/amd64 windows/arm64 openbsd/amd64 openbsd/arm64 freebsd/amd64 freebsd/arm64"
+PLATFORMS="linux/386 linux/amd64 linux/arm64 linux/mips linux/mips64 linux/mipsle linux/mips64le linux/loong64 windows/amd64 windows/arm64 openbsd/amd64 openbsd/arm64 freebsd/amd64 freebsd/arm64"
 UPX_BIN="${UPX_BIN:-$(command -v upx 2>/dev/null || true)}"
 UPX_FLAGS="${UPX_FLAGS:--9}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           - { goos: windows, goarch: arm,    goarm: 7, allow_fail: true } # windows/arm 计划于 Go 1.26 移除
           - { goos: linux,   goarch: arm64 }
           - { goos: linux,   goarch: riscv64 }
+          - { goos: linux,   goarch: loong64 }
           - { goos: linux,   goarch: mips64 }
           - { goos: linux,   goarch: mips64le }
           - { goos: linux,   goarch: mipsle }

--- a/nt_install.sh
+++ b/nt_install.sh
@@ -34,6 +34,8 @@ checkSystemArch() {
     archParam="armv7"
     elif [[ $arch == "mips" ]]; then
     archParam="mips"
+    elif [[ $arch == "loong64" ]]; then
+    archParam="loong64"
     fi
 }
 


### PR DESCRIPTION
Add linux/loong64 target to:
* Installation script
* Github Action workflow
  * Works fine on my repo: https://github.com/KatyushaScarlet/NTrace-V1/actions/runs/20779398387
* Build script
  * Works fine on my Loongson 3B6000 system.
<img width="1893" height="1091" alt="image" src="https://github.com/user-attachments/assets/298815c4-6db8-4261-b218-78665051bdac" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新增功能
* 扩展了支持的目标架构：新增了对 loong64 架构的支持，使产品现可在 loong64 系统上进行构建和部署。该变更更新了构建配置、持续集成流程和系统架构检测逻辑，增强了产品的跨平台兼容性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->