### PR TITLE
Fix arch detect for nt_install.sh

### DIFF
--- a/nt_install.sh
+++ b/nt_install.sh
@@ -34,7 +34,7 @@ checkSystemArch() {
     archParam="armv7"
     elif [[ $arch == "mips" ]]; then
     archParam="mips"
-    elif [[ $arch == "loong64" ]]; then
+    elif [[ $arch == "loongarch64" ]]; then
     archParam="loong64"
     fi
 }


### PR DESCRIPTION
The `uname -m` get `loongarch64` on the Loongson system, not `loong64`. The `loong64` is goarch.
I'm sorry for the mistake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了系统架构识别逻辑，增加对 loongarch64 的识别与兼容映射，提升在该架构平台上的运行兼容性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->