### PR TITLE
fix(ipgeo): 对齐 v4 Geo 组织信息与 v3 输出

### DIFF
--- a/ipgeo/nexttrace_api_v4.go
+++ b/ipgeo/nexttrace_api_v4.go
@@ -540,6 +540,10 @@ func decodeNextTraceAPIV4Geo(body []byte) (*IPGeoData, error) {
 	if err != nil {
 		return nil, err
 	}
+	owner := wire.Domain
+	if owner == "" {
+		owner = wire.Owner
+	}
 	return &IPGeoData{
 		IP:        wire.IP,
 		Asnumber:  wire.Asnumber,
@@ -550,7 +554,7 @@ func decodeNextTraceAPIV4Geo(body []byte) (*IPGeoData, error) {
 		City:      wire.City,
 		CityEn:    wire.CityEn,
 		District:  wire.District,
-		Owner:     wire.Owner,
+		Owner:     owner,
 		Isp:       wire.Isp,
 		Domain:    wire.Domain,
 		Whois:     wire.Whois,

--- a/ipgeo/nexttrace_api_v4_test.go
+++ b/ipgeo/nexttrace_api_v4_test.go
@@ -1022,6 +1022,109 @@ func TestDecodeNextTraceAPIV4GeoAllowsMissingOrEmptyRouter(t *testing.T) {
 	}
 }
 
+func TestDecodeNextTraceAPIV4GeoPrefersDomainForOwner(t *testing.T) {
+	body := []byte(`{
+		"ip":"203.0.113.8",
+		"asnumber":"4808",
+		"country":"中国",
+		"country_en":"China",
+		"prov":"北京",
+		"prov_en":"Beijing",
+		"city":"北京",
+		"city_en":"Beijing",
+		"district":"海淀",
+		"owner":"中国联通",
+		"domain":"chinaunicom.cn 联通",
+		"isp":"联通",
+		"whois":"China Unicom Beijing Province Network",
+		"lat":39.9042,
+		"lng":116.4074,
+		"prefix":"203.0.113.0/24",
+		"router":{"4808":["4837"]},
+		"source":"nexttrace"
+	}`)
+
+	geo, err := decodeNextTraceAPIV4Geo(body)
+	if err != nil {
+		t.Fatalf("decodeNextTraceAPIV4Geo() error = %v", err)
+	}
+	want := &IPGeoData{
+		IP:        "203.0.113.8",
+		Asnumber:  "4808",
+		Country:   "中国",
+		CountryEn: "China",
+		Prov:      "北京",
+		ProvEn:    "Beijing",
+		City:      "北京",
+		CityEn:    "Beijing",
+		District:  "海淀",
+		Owner:     "chinaunicom.cn 联通",
+		Isp:       "联通",
+		Domain:    "chinaunicom.cn 联通",
+		Whois:     "China Unicom Beijing Province Network",
+		Lat:       39.9042,
+		Lng:       116.4074,
+		Prefix:    "203.0.113.0/24",
+		Router:    map[string][]string{"4808": {"4837"}},
+		Source:    "nexttrace",
+	}
+	if !reflect.DeepEqual(geo, want) {
+		t.Fatalf("geo = %+v, want %+v", geo, want)
+	}
+}
+
+func TestDecodeNextTraceAPIV4GeoFallsBackToRawOwner(t *testing.T) {
+	geo, err := decodeNextTraceAPIV4Geo([]byte(`{
+		"ip":"203.0.113.8",
+		"owner":"中国联通",
+		"domain":""
+	}`))
+	if err != nil {
+		t.Fatalf("decodeNextTraceAPIV4Geo() error = %v", err)
+	}
+	if geo.Owner != "中国联通" {
+		t.Fatalf("Owner = %q, want 中国联通", geo.Owner)
+	}
+	if geo.Domain != "" {
+		t.Fatalf("Domain = %q, want empty", geo.Domain)
+	}
+}
+
+func TestDecodeNextTraceAPIV4GeoOwnerMatchesV3(t *testing.T) {
+	const ip = "203.0.113.8"
+	raw := []byte(`{
+		"ip":"203.0.113.8",
+		"owner":"中国联通",
+		"domain":"chinaunicom.cn 联通"
+	}`)
+
+	ch := make(chan IPGeoData, 1)
+	IPPools.poolMux.Lock()
+	oldPool := IPPools.pool
+	IPPools.pool = map[string]chan IPGeoData{ip: ch}
+	IPPools.poolMux.Unlock()
+	defer func() {
+		IPPools.poolMux.Lock()
+		IPPools.pool = oldPool
+		IPPools.poolMux.Unlock()
+	}()
+
+	dispatchLeoMessage(string(raw))
+	var v3Geo IPGeoData
+	select {
+	case v3Geo = <-ch:
+	default:
+		t.Fatal("v3 parser did not deliver geo data")
+	}
+	v4Geo, err := decodeNextTraceAPIV4Geo(raw)
+	if err != nil {
+		t.Fatalf("decodeNextTraceAPIV4Geo() error = %v", err)
+	}
+	if v4Geo.Owner != v3Geo.Owner {
+		t.Fatalf("v4 Owner = %q, want v3 Owner %q", v4Geo.Owner, v3Geo.Owner)
+	}
+}
+
 func TestNextTraceAPIV4ClientLookupRetriesNetworkErrors(t *testing.T) {
 	withNextTraceAPIV4RetryDelays(t, 0, 0)
 	attempts := 0


### PR DESCRIPTION
## Summary

- v4 Geo 解码在 `domain` 非空时将其用于展示字段 `IPGeoData.Owner`
- `domain` 为空时回退 raw `owner`，并继续保留 raw `Domain`
- 增加 v4 字段保真、owner 回退及 v3/v4 输出一致性的回归测试

## Motivation

v4 HTTP Geo API 原先直接将 raw `owner` 写入 `IPGeoData.Owner`，而现有 v3 WebSocket 路径优先使用 `domain`。实时输出直接打印 `Geo.Owner`，导致同一份后端数据在 v3/v4 下展示不同。

## Changes

- 在 `decodeNextTraceAPIV4Geo` 中按 v3 兼容规则选择展示用 Owner
- 保持 v3 解析、后端字段定义、Domain 及其他 Geo 字段不变
- 覆盖 domain 优先、owner 回退、v3/v4 Owner 一致和其他字段保真的测试

## Testing

- `go test -count=1 ./ipgeo`
- `go test -count=1 ./printer`
- `go test -count=1 ./...`
- `git diff --check`

## Notes for Reviewers

- 预期行为变化仅限 v4 在 `domain` 非空时的展示用 `Owner`
- 空值判断保持与 v3 相同的精确空字符串语义

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 IP 地理信息中的所有者显示：优先使用域名信息，域名缺失时自动回退至原有所有者信息。
  * 改善新旧版本解析结果的一致性，确保兼容已有数据格式。

* **Tests**
  * 增加域名优先、所有者回退及版本兼容性的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->