### PR TITLE
fix(trace): align traceroute stop conditions and report termination reasons (#204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ nexttrace --disable-mpls example.com
 export NEXTTRACE_DISABLEMPLS=1
 ```
 
+Normal traceroute reports why it stopped: destination reached, a terminal unreachable response (including its marker), or the configured maximum hop count. `--json` keeps the existing top-level result shape and adds optional `StopReason` with lowercase nested fields `hop`, `reason`, `responses`, and `markers`. Classic/raw/JSON modes do not receive an extra human-readable footer. `--output` writes the same plain stop line to the log without ANSI escapes.
+
 PS: The route visualization module is an independent component, You can find its source code at [nxtrace/traceMap](https://github.com/nxtrace/traceMap).  
 The routing visualization function requires the geographical coordinates of each Hop, but third-party APIs generally do not provide this information, so this function is currently only supported when used with LeoMoeAPI.
 
@@ -636,6 +638,8 @@ Field order:
 Timeout rows keep the same 12-column layout:
 
 `ttl|*||||||||||`
+
+The raw stdout contract remains exactly 12 columns. When MTR establishes a terminal unreachable path edge, its diagnostic is written to stderr; structured Web/API/MCP records expose per-probe `response` and a final `path_end` instead of inferring the edge from responder-IP equality.
 
 In MTR mode (`--mtr`, `-r`, `-w`, including `--raw`), `-i/--ttl-time` sets the **per-hop probe interval**: how long to wait between successive probes to the same hop (default: 1000ms when omitted). `-z/--send-time` is ignored in MTR mode.
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,9 @@ nexttrace --disable-mpls example.com
 export NEXTTRACE_DISABLEMPLS=1
 ```
 
-Normal traceroute reports why it stopped: destination reached, a terminal unreachable response (including its marker), or the configured maximum hop count. `--json` keeps the existing top-level result shape and adds optional `StopReason` with lowercase nested fields `hop`, `reason`, `responses`, and `markers`. Classic/raw/JSON modes do not receive an extra human-readable footer. `--output` writes the same plain stop line to the log without ANSI escapes.
+Normal traceroute reports why it stopped: destination reached, a terminal unreachable response (including its marker), or the configured maximum hop count. `--json` keeps the existing top-level result shape and adds optional `StopReason` with lowercase nested fields `hop`, `reason`, `responses`, and `markers`; `responses` contains human-readable descriptions while `markers` contains machine-readable codes. Classic/raw/JSON modes do not receive an extra human-readable footer. `--output` writes the same plain stop line to the log without ANSI escapes.
+
+When multiple normal-trace output modes are selected, precedence is `--json` > `--table` > `--classic` > `--raw` > `--output` > realtime output. If a higher-priority mode overrides an explicit `--output` or `--output-default`, NextTrace reports that choice on stderr and does not create the ignored log file.
 
 PS: The route visualization module is an independent component, You can find its source code at [nxtrace/traceMap](https://github.com/nxtrace/traceMap).  
 The routing visualization function requires the geographical coordinates of each Hop, but third-party APIs generally do not provide this information, so this function is currently only supported when used with LeoMoeAPI.
@@ -639,7 +641,7 @@ Timeout rows keep the same 12-column layout:
 
 `ttl|*||||||||||`
 
-The raw stdout contract remains exactly 12 columns. When MTR establishes a terminal unreachable path edge, its diagnostic is written to stderr; structured Web/API/MCP records expose per-probe `response` and a final `path_end` instead of inferring the edge from responder-IP equality.
+The raw stdout contract remains exactly 12 columns. An unreachable edge in unbounded MTR is provisional: later transit evidence can reopen higher hops, and a new unreachable edge may therefore produce another stderr diagnostic. For bounded runs, the final structured `path_end` is authoritative. Structured Web/API/MCP records expose per-probe `response` and the final `path_end` instead of inferring the edge from responder-IP equality.
 
 In MTR mode (`--mtr`, `-r`, `-w`, including `--raw`), `-i/--ttl-time` sets the **per-hop probe interval**: how long to wait between successive probes to the same hop (default: 1000ms when omitted). `-z/--send-time` is ignored in MTR mode.
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -296,7 +296,9 @@ nexttrace --disable-mpls example.com
 export NEXTTRACE_DISABLEMPLS=1
 ```
 
-普通 traceroute 会报告停止原因：到达目标、收到终止性的 unreachable 响应（含 marker），或达到配置的最大跳数。`--json` 保持既有顶层结果结构，并新增可选 `StopReason`；其嵌套字段固定为小写 `hop`、`reason`、`responses`、`markers`。classic/raw/JSON 不追加人类可读 footer；`--output` 会把同一停止原因以无 ANSI 的纯文本写入日志。
+普通 traceroute 会报告停止原因：到达目标、收到终止性的 unreachable 响应（含 marker），或达到配置的最大跳数。`--json` 保持既有顶层结果结构，并新增可选 `StopReason`；其嵌套字段固定为小写 `hop`、`reason`、`responses`、`markers`，其中 `responses` 是人类可读描述，`markers` 是机器可读代码。classic/raw/JSON 不追加人类可读 footer；`--output` 会把同一停止原因以无 ANSI 的纯文本写入日志。
+
+普通 traceroute 同时指定多个输出模式时，优先级为 `--json` > `--table` > `--classic` > `--raw` > `--output` > 实时输出。高优先级模式覆盖显式 `--output` 或 `--output-default` 时，NextTrace 会在 stderr 说明该选择，且不会创建被忽略的日志文件。
 
 PS: 路由可视化的绘制模块为独立模块，具体代码可在 [nxtrace/traceMap](https://github.com/nxtrace/traceMap) 查看  
 路由可视化功能因为需要每个 Hop 的地理位置坐标，而第三方 API 通常不提供此类信息，所以此功能目前只支持搭配 LeoMoeAPI 使用。
@@ -631,7 +633,7 @@ wide 报告模式（`-w` / `--wide`）继续保留当前完整信息行为，包
 
 `ttl|*||||||||||`
 
-raw stdout 契约仍严格保持 12 列。MTR 确认终止性 unreachable 路径边界时，诊断只写 stderr；Web/API/MCP 的结构化记录通过逐 probe `response` 和最终 `path_end` 表达语义，不再按 responder IP 是否等于目标 IP 推断。
+raw stdout 契约仍严格保持 12 列。无限运行的 MTR 中，unreachable 边界是临时状态：后续 transit 证据可以重新开放更高跳数，之后新的 unreachable 边界可能再次输出 stderr 诊断。有限运行以最终结构化 `path_end` 为准。Web/API/MCP 的结构化记录通过逐 probe `response` 和最终 `path_end` 表达语义，不再按 responder IP 是否等于目标 IP 推断。
 
 在 MTR 模式（`--mtr`、`-r`、`-w`，包括 `--raw`）下，`-i/--ttl-time` 设置的是**每个跳点的探测间隔**：同一跳点两次连续探测之间的等待时间（未显式指定时默认 1000ms）。`-z/--send-time` 在 MTR 模式下被忽略。
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -296,6 +296,8 @@ nexttrace --disable-mpls example.com
 export NEXTTRACE_DISABLEMPLS=1
 ```
 
+普通 traceroute 会报告停止原因：到达目标、收到终止性的 unreachable 响应（含 marker），或达到配置的最大跳数。`--json` 保持既有顶层结果结构，并新增可选 `StopReason`；其嵌套字段固定为小写 `hop`、`reason`、`responses`、`markers`。classic/raw/JSON 不追加人类可读 footer；`--output` 会把同一停止原因以无 ANSI 的纯文本写入日志。
+
 PS: 路由可视化的绘制模块为独立模块，具体代码可在 [nxtrace/traceMap](https://github.com/nxtrace/traceMap) 查看  
 路由可视化功能因为需要每个 Hop 的地理位置坐标，而第三方 API 通常不提供此类信息，所以此功能目前只支持搭配 LeoMoeAPI 使用。
 
@@ -628,6 +630,8 @@ wide 报告模式（`-w` / `--wide`）继续保留当前完整信息行为，包
 超时行保持固定 12 列：
 
 `ttl|*||||||||||`
+
+raw stdout 契约仍严格保持 12 列。MTR 确认终止性 unreachable 路径边界时，诊断只写 stderr；Web/API/MCP 的结构化记录通过逐 probe `response` 和最终 `path_end` 表达语义，不再按 responder IP 是否等于目标 IP 推断。
 
 在 MTR 模式（`--mtr`、`-r`、`-w`，包括 `--raw`）下，`-i/--ttl-time` 设置的是**每个跳点的探测间隔**：同一跳点两次连续探测之间的等待时间（未显式指定时默认 1000ms）。`-z/--send-time` 在 MTR 模式下被忽略。
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1122,6 +1122,33 @@ func (mode traceOutputMode) printsStopReason() bool {
 	return mode == traceOutputRealtime || mode == traceOutputFile || mode == traceOutputTable
 }
 
+func (mode traceOutputMode) label() string {
+	switch mode {
+	case traceOutputRaw:
+		return "raw"
+	case traceOutputClassic:
+		return "classic"
+	case traceOutputTable:
+		return "table"
+	case traceOutputJSON:
+		return "JSON"
+	default:
+		return ""
+	}
+}
+
+func writeIgnoredTraceOutputWarning(w io.Writer, mode traceOutputMode, outputPath string) error {
+	if strings.TrimSpace(outputPath) == "" || mode == traceOutputFile {
+		return nil
+	}
+	label := mode.label()
+	if label == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "warning: trace output file is ignored because %s output has higher priority\n", label)
+	return err
+}
+
 type traceOutputPlan struct {
 	mode traceOutputMode
 	file io.WriteCloser
@@ -1163,7 +1190,12 @@ func configureTracePrinters(conf *trace.Config, mode traceOutputMode, outputPath
 		if err != nil {
 			return nil, err
 		}
-		conf.RealtimePrinter = tracelog.NewRealtimePrinter(io.MultiWriter(os.Stdout, f))
+		conf.RealtimePrinter = func(res *trace.Result, ttl int) {
+			printer.RealtimePrinter(res, ttl)
+			if err := tracelog.WriteRealtime(f, res, ttl); err != nil {
+				log.Printf("write trace output: %v", err)
+			}
+		}
 		plan.file = f
 	case traceOutputRealtime:
 		conf.RealtimePrinter = printer.RealtimePrinter
@@ -1729,6 +1761,9 @@ func Execute() {
 
 	if maybeRunMTRMode(mtrModes, method, conf, queriesExplicit, *numMeasurements, ttlTimeExplicit, *ttlInterval, domain, *dataOrigin, *showIPs, *ipInfoMode) {
 		return
+	}
+	if err := writeIgnoredTraceOutputWarning(os.Stderr, outputMode, resolvedOutputPath); err != nil {
+		log.Printf("write trace output warning: %v", err)
 	}
 
 	outputPlan, err := configureTracePrinters(&conf, outputMode, resolvedOutputPath)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -405,8 +405,8 @@ func registerTracerouteOutputFlags(parser *argparse.Parser) tracerouteOutputFlag
 	if !defaultMTR {
 		return tracerouteOutputFlags{
 			routePath:     parser.Flag("P", "route-path", &argparse.Options{Help: "Print traceroute hop path by ASN and location"}),
-			outputPath:    parser.String("o", "output", &argparse.Options{Help: "Write trace result to FILE (RealtimePrinter only)"}),
-			outputDefault: parser.Flag("O", "output-default", &argparse.Options{Help: "Write trace result to the default log file (/tmp/trace.log)"}),
+			outputPath:    parser.String("o", "output", &argparse.Options{Help: "Write realtime trace output and final stop reason to FILE"}),
+			outputDefault: parser.Flag("O", "output-default", &argparse.Options{Help: "Write realtime trace output and final stop reason to the default log file (/tmp/trace.log)"}),
 			tablePrint:    parser.Flag("", "table", &argparse.Options{Help: "Output trace results as a final summary table (traceroute report mode)"}),
 			jsonPrint:     parser.Flag("j", "json", &argparse.Options{Help: "Output trace results as JSON"}),
 			classicPrint:  parser.Flag("c", "classic", &argparse.Options{Help: "Classic Output trace results like BestTrace"}),
@@ -1082,13 +1082,6 @@ func resolveOutputPath(outputPath string, outputDefault bool) (string, error) {
 	return "", nil
 }
 
-func validateJSONRealtimeOutput(jsonPrint bool, outputPath string) error {
-	if jsonPrint && strings.TrimSpace(outputPath) != "" {
-		return errors.New("--json 不能与 --output/--output-default 同时使用")
-	}
-	return nil
-}
-
 func setFastIPOutputSuppression(suppress bool) func() {
 	prev := util.SuppressFastIPOutput
 	util.SuppressFastIPOutput = suppress
@@ -1097,41 +1090,85 @@ func setFastIPOutputSuppression(suppress bool) func() {
 	}
 }
 
-func configureTracePrinters(conf *trace.Config, tablePrint, classicPrint, rawPrint bool, outputPath string) (func() error, error) {
-	if tablePrint {
-		return nil, nil
-	}
-	router := false
+type traceOutputMode uint8
+
+const (
+	traceOutputRealtime traceOutputMode = iota
+	traceOutputFile
+	traceOutputRaw
+	traceOutputClassic
+	traceOutputTable
+	traceOutputJSON
+)
+
+func selectTraceOutputMode(tablePrint, classicPrint, jsonPrint, rawPrint bool, outputPath string) traceOutputMode {
 	switch {
+	case jsonPrint:
+		return traceOutputJSON
+	case tablePrint:
+		return traceOutputTable
 	case classicPrint:
-		conf.RealtimePrinter = printer.ClassicPrinter
+		return traceOutputClassic
 	case rawPrint:
+		return traceOutputRaw
+	case strings.TrimSpace(outputPath) != "":
+		return traceOutputFile
+	default:
+		return traceOutputRealtime
+	}
+}
+
+func (mode traceOutputMode) printsStopReason() bool {
+	return mode == traceOutputRealtime || mode == traceOutputFile || mode == traceOutputTable
+}
+
+type traceOutputPlan struct {
+	mode traceOutputMode
+	file io.WriteCloser
+}
+
+func (plan *traceOutputPlan) printStopReason(reason *trace.StopReason) error {
+	if plan == nil || !plan.mode.printsStopReason() {
+		return nil
+	}
+	terminalErr := printer.PrintTraceStopReason(reason)
+	var fileErr error
+	if plan.mode == traceOutputFile && plan.file != nil {
+		fileErr = printer.WriteTraceStopReason(plan.file, reason)
+	}
+	return errors.Join(terminalErr, fileErr)
+}
+
+func (plan *traceOutputPlan) close() error {
+	if plan == nil || plan.file == nil {
+		return nil
+	}
+	return plan.file.Close()
+}
+
+func configureTracePrinters(conf *trace.Config, mode traceOutputMode, outputPath string) (*traceOutputPlan, error) {
+	plan := &traceOutputPlan{mode: mode}
+	switch mode {
+	case traceOutputJSON:
+		conf.RealtimePrinter = nil
+		conf.AsyncPrinter = nil
+	case traceOutputTable:
+		conf.RealtimePrinter = nil
+	case traceOutputClassic:
+		conf.RealtimePrinter = printer.ClassicPrinter
+	case traceOutputRaw:
 		conf.RealtimePrinter = printer.EasyPrinter
-	case outputPath != "":
+	case traceOutputFile:
 		f, err := tracelog.OpenFile(outputPath)
 		if err != nil {
 			return nil, err
 		}
 		conf.RealtimePrinter = tracelog.NewRealtimePrinter(io.MultiWriter(os.Stdout, f))
-		return f.Close, nil
-	case router:
-		conf.RealtimePrinter = printer.RealtimePrinterWithRouter
-		fmt.Println("路由表数据源由 BGP.Tools 提供，在此特表感谢")
-	default:
+		plan.file = f
+	case traceOutputRealtime:
 		conf.RealtimePrinter = printer.RealtimePrinter
 	}
-	return nil, nil
-}
-
-func applyJSONOutputMode(conf *trace.Config, jsonPrint bool) {
-	if jsonPrint {
-		conf.RealtimePrinter = nil
-		conf.AsyncPrinter = nil
-	}
-}
-
-func effectiveRawOutput(tablePrint, classicPrint, jsonPrint, rawPrint bool) bool {
-	return !tablePrint && !classicPrint && !jsonPrint && rawPrint
+	return plan, nil
 }
 
 func maybeRunUninterruptedRaw(rawPrint bool, method trace.Method, conf trace.Config) bool {
@@ -1164,18 +1201,34 @@ func runTraceOnce(method trace.Method, conf trace.Config) (*trace.Result, bool) 
 	return res, true
 }
 
-func finalizeTraceResult(ctx context.Context, res *trace.Result, tablePrint, tableClearScreen, routePath bool, dstIP net.IP, disableMaptrace, jsonPrint, rawPrint bool, dataOrigin string) {
-	if tablePrint {
+// traceMapPayload preserves the historical external tracemap request shape.
+type traceMapPayload struct {
+	Hops        [][]trace.Hop `json:"Hops"`
+	TraceMapURL string        `json:"TraceMapUrl"`
+}
+
+func marshalTraceMapPayload(res *trace.Result) ([]byte, error) {
+	return json.Marshal(traceMapPayload{
+		Hops:        res.Hops,
+		TraceMapURL: res.TraceMapUrl,
+	})
+}
+
+func finalizeTraceResult(ctx context.Context, res *trace.Result, outputPlan *traceOutputPlan, tableClearScreen, routePath bool, dstIP net.IP, disableMaptrace bool, dataOrigin string) {
+	if outputPlan == nil {
+		outputPlan = &traceOutputPlan{mode: traceOutputRealtime}
+	}
+	if outputPlan.mode == traceOutputTable {
 		printer.TracerouteTablePrinter(res, tableClearScreen)
 	}
 	if routePath {
 		reporter.New(res, dstIP.String()).Print()
 	}
-	if !jsonPrint && !rawPrint {
-		printer.PrintTraceStopReason(res.StopReason)
+	if err := outputPlan.printStopReason(res.StopReason); err != nil {
+		log.Printf("print trace stop reason: %v", err)
 	}
 
-	r, err := json.Marshal(res)
+	r, err := marshalTraceMapPayload(res)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -1188,7 +1241,7 @@ func finalizeTraceResult(ctx context.Context, res *trace.Result, tablePrint, tab
 			return
 		}
 		res.TraceMapUrl = url
-		if !jsonPrint {
+		if outputPlan.mode != traceOutputJSON {
 			tracemap.PrintMapUrl(url)
 		}
 	}
@@ -1197,7 +1250,7 @@ func finalizeTraceResult(ctx context.Context, res *trace.Result, tablePrint, tab
 		fmt.Println(err)
 		return
 	}
-	if jsonPrint {
+	if outputPlan.mode == traceOutputJSON {
 		fmt.Println(string(r))
 	}
 }
@@ -1376,10 +1429,7 @@ func Execute() {
 		fmt.Println(outputErr)
 		os.Exit(1)
 	}
-	if err := validateJSONRealtimeOutput(*jsonPrint, resolvedOutputPath); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	outputMode := selectTraceOutputMode(*tablePrint, *classicPrint, *jsonPrint, *rawPrint, resolvedOutputPath)
 	if *mtuMode {
 		conflictFlags := buildMTUConflictFlags(
 			*tcp,
@@ -1681,21 +1731,17 @@ func Execute() {
 		return
 	}
 
-	outputCleanup, err := configureTracePrinters(&conf, *tablePrint, *classicPrint, *rawPrint, resolvedOutputPath)
+	outputPlan, err := configureTracePrinters(&conf, outputMode, resolvedOutputPath)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if outputCleanup != nil {
-		defer func() {
-			if closeErr := outputCleanup(); closeErr != nil {
-				fmt.Println(closeErr)
-			}
-		}()
-	}
-	applyJSONOutputMode(&conf, *jsonPrint)
-	rawOutput := effectiveRawOutput(*tablePrint, *classicPrint, *jsonPrint, *rawPrint)
-	if maybeRunUninterruptedRaw(rawOutput, method, conf) {
+	defer func() {
+		if closeErr := outputPlan.close(); closeErr != nil {
+			log.Printf("close trace output: %v", closeErr)
+		}
+	}()
+	if maybeRunUninterruptedRaw(outputMode == traceOutputRaw, method, conf) {
 		return
 	}
 
@@ -1704,7 +1750,7 @@ func Execute() {
 		return
 	}
 
-	finalizeTraceResult(rootCtx, res, *tablePrint, stdoutIsTTY, *routePath, ip, *disableMaptrace, *jsonPrint, rawOutput, *dataOrigin)
+	finalizeTraceResult(rootCtx, res, outputPlan, stdoutIsTTY, *routePath, ip, *disableMaptrace, *dataOrigin)
 }
 
 type mtrRunMode int

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1130,6 +1130,10 @@ func applyJSONOutputMode(conf *trace.Config, jsonPrint bool) {
 	}
 }
 
+func effectiveRawOutput(tablePrint, classicPrint, jsonPrint, rawPrint bool) bool {
+	return !tablePrint && !classicPrint && !jsonPrint && rawPrint
+}
+
 func maybeRunUninterruptedRaw(rawPrint bool, method trace.Method, conf trace.Config) bool {
 	if !(util.Uninterrupted && rawPrint) {
 		return false
@@ -1160,12 +1164,15 @@ func runTraceOnce(method trace.Method, conf trace.Config) (*trace.Result, bool) 
 	return res, true
 }
 
-func finalizeTraceResult(ctx context.Context, res *trace.Result, tablePrint, tableClearScreen, routePath bool, dstIP net.IP, disableMaptrace, jsonPrint bool, dataOrigin string) {
+func finalizeTraceResult(ctx context.Context, res *trace.Result, tablePrint, tableClearScreen, routePath bool, dstIP net.IP, disableMaptrace, jsonPrint, rawPrint bool, dataOrigin string) {
 	if tablePrint {
 		printer.TracerouteTablePrinter(res, tableClearScreen)
 	}
 	if routePath {
 		reporter.New(res, dstIP.String()).Print()
+	}
+	if !jsonPrint && !rawPrint {
+		printer.PrintTraceStopReason(res.StopReason)
 	}
 
 	r, err := json.Marshal(res)
@@ -1687,7 +1694,8 @@ func Execute() {
 		}()
 	}
 	applyJSONOutputMode(&conf, *jsonPrint)
-	if maybeRunUninterruptedRaw(*rawPrint, method, conf) {
+	rawOutput := effectiveRawOutput(*tablePrint, *classicPrint, *jsonPrint, *rawPrint)
+	if maybeRunUninterruptedRaw(rawOutput, method, conf) {
 		return
 	}
 
@@ -1696,7 +1704,7 @@ func Execute() {
 		return
 	}
 
-	finalizeTraceResult(rootCtx, res, *tablePrint, stdoutIsTTY, *routePath, ip, *disableMaptrace, *jsonPrint, *dataOrigin)
+	finalizeTraceResult(rootCtx, res, *tablePrint, stdoutIsTTY, *routePath, ip, *disableMaptrace, *jsonPrint, rawOutput, *dataOrigin)
 }
 
 type mtrRunMode int

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -563,7 +563,6 @@ func TestTraceOutputPlanStopReasonVisibility(t *testing.T) {
 		want bool
 	}{
 		{name: "default", mode: traceOutputRealtime, want: true},
-		{name: "route path default", mode: traceOutputRealtime, want: true},
 		{name: "table", mode: traceOutputTable, want: true},
 		{name: "output", mode: traceOutputFile, want: true},
 		{name: "classic", mode: traceOutputClassic},
@@ -581,6 +580,40 @@ func TestTraceOutputPlanStopReasonVisibility(t *testing.T) {
 			}
 			if got := strings.Contains(terminal.String(), "Trace Stopped:"); got != tt.want {
 				t.Fatalf("terminal stop reason present = %v, want %v; output=%q", got, tt.want, terminal.String())
+			}
+		})
+	}
+}
+
+func TestWriteIgnoredTraceOutputWarning(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       traceOutputMode
+		outputPath string
+		want       string
+	}{
+		{name: "JSON overrides output", mode: traceOutputJSON, outputPath: "trace.log", want: "JSON"},
+		{name: "table overrides output", mode: traceOutputTable, outputPath: "trace.log", want: "table"},
+		{name: "classic overrides output", mode: traceOutputClassic, outputPath: "trace.log", want: "classic"},
+		{name: "raw overrides output", mode: traceOutputRaw, outputPath: "trace.log", want: "raw"},
+		{name: "file output active", mode: traceOutputFile, outputPath: "trace.log"},
+		{name: "no output requested", mode: traceOutputJSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := writeIgnoredTraceOutputWarning(&output, tt.mode, tt.outputPath); err != nil {
+				t.Fatalf("writeIgnoredTraceOutputWarning() error = %v", err)
+			}
+			if tt.want == "" {
+				if output.Len() != 0 {
+					t.Fatalf("warning = %q, want empty", output.String())
+				}
+				return
+			}
+			if got := output.String(); !strings.Contains(got, "output file is ignored") || !strings.Contains(got, tt.want) {
+				t.Fatalf("warning = %q, want ignored warning for %s", got, tt.want)
 			}
 		})
 	}
@@ -650,6 +683,10 @@ func TestTraceOutputFileWritesPlainStopReason(t *testing.T) {
 	if conf.RealtimePrinter == nil {
 		t.Fatal("RealtimePrinter = nil, want output printer")
 	}
+	conf.RealtimePrinter(&trace.Result{Hops: [][]trace.Hop{{}}}, 0)
+	if !strings.Contains(terminal.String(), "\x1b[") {
+		t.Fatalf("terminal hop output is not styled: %q", terminal.String())
+	}
 	reason := &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}}
 	if err := plan.printStopReason(reason); err != nil {
 		t.Fatalf("printStopReason() error = %v", err)
@@ -662,9 +699,12 @@ func TestTraceOutputFileWritesPlainStopReason(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile() error = %v", err)
 	}
-	want := "Trace Stopped: Destination Reached at Hop 5 (ICMP Echo Reply)\n"
-	if string(got) != want {
-		t.Fatalf("output file = %q, want %q", got, want)
+	if !strings.Contains(string(got), "1   *\n") {
+		t.Fatalf("output file missing plain hop output: %q", got)
+	}
+	wantStop := "Trace Stopped: Destination Reached at Hop 5 (ICMP Echo Reply)\n"
+	if !strings.Contains(string(got), wantStop) {
+		t.Fatalf("output file = %q, want stop line %q", got, wantStop)
 	}
 	if bytes.Contains(got, []byte("\x1b[")) {
 		t.Fatalf("output file contains ANSI escapes: %q", got)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"os"
@@ -11,12 +13,58 @@ import (
 	"time"
 
 	"github.com/akamensky/argparse"
+	"github.com/fatih/color"
 	fastTrace "github.com/nxtrace/NTrace-core/fast_trace"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/tracelog"
 	"github.com/nxtrace/NTrace-core/util"
 	"github.com/nxtrace/NTrace-core/wshandle"
 )
+
+var errCmdOutputWriter = errors.New("cmd output writer failed")
+
+type failingCmdOutputWriter struct{}
+
+func (failingCmdOutputWriter) Write([]byte) (int, error) {
+	return 0, errCmdOutputWriter
+}
+
+func TestMarshalTraceMapPayloadKeepsHistoricalShape(t *testing.T) {
+	res := &trace.Result{
+		Hops:        [][]trace.Hop{{{TTL: 1}}},
+		StopReason:  &trace.StopReason{Hop: 1, Reason: trace.StopReasonDestination},
+		TraceMapUrl: "https://map.example.test",
+	}
+
+	payload, err := marshalTraceMapPayload(res)
+	if err != nil {
+		t.Fatalf("marshalTraceMapPayload() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatalf("trace map payload decode: %v", err)
+	}
+	if len(fields) != 2 {
+		t.Fatalf("trace map payload fields = %v, want historical Hops and TraceMapUrl only", fields)
+	}
+	if _, ok := fields["Hops"]; !ok {
+		t.Fatalf("trace map payload missing Hops: %s", payload)
+	}
+	if got := string(fields["TraceMapUrl"]); got != `"https://map.example.test"` {
+		t.Fatalf("trace map payload TraceMapUrl = %s", got)
+	}
+	if _, ok := fields["StopReason"]; ok {
+		t.Fatalf("trace map payload leaked StopReason: %s", payload)
+	}
+
+	fullResult, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("full result marshal: %v", err)
+	}
+	if !bytes.Contains(fullResult, []byte(`"StopReason"`)) {
+		t.Fatalf("full JSON result lost StopReason: %s", fullResult)
+	}
+}
 
 func TestLookupTargetIPHonorsContextCancellation(t *testing.T) {
 	oldLookup := domainLookupFn
@@ -471,28 +519,222 @@ func TestMaybeRunUninterruptedRawReturnsOnCanceledContext(t *testing.T) {
 	}
 }
 
-func TestEffectiveRawOutput(t *testing.T) {
+func TestSelectTraceOutputModePriority(t *testing.T) {
 	tests := []struct {
 		name         string
 		tablePrint   bool
 		classicPrint bool
 		jsonPrint    bool
 		rawPrint     bool
-		want         bool
+		outputPath   string
+		want         traceOutputMode
 	}{
-		{name: "raw", rawPrint: true, want: true},
-		{name: "table overrides raw", tablePrint: true, rawPrint: true},
-		{name: "classic overrides raw", classicPrint: true, rawPrint: true},
-		{name: "JSON overrides raw", jsonPrint: true, rawPrint: true},
-		{name: "default", want: false},
+		{name: "realtime", want: traceOutputRealtime},
+		{name: "output", outputPath: "trace.log", want: traceOutputFile},
+		{name: "raw over output", rawPrint: true, outputPath: "trace.log", want: traceOutputRaw},
+		{name: "classic over raw", classicPrint: true, rawPrint: true, outputPath: "trace.log", want: traceOutputClassic},
+		{name: "table over classic", tablePrint: true, classicPrint: true, rawPrint: true, outputPath: "trace.log", want: traceOutputTable},
+		{name: "JSON over table and output", tablePrint: true, classicPrint: true, jsonPrint: true, rawPrint: true, outputPath: "trace.log", want: traceOutputJSON},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := effectiveRawOutput(tt.tablePrint, tt.classicPrint, tt.jsonPrint, tt.rawPrint); got != tt.want {
-				t.Fatalf("effectiveRawOutput() = %v, want %v", got, tt.want)
+			got := selectTraceOutputMode(tt.tablePrint, tt.classicPrint, tt.jsonPrint, tt.rawPrint, tt.outputPath)
+			if got != tt.want {
+				t.Fatalf("selectTraceOutputMode() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTraceOutputPlanStopReasonVisibility(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+	color.NoColor = true
+
+	reason := &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination}
+	tests := []struct {
+		name string
+		mode traceOutputMode
+		want bool
+	}{
+		{name: "default", mode: traceOutputRealtime, want: true},
+		{name: "route path default", mode: traceOutputRealtime, want: true},
+		{name: "table", mode: traceOutputTable, want: true},
+		{name: "output", mode: traceOutputFile, want: true},
+		{name: "classic", mode: traceOutputClassic},
+		{name: "raw", mode: traceOutputRaw},
+		{name: "JSON", mode: traceOutputJSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var terminal bytes.Buffer
+			color.Output = &terminal
+			plan := &traceOutputPlan{mode: tt.mode}
+			if err := plan.printStopReason(reason); err != nil {
+				t.Fatalf("printStopReason() error = %v", err)
+			}
+			if got := strings.Contains(terminal.String(), "Trace Stopped:"); got != tt.want {
+				t.Fatalf("terminal stop reason present = %v, want %v; output=%q", got, tt.want, terminal.String())
+			}
+		})
+	}
+}
+
+func TestJSONOutputOverridesFileWithoutSideEffects(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	var terminal bytes.Buffer
+	color.Output = &terminal
+	color.NoColor = true
+	path := filepath.Join(t.TempDir(), "trace.log")
+	mode := selectTraceOutputMode(false, false, true, false, path)
+	if mode != traceOutputJSON {
+		t.Fatalf("selectTraceOutputMode() = %v, want JSON", mode)
+	}
+
+	conf := trace.Config{
+		RealtimePrinter: func(*trace.Result, int) {},
+		AsyncPrinter:    func(*trace.Result) {},
+	}
+	plan, err := configureTracePrinters(&conf, mode, path)
+	if err != nil {
+		t.Fatalf("configureTracePrinters() error = %v", err)
+	}
+	if plan.file != nil {
+		t.Fatal("JSON output opened a trace file")
+	}
+	if conf.RealtimePrinter != nil || conf.AsyncPrinter != nil {
+		t.Fatal("JSON output left a human-readable printer enabled")
+	}
+	if err := plan.printStopReason(&trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination}); err != nil {
+		t.Fatalf("printStopReason() error = %v", err)
+	}
+	if terminal.Len() != 0 {
+		t.Fatalf("JSON output wrote a stop footer: %q", terminal.String())
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("JSON output file stat error = %v, want not exist", err)
+	}
+}
+
+func TestTraceOutputFileWritesPlainStopReason(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm-256color")
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	var terminal bytes.Buffer
+	color.Output = &terminal
+	color.NoColor = false
+	path := filepath.Join(t.TempDir(), "trace.log")
+	conf := trace.Config{}
+	plan, err := configureTracePrinters(&conf, traceOutputFile, path)
+	if err != nil {
+		t.Fatalf("configureTracePrinters() error = %v", err)
+	}
+	if conf.RealtimePrinter == nil {
+		t.Fatal("RealtimePrinter = nil, want output printer")
+	}
+	reason := &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}}
+	if err := plan.printStopReason(reason); err != nil {
+		t.Fatalf("printStopReason() error = %v", err)
+	}
+	if err := plan.close(); err != nil {
+		t.Fatalf("close() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	want := "Trace Stopped: Destination Reached at Hop 5 (ICMP Echo Reply)\n"
+	if string(got) != want {
+		t.Fatalf("output file = %q, want %q", got, want)
+	}
+	if bytes.Contains(got, []byte("\x1b[")) {
+		t.Fatalf("output file contains ANSI escapes: %q", got)
+	}
+	if !strings.Contains(terminal.String(), "Trace Stopped:") {
+		t.Fatalf("terminal missing stop reason: %q", terminal.String())
+	}
+	if !strings.Contains(terminal.String(), "\x1b[") {
+		t.Fatalf("terminal stop reason is not styled: %q", terminal.String())
+	}
+}
+
+func TestTraceOutputFileStillWritesWhenTerminalFails(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	color.Output = failingCmdOutputWriter{}
+	color.NoColor = true
+	path := filepath.Join(t.TempDir(), "trace.log")
+	plan, err := configureTracePrinters(&trace.Config{}, traceOutputFile, path)
+	if err != nil {
+		t.Fatalf("configureTracePrinters() error = %v", err)
+	}
+	reason := &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination}
+	if err := plan.printStopReason(reason); !errors.Is(err, errCmdOutputWriter) {
+		t.Fatalf("printStopReason() error = %v, want %v", err, errCmdOutputWriter)
+	}
+	if err := plan.close(); err != nil {
+		t.Fatalf("close() error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if want := "Trace Stopped: Destination Reached at Hop 5\n"; string(got) != want {
+		t.Fatalf("output file = %q, want %q", got, want)
+	}
+}
+
+func TestFinalizeTraceResultRoutePathPrintsStopReason(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	var terminal bytes.Buffer
+	color.Output = &terminal
+	color.NoColor = true
+	res := &trace.Result{
+		Hops:       [][]trace.Hop{},
+		StopReason: &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination},
+	}
+	finalizeTraceResult(
+		context.Background(),
+		res,
+		&traceOutputPlan{mode: traceOutputRealtime},
+		false,
+		true,
+		net.ParseIP("192.0.2.1"),
+		true,
+		"disable-geoip",
+	)
+	if !strings.Contains(terminal.String(), "Trace Stopped: Destination Reached at Hop 5") {
+		t.Fatalf("route-path output missing stop reason: %q", terminal.String())
 	}
 }
 
@@ -889,15 +1131,6 @@ func TestResolveConfiguredSrcAddrPrefersExplicitSource(t *testing.T) {
 	}
 	if resolved != "192.0.2.10" {
 		t.Fatalf("resolved source = %q, want %q", resolved, "192.0.2.10")
-	}
-}
-
-func TestValidateJSONRealtimeOutput(t *testing.T) {
-	if err := validateJSONRealtimeOutput(true, "trace.log"); err == nil || err.Error() != "--json 不能与 --output/--output-default 同时使用" {
-		t.Fatalf("err = %v, want json/output conflict", err)
-	}
-	if err := validateJSONRealtimeOutput(true, ""); err != nil {
-		t.Fatalf("unexpected error without output path: %v", err)
 	}
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -471,6 +471,31 @@ func TestMaybeRunUninterruptedRawReturnsOnCanceledContext(t *testing.T) {
 	}
 }
 
+func TestEffectiveRawOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		tablePrint   bool
+		classicPrint bool
+		jsonPrint    bool
+		rawPrint     bool
+		want         bool
+	}{
+		{name: "raw", rawPrint: true, want: true},
+		{name: "table overrides raw", tablePrint: true, rawPrint: true},
+		{name: "classic overrides raw", classicPrint: true, rawPrint: true},
+		{name: "JSON overrides raw", jsonPrint: true, rawPrint: true},
+		{name: "default", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveRawOutput(tt.tablePrint, tt.classicPrint, tt.jsonPrint, tt.rawPrint); got != tt.want {
+				t.Fatalf("effectiveRawOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRegisterGlobalpingFlagWithAvailability_DisabledStillParses(t *testing.T) {
 	parser := argparse.NewParser("ntr", "")
 	from := registerGlobalpingFlagWithAvailability(parser, false)

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -212,6 +212,14 @@ func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	opts := trace.MTRRawOptions{
 		HopInterval: time.Duration(hopIntervalMs) * time.Millisecond,
 		MaxPerHop:   maxPerHop,
+		OnPathEnd: func(reason *trace.StopReason) {
+			if reason == nil || reason.Reason != trace.StopReasonUnreachable {
+				return
+			}
+			if err := printer.WriteTraceStopReason(os.Stderr, reason); err != nil {
+				writeMTRRawRuntimeError(os.Stderr, err)
+			}
+		},
 	}
 
 	roundConf := normalizeMTRTraceConfig(conf)

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -201,6 +201,13 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 // runMTRRaw 执行 MTR 原始流式模式（逐事件输出，'|' 分隔）。
 // 行格式固定为 12 列：
 // ttl|ip|ptr|rtt|asn|country|prov|city|district|owner|lat|lng
+func writeMTRRawPathEnd(w io.Writer, reason *trace.StopReason) error {
+	if reason == nil || reason.Reason != trace.StopReasonUnreachable {
+		return nil
+	}
+	return printer.WriteTraceStopReason(w, reason)
+}
+
 func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, dataOrigin string) {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
@@ -213,10 +220,7 @@ func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		HopInterval: time.Duration(hopIntervalMs) * time.Millisecond,
 		MaxPerHop:   maxPerHop,
 		OnPathEnd: func(reason *trace.StopReason) {
-			if reason == nil || reason.Reason != trace.StopReasonUnreachable {
-				return
-			}
-			if err := printer.WriteTraceStopReason(os.Stderr, reason); err != nil {
+			if err := writeMTRRawPathEnd(os.Stderr, reason); err != nil {
 				writeMTRRawRuntimeError(os.Stderr, err)
 			}
 		},

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,6 +14,38 @@ import (
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
 )
+
+func TestWriteMTRRawPathEnd(t *testing.T) {
+	reason := &trace.StopReason{
+		Hop:       4,
+		Reason:    trace.StopReasonUnreachable,
+		Responses: []string{"ICMP Host Unreachable"},
+		Markers:   []string{"!H"},
+	}
+	var output bytes.Buffer
+	if err := writeMTRRawPathEnd(&output, reason); err != nil {
+		t.Fatalf("writeMTRRawPathEnd() error = %v", err)
+	}
+	for _, want := range []string{"No Continuing Route Observed", "ICMP Host Unreachable", "!H"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("output missing %q: %q", want, output.String())
+		}
+	}
+
+	for _, ignored := range []*trace.StopReason{
+		nil,
+		{Hop: 4, Reason: trace.StopReasonDestination},
+		{Hop: 30, Reason: trace.StopReasonMaxHops},
+	} {
+		output.Reset()
+		if err := writeMTRRawPathEnd(&output, ignored); err != nil {
+			t.Fatalf("writeMTRRawPathEnd(%v) error = %v", ignored, err)
+		}
+		if output.Len() != 0 {
+			t.Fatalf("writeMTRRawPathEnd(%v) output = %q, want empty", ignored, output.String())
+		}
+	}
+}
 
 func TestCheckMTRConflicts_NoConflict(t *testing.T) {
 	flags := map[string]bool{

--- a/fast_trace/fast_trace ipv6.go
+++ b/fast_trace/fast_trace ipv6.go
@@ -11,21 +11,21 @@ import (
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace"
-	"github.com/nxtrace/NTrace-core/util"
 )
 
 //var pFastTracer ParamsFastTrace
 
 func (f *FastTracer) tracert_v6(location string, ispCollection ISPCollection) {
-	fmt.Fprintf(color.Output, "%s\n", color.New(color.FgYellow, color.Bold).Sprintf("『%s %s 』", location, ispCollection.ISPName))
+	if _, err := fmt.Fprintf(color.Output, "%s\n", color.New(color.FgYellow, color.Bold).Sprintf("『%s %s 』", location, ispCollection.ISPName)); err != nil {
+		log.Printf("fast trace title write failed: %v", err)
+	}
 	displayPacketSize := f.ParamsFastTrace.PktSize
 	if !f.ParamsFastTrace.PacketSizeSet {
 		displayPacketSize = trace.DefaultPacketSize(f.TracerouteMethod, net.ParseIP(ispCollection.IPv6))
 	}
 	fmt.Printf("traceroute to %s, %d hops max, %s, %s mode\n", ispCollection.IPv6, f.ParamsFastTrace.MaxHops, trace.FormatPacketSizeLabel(displayPacketSize), strings.ToUpper(string(f.TracerouteMethod)))
 
-	// ip, err := util.DomainLookUp(ispCollection.IPv6, "6", "", true)
-	ip, err := util.DomainLookUpWithContext(f.ParamsFastTrace.Context, ispCollection.IPv6, "6", f.ParamsFastTrace.Dot, true)
+	ip, err := fastTraceDomainLookupFn(f.ParamsFastTrace.Context, ispCollection.IPv6, "6", f.ParamsFastTrace.Dot, true)
 	if shouldStopFastTrace(err) {
 		return
 	}
@@ -68,20 +68,17 @@ func (f *FastTracer) tracert_v6(location string, ispCollection ISPCollection) {
 
 	header := fmt.Sprintf("『%s %s 』\ntraceroute to %s, %d hops max, %s, %s mode\n",
 		location, ispCollection.ISPName, ispCollection.IPv6, f.ParamsFastTrace.MaxHops, trace.FormatPacketSizeLabel(displayPacketSize), strings.ToUpper(string(f.TracerouteMethod)))
-	cleanup, err := configureFastTraceRealtimePrinter(&conf, f.ParamsFastTrace.OutputPath, header)
+	outputPlan, err := configureFastTraceRealtimePrinter(&conf, f.ParamsFastTrace.OutputPath, header)
 	if err != nil {
 		return
 	}
-	if cleanup != nil {
-		defer func() {
-			if closeErr := cleanup(); closeErr != nil {
-				log.Println(closeErr)
-			}
-		}()
-	}
+	defer func() {
+		if closeErr := outputPlan.close(); closeErr != nil {
+			log.Println(closeErr)
+		}
+	}()
 
-	_, err = trace.Traceroute(f.TracerouteMethod, conf)
-	if shouldStopFastTrace(err) {
+	if !runFastTraceOnce(f.TracerouteMethod, conf, outputPlan) {
 		return
 	}
 

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -315,7 +315,12 @@ func configureFastTraceRealtimePrinter(conf *trace.Config, outputPath, header st
 		conf.RealtimePrinter = printer.RealtimePrinter
 		return plan, nil
 	}
-	conf.RealtimePrinter = tracelog.NewRealtimePrinter(io.MultiWriter(os.Stdout, fp))
+	conf.RealtimePrinter = func(res *trace.Result, ttl int) {
+		printer.RealtimePrinter(res, ttl)
+		if err := tracelog.WriteRealtime(fp, res, ttl); err != nil {
+			log.Printf("fast trace output write failed for %q: %v", outputPath, err)
+		}
+	}
 	plan.file = fp
 	return plan, nil
 }

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -27,6 +27,11 @@ type FastTracer struct {
 	ParamsFastTrace  ParamsFastTrace
 }
 
+var (
+	fastTraceTracerouteFn   = trace.Traceroute
+	fastTraceDomainLookupFn = util.DomainLookUpWithContext
+)
+
 type ParamsFastTrace struct {
 	Context         context.Context
 	OSType          int
@@ -216,8 +221,8 @@ func loadIPList(ctx context.Context, filePath string) []IpListElement {
 	return ipList
 }
 
-func printFileTraceHeader(ip IpListElement, params ParamsFastTrace, tracerouteMethod trace.Method) {
-	fmt.Fprintf(color.Output, "%s\n", color.New(color.FgYellow, color.Bold).Sprint("『 "+ip.Desc+"』"))
+func printFileTraceHeader(ip IpListElement, params ParamsFastTrace, tracerouteMethod trace.Method) error {
+	_, titleErr := fmt.Fprintf(color.Output, "%s\n", color.New(color.FgYellow, color.Bold).Sprint("『 "+ip.Desc+"』"))
 	dst := ip.Ip
 	if util.EnableHidDstIP {
 		dst = util.HideIPPart(ip.Ip)
@@ -227,6 +232,7 @@ func printFileTraceHeader(ip IpListElement, params ParamsFastTrace, tracerouteMe
 		displayPacketSize = trace.DefaultPacketSize(tracerouteMethod, net.ParseIP(ip.Ip))
 	}
 	fmt.Printf("traceroute to %s, %d hops max, %s, %s mode\n", dst, params.MaxHops, trace.FormatPacketSizeLabel(displayPacketSize), strings.ToUpper(string(tracerouteMethod)))
+	return titleErr
 }
 
 func buildFileTraceConfig(params ParamsFastTrace, tracerouteMethod trace.Method, ip IpListElement) (trace.Config, error) {
@@ -268,30 +274,71 @@ func normalizeFastTraceConfig(method trace.Method, conf trace.Config) (trace.Con
 	return trace.NormalizeExplicitSourceConfig(method, conf)
 }
 
-func configureFastTraceRealtimePrinter(conf *trace.Config, outputPath, header string) (func() error, error) {
+type fastTraceOutputPlan struct {
+	file io.WriteCloser
+}
+
+func (plan *fastTraceOutputPlan) printStopReason(reason *trace.StopReason) error {
+	terminalErr := printer.PrintTraceStopReason(reason)
+	var fileErr error
+	if plan != nil && plan.file != nil {
+		fileErr = printer.WriteTraceStopReason(plan.file, reason)
+	}
+	return errors.Join(terminalErr, fileErr)
+}
+
+func (plan *fastTraceOutputPlan) close() error {
+	if plan == nil || plan.file == nil {
+		return nil
+	}
+	return plan.file.Close()
+}
+
+func configureFastTraceRealtimePrinter(conf *trace.Config, outputPath, header string) (*fastTraceOutputPlan, error) {
+	plan := &fastTraceOutputPlan{}
 	if strings.TrimSpace(outputPath) == "" {
 		conf.RealtimePrinter = printer.RealtimePrinter
-		return nil, nil
+		return plan, nil
 	}
 
 	fp, err := tracelog.OpenFile(outputPath)
 	if err != nil {
 		log.Printf("fast trace output open failed for %q: %v; falling back to stdout", outputPath, err)
 		conf.RealtimePrinter = printer.RealtimePrinter
-		return nil, nil
+		return plan, nil
 	}
 	if err := tracelog.WriteHeader(fp, header); err != nil {
-		_ = fp.Close()
+		if closeErr := fp.Close(); closeErr != nil {
+			log.Printf("fast trace output close failed for %q: %v", outputPath, closeErr)
+		}
 		log.Printf("fast trace output header write failed for %q: %v; falling back to stdout", outputPath, err)
 		conf.RealtimePrinter = printer.RealtimePrinter
-		return nil, nil
+		return plan, nil
 	}
 	conf.RealtimePrinter = tracelog.NewRealtimePrinter(io.MultiWriter(os.Stdout, fp))
-	return fp.Close, nil
+	plan.file = fp
+	return plan, nil
+}
+
+func runFastTraceOnce(method trace.Method, conf trace.Config, outputPlan *fastTraceOutputPlan) bool {
+	res, err := fastTraceTracerouteFn(method, conf)
+	if shouldStopFastTrace(err) {
+		return false
+	}
+	if res == nil {
+		log.Println("fast trace returned no result")
+		return false
+	}
+	if err := outputPlan.printStopReason(res.StopReason); err != nil {
+		log.Printf("fast trace stop reason write failed: %v", err)
+	}
+	return true
 }
 
 func runFileTraceTarget(params ParamsFastTrace, tracerouteMethod trace.Method, ip IpListElement) {
-	printFileTraceHeader(ip, params, tracerouteMethod)
+	if err := printFileTraceHeader(ip, params, tracerouteMethod); err != nil {
+		log.Printf("fast trace title write failed: %v", err)
+	}
 
 	conf, err := buildFileTraceConfig(params, tracerouteMethod, ip)
 	if shouldStopFastTrace(err) {
@@ -306,27 +353,27 @@ func runFileTraceTarget(params ParamsFastTrace, tracerouteMethod trace.Method, i
 		displayPacketSize = trace.DefaultPacketSize(tracerouteMethod, net.ParseIP(ip.Ip))
 	}
 	header := fmt.Sprintf("『%s』\ntraceroute to %s, %d hops max, %s, %s mode\n", ip.Desc, ip.Ip, params.MaxHops, trace.FormatPacketSizeLabel(displayPacketSize), strings.ToUpper(string(tracerouteMethod)))
-	cleanup, err := configureFastTraceRealtimePrinter(&conf, params.OutputPath, header)
+	outputPlan, err := configureFastTraceRealtimePrinter(&conf, params.OutputPath, header)
 	if err != nil {
 		log.Println(err)
 		return
 	}
-	if cleanup != nil {
-		defer func() {
-			if closeErr := cleanup(); closeErr != nil {
-				log.Println(closeErr)
-			}
-		}()
-	}
+	defer func() {
+		if closeErr := outputPlan.close(); closeErr != nil {
+			log.Println(closeErr)
+		}
+	}()
 
-	if _, err := trace.Traceroute(tracerouteMethod, conf); shouldStopFastTrace(err) {
+	if !runFastTraceOnce(tracerouteMethod, conf, outputPlan) {
 		return
 	}
 	fmt.Println()
 }
 
 func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
-	fmt.Fprintf(color.Output, "%s\n", color.New(color.FgYellow, color.Bold).Sprintf("『%s %s 』", location, ispCollection.ISPName))
+	if _, err := fmt.Fprintf(color.Output, "%s\n", color.New(color.FgYellow, color.Bold).Sprintf("『%s %s 』", location, ispCollection.ISPName)); err != nil {
+		log.Printf("fast trace title write failed: %v", err)
+	}
 	displayPacketSize := f.ParamsFastTrace.PktSize
 	if !f.ParamsFastTrace.PacketSizeSet {
 		displayPacketSize = trace.DefaultPacketSize(f.TracerouteMethod, net.ParseIP(ispCollection.IP))
@@ -334,7 +381,7 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 	fmt.Printf("traceroute to %s, %d hops max, %s, %s mode\n", ispCollection.IP, f.ParamsFastTrace.MaxHops, trace.FormatPacketSizeLabel(displayPacketSize), strings.ToUpper(string(f.TracerouteMethod)))
 
 	// ip, err := util.DomainLookUp(ispCollection.IP, "4", "", true)
-	ip, err := util.DomainLookUpWithContext(f.ParamsFastTrace.Context, ispCollection.IP, "4", f.ParamsFastTrace.Dot, true)
+	ip, err := fastTraceDomainLookupFn(f.ParamsFastTrace.Context, ispCollection.IP, "4", f.ParamsFastTrace.Dot, true)
 	if shouldStopFastTrace(err) {
 		return
 	}
@@ -377,22 +424,18 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 
 	header := fmt.Sprintf("『%s %s 』\ntraceroute to %s, %d hops max, %s, %s mode\n",
 		location, ispCollection.ISPName, ispCollection.IP, f.ParamsFastTrace.MaxHops, trace.FormatPacketSizeLabel(displayPacketSize), strings.ToUpper(string(f.TracerouteMethod)))
-	cleanup, err := configureFastTraceRealtimePrinter(&conf, f.ParamsFastTrace.OutputPath, header)
+	outputPlan, err := configureFastTraceRealtimePrinter(&conf, f.ParamsFastTrace.OutputPath, header)
 	if err != nil {
 		log.Println(err)
 		return
 	}
-	if cleanup != nil {
-		defer func() {
-			if closeErr := cleanup(); closeErr != nil {
-				log.Println(closeErr)
-			}
-		}()
-	}
+	defer func() {
+		if closeErr := outputPlan.close(); closeErr != nil {
+			log.Println(closeErr)
+		}
+	}()
 
-	_, err = trace.Traceroute(f.TracerouteMethod, conf)
-
-	if shouldStopFastTrace(err) {
+	if !runFastTraceOnce(f.TracerouteMethod, conf, outputPlan) {
 		return
 	}
 	fmt.Println()

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -89,6 +89,8 @@ func TestReadFastTestv6ChoiceCanceledContext(t *testing.T) {
 }
 
 func TestFastTraceStopReasonReachesTerminalAndOutputFile(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm-256color")
 	previousTraceroute := fastTraceTracerouteFn
 	previousLookup := fastTraceDomainLookupFn
 	previousOutput := color.Output
@@ -133,15 +135,19 @@ func TestFastTraceStopReasonReachesTerminalAndOutputFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var terminal bytes.Buffer
+			var styledHop bool
 			var calls int
 			fastTraceTracerouteFn = func(_ trace.Method, conf trace.Config) (*trace.Result, error) {
 				calls++
 				if conf.RealtimePrinter == nil {
 					t.Fatal("RealtimePrinter = nil, want configured output printer")
 				}
+				before := terminal.Len()
+				conf.RealtimePrinter(&trace.Result{Hops: [][]trace.Hop{{}}}, 0)
+				styledHop = strings.Contains(terminal.String()[before:], "\x1b[")
 				return &trace.Result{StopReason: reason}, nil
 			}
-			var terminal bytes.Buffer
 			color.Output = &terminal
 			color.NoColor = false
 			outputPath := filepath.Join(t.TempDir(), "trace.log")
@@ -150,6 +156,9 @@ func TestFastTraceStopReasonReachesTerminalAndOutputFile(t *testing.T) {
 
 			if calls != 1 {
 				t.Fatalf("Traceroute calls = %d, want 1", calls)
+			}
+			if !styledHop {
+				t.Fatalf("terminal hop output is not styled: %q", terminal.String())
 			}
 			if got := strings.Count(terminal.String(), "Trace Stopped:"); got != 1 {
 				t.Fatalf("terminal stop reason count = %d, want 1; output=%q", got, terminal.String())
@@ -222,6 +231,69 @@ func TestFastTraceNilResultDoesNotPanicOrWriteStopReason(t *testing.T) {
 
 	if strings.Contains(terminal.String(), "Trace Stopped:") {
 		t.Fatalf("terminal contains misleading stop reason: %q", terminal.String())
+	}
+}
+
+func TestFileTraceWritesStopReasonForEveryTarget(t *testing.T) {
+	previousTraceroute := fastTraceTracerouteFn
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	t.Cleanup(func() {
+		fastTraceTracerouteFn = previousTraceroute
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	})
+
+	reasons := []*trace.StopReason{
+		{Hop: 2, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}},
+		{Hop: 4, Reason: trace.StopReasonUnreachable, Responses: []string{"ICMP Host Unreachable"}, Markers: []string{"!H"}},
+	}
+	var calls int
+	fastTraceTracerouteFn = func(trace.Method, trace.Config) (*trace.Result, error) {
+		if calls >= len(reasons) {
+			t.Fatalf("unexpected traceroute call %d", calls+1)
+		}
+		reason := reasons[calls]
+		calls++
+		return &trace.Result{StopReason: reason}, nil
+	}
+
+	dir := t.TempDir()
+	targetsPath := filepath.Join(dir, "targets.txt")
+	if err := os.WriteFile(targetsPath, []byte("192.0.2.1 first\n2001:db8::1 second\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile targets: %v", err)
+	}
+	outputPath := filepath.Join(dir, "trace.log")
+	var terminal bytes.Buffer
+	color.Output = &terminal
+	color.NoColor = true
+
+	testFile(ParamsFastTrace{
+		Context:         context.Background(),
+		File:            targetsPath,
+		MaxHops:         30,
+		Timeout:         time.Second,
+		OutputPath:      outputPath,
+		RuntimePrepared: true,
+	}, trace.ICMPTrace)
+
+	if calls != len(reasons) {
+		t.Fatalf("Traceroute calls = %d, want %d", calls, len(reasons))
+	}
+	if got := strings.Count(terminal.String(), "Trace Stopped:"); got != len(reasons) {
+		t.Fatalf("terminal stop reason count = %d, want %d; output=%q", got, len(reasons), terminal.String())
+	}
+	fileOutput, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile output: %v", err)
+	}
+	if got := strings.Count(string(fileOutput), "Trace Stopped:"); got != len(reasons) {
+		t.Fatalf("file stop reason count = %d, want %d; output=%q", got, len(reasons), fileOutput)
+	}
+	first := strings.Index(string(fileOutput), "Destination Reached at Hop 2")
+	second := strings.Index(string(fileOutput), "No Continuing Route Observed at Hop 4")
+	if first < 0 || second < 0 || first >= second {
+		t.Fatalf("file stop reasons out of order: %q", fileOutput)
 	}
 }
 

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -1,11 +1,17 @@
 package fastTrace
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/fatih/color"
 
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
@@ -79,6 +85,152 @@ func TestReadFastTestv6ChoiceCanceledContext(t *testing.T) {
 	}
 	if choice != "" {
 		t.Fatalf("readFastTestv6Choice choice = %q, want empty", choice)
+	}
+}
+
+func TestFastTraceStopReasonReachesTerminalAndOutputFile(t *testing.T) {
+	previousTraceroute := fastTraceTracerouteFn
+	previousLookup := fastTraceDomainLookupFn
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	t.Cleanup(func() {
+		fastTraceTracerouteFn = previousTraceroute
+		fastTraceDomainLookupFn = previousLookup
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	})
+
+	fastTraceDomainLookupFn = func(_ context.Context, host, _, _ string, _ bool) (net.IP, error) {
+		return net.ParseIP(host), nil
+	}
+	reason := &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}}
+
+	tests := []struct {
+		name string
+		run  func(outputPath string)
+	}{
+		{
+			name: "file target",
+			run: func(outputPath string) {
+				runFileTraceTarget(fastTraceTestParams(outputPath), trace.ICMPTrace, IpListElement{Ip: "192.0.2.1", Desc: "file target", Version4: true})
+			},
+		},
+		{
+			name: "IPv4 interactive target",
+			run: func(outputPath string) {
+				f := FastTracer{TracerouteMethod: trace.ICMPTrace, ParamsFastTrace: fastTraceTestParams(outputPath)}
+				f.tracert("test", ISPCollection{ISPName: "ISP", IP: "192.0.2.1"})
+			},
+		},
+		{
+			name: "IPv6 interactive target",
+			run: func(outputPath string) {
+				f := FastTracer{TracerouteMethod: trace.ICMPTrace, ParamsFastTrace: fastTraceTestParams(outputPath)}
+				f.tracert_v6("test", ISPCollection{ISPName: "ISP", IPv6: "2001:db8::1"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			fastTraceTracerouteFn = func(_ trace.Method, conf trace.Config) (*trace.Result, error) {
+				calls++
+				if conf.RealtimePrinter == nil {
+					t.Fatal("RealtimePrinter = nil, want configured output printer")
+				}
+				return &trace.Result{StopReason: reason}, nil
+			}
+			var terminal bytes.Buffer
+			color.Output = &terminal
+			color.NoColor = false
+			outputPath := filepath.Join(t.TempDir(), "trace.log")
+
+			tt.run(outputPath)
+
+			if calls != 1 {
+				t.Fatalf("Traceroute calls = %d, want 1", calls)
+			}
+			if got := strings.Count(terminal.String(), "Trace Stopped:"); got != 1 {
+				t.Fatalf("terminal stop reason count = %d, want 1; output=%q", got, terminal.String())
+			}
+			fileOutput, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatalf("ReadFile output: %v", err)
+			}
+			if got := strings.Count(string(fileOutput), "Trace Stopped:"); got != 1 {
+				t.Fatalf("file stop reason count = %d, want 1; output=%q", got, fileOutput)
+			}
+			if bytes.Contains(fileOutput, []byte("\x1b[")) {
+				t.Fatalf("file contains ANSI escapes: %q", fileOutput)
+			}
+		})
+	}
+}
+
+func TestFastTraceTracerErrorDoesNotWriteStopReason(t *testing.T) {
+	previousTraceroute := fastTraceTracerouteFn
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	t.Cleanup(func() {
+		fastTraceTracerouteFn = previousTraceroute
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	})
+
+	fastTraceTracerouteFn = func(trace.Method, trace.Config) (*trace.Result, error) {
+		return nil, errors.New("probe failed")
+	}
+	var terminal bytes.Buffer
+	color.Output = &terminal
+	color.NoColor = true
+	outputPath := filepath.Join(t.TempDir(), "trace.log")
+
+	runFileTraceTarget(fastTraceTestParams(outputPath), trace.ICMPTrace, IpListElement{Ip: "192.0.2.1", Desc: "file target", Version4: true})
+
+	if strings.Contains(terminal.String(), "Trace Stopped:") {
+		t.Fatalf("terminal contains misleading stop reason: %q", terminal.String())
+	}
+	fileOutput, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile output: %v", err)
+	}
+	if strings.Contains(string(fileOutput), "Trace Stopped:") {
+		t.Fatalf("file contains misleading stop reason: %q", fileOutput)
+	}
+}
+
+func TestFastTraceNilResultDoesNotPanicOrWriteStopReason(t *testing.T) {
+	previousTraceroute := fastTraceTracerouteFn
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	t.Cleanup(func() {
+		fastTraceTracerouteFn = previousTraceroute
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	})
+
+	fastTraceTracerouteFn = func(trace.Method, trace.Config) (*trace.Result, error) {
+		return nil, nil
+	}
+	var terminal bytes.Buffer
+	color.Output = &terminal
+	color.NoColor = true
+	outputPath := filepath.Join(t.TempDir(), "trace.log")
+
+	runFileTraceTarget(fastTraceTestParams(outputPath), trace.ICMPTrace, IpListElement{Ip: "192.0.2.1", Desc: "file target", Version4: true})
+
+	if strings.Contains(terminal.String(), "Trace Stopped:") {
+		t.Fatalf("terminal contains misleading stop reason: %q", terminal.String())
+	}
+}
+
+func fastTraceTestParams(outputPath string) ParamsFastTrace {
+	return ParamsFastTrace{
+		Context:    context.Background(),
+		MaxHops:    30,
+		Timeout:    time.Second,
+		OutputPath: outputPath,
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -124,6 +124,7 @@ func (s *Service) Traceroute(ctx context.Context, req TraceRequest) (TraceRespon
 		Hops:         convertTraceHops(res, setup.Config.Lang),
 		DurationMs:   durationMs(start),
 		Parameters:   traceParameterBoundaries(),
+		StopReason:   NewTraceStopReason(res.StopReason),
 	}, nil
 }
 
@@ -139,12 +140,16 @@ func (s *Service) MTRReport(ctx context.Context, req MTRReportRequest) (MTRRepor
 	hopInterval := positiveOrDefault(req.HopIntervalMs, defaultMTRHopIntervalMs)
 	maxPerHop := positiveOrDefault(req.MaxPerHop, 10)
 	var latest []trace.MTRHopStat
+	var pathEnd *TraceStopReason
 	err = withTraceRuntimeNoResult(ctx, setup, func() error {
 		return runMTRFn(ctx, setup.Method, setup.Config, trace.MTROptions{
 			HopInterval: time.Duration(hopInterval) * time.Millisecond,
 			MaxPerHop:   maxPerHop,
+			OnPathEnd: func(reason *trace.StopReason) {
+				pathEnd = NewTraceStopReason(reason)
+			},
 		}, func(_ int, stats []trace.MTRHopStat) {
-			latest = cloneMTRStats(stats)
+			latest = cloneMTRStats(stats, setup.Config.Lang)
 		})
 	})
 	if err != nil {
@@ -158,6 +163,7 @@ func (s *Service) MTRReport(ctx context.Context, req MTRReportRequest) (MTRRepor
 		Stats:      latest,
 		DurationMs: durationMs(start),
 		Parameters: mtrReportParameterBoundaries(),
+		PathEnd:    pathEnd,
 	}, nil
 }
 
@@ -183,10 +189,14 @@ func (s *Service) MTRRaw(ctx context.Context, req MTRRawRequest) (MTRRawResponse
 	}
 
 	var records []trace.MTRRawRecord
+	var pathEnd *TraceStopReason
 	err = withTraceRuntimeNoResult(runCtx, setup, func() error {
 		return runMTRRawFn(runCtx, setup.Method, setup.Config, trace.MTRRawOptions{
 			HopInterval: time.Duration(hopInterval) * time.Millisecond,
 			MaxPerHop:   maxPerHop,
+			OnPathEnd: func(reason *trace.StopReason) {
+				pathEnd = NewTraceStopReason(reason)
+			},
 		}, func(rec trace.MTRRawRecord) {
 			records = append(records, rec)
 		})
@@ -213,6 +223,7 @@ func (s *Service) MTRRaw(ctx context.Context, req MTRRawRequest) (MTRRawResponse
 		DurationMs: durationMs(start),
 		Warnings:   warnings,
 		Parameters: mtrRawParameterBoundaries(),
+		PathEnd:    pathEnd,
 	}, nil
 }
 
@@ -642,12 +653,19 @@ func convertTraceHops(res *trace.Result, lang string) []Hop {
 	return hops
 }
 
-func cloneMTRStats(stats []trace.MTRHopStat) []trace.MTRHopStat {
+func cloneMTRStats(stats []trace.MTRHopStat, lang string) []trace.MTRHopStat {
 	if len(stats) == 0 {
 		return nil
 	}
 	out := make([]trace.MTRHopStat, len(stats))
 	copy(out, stats)
+	for i := range out {
+		out[i].Geo = localizeGeo(stats[i].Geo, lang)
+		if stats[i].Response != nil {
+			response := *stats[i].Response
+			out[i].Response = &response
+		}
+	}
 	return out
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -127,17 +127,42 @@ func TestMTRRawAllowsLocalDurationTimeout(t *testing.T) {
 	if len(resp.Records) != 1 || resp.Records[0].IP != "192.0.2.1" {
 		t.Fatalf("MTRRaw records = %+v, want one preserved record", resp.Records)
 	}
+	if resp.PathEnd != nil {
+		t.Fatalf("local duration timeout fabricated path_end = %#v", resp.PathEnd)
+	}
+}
+
+func TestMTRRawLocalDurationTimeoutPreservesSemanticPathEnd(t *testing.T) {
+	restore := stubServiceRuntimeForTests(t)
+	defer restore()
+
+	runMTRRawFn = func(_ context.Context, _ trace.Method, _ trace.Config, opts trace.MTRRawOptions, _ trace.MTRRawOnRecord) error {
+		opts.OnPathEnd(&trace.StopReason{Hop: 2, Reason: trace.StopReasonUnreachable, Markers: []string{"!H"}})
+		return context.DeadlineExceeded
+	}
+	resp, err := New().MTRRaw(context.Background(), MTRRawRequest{
+		TraceRequest: TraceRequest{Target: "192.0.2.1", DataProvider: "disable-geoip"},
+		DurationMs:   1,
+	})
+	if err != nil {
+		t.Fatalf("MTRRaw returned error: %v", err)
+	}
+	if resp.PathEnd == nil || resp.PathEnd.Hop != 2 || resp.PathEnd.Reason != trace.StopReasonUnreachable || len(resp.PathEnd.Markers) != 1 || resp.PathEnd.Markers[0] != "!H" {
+		t.Fatalf("duration timeout path_end = %#v, want unreachable !H", resp.PathEnd)
+	}
 }
 
 func TestMTRResponsesUseMTRParameterBoundaries(t *testing.T) {
 	restore := stubServiceRuntimeForTests(t)
 	defer restore()
 
-	runMTRFn = func(_ context.Context, _ trace.Method, _ trace.Config, _ trace.MTROptions, onUpdate trace.MTROnSnapshot) error {
-		onUpdate(1, []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1"}})
+	runMTRFn = func(_ context.Context, _ trace.Method, _ trace.Config, opts trace.MTROptions, onUpdate trace.MTROnSnapshot) error {
+		opts.OnPathEnd(&trace.StopReason{Hop: 1, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}})
+		onUpdate(1, []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1", Geo: &ipgeo.IPGeoData{}}})
 		return nil
 	}
-	runMTRRawFn = func(_ context.Context, _ trace.Method, _ trace.Config, _ trace.MTRRawOptions, onRecord trace.MTRRawOnRecord) error {
+	runMTRRawFn = func(_ context.Context, _ trace.Method, _ trace.Config, opts trace.MTRRawOptions, onRecord trace.MTRRawOnRecord) error {
+		opts.OnPathEnd(&trace.StopReason{Hop: 1, Reason: trace.StopReasonUnreachable, Markers: []string{"!H"}})
 		onRecord(trace.MTRRawRecord{TTL: 1, Success: true, IP: "192.0.2.1"})
 		return nil
 	}
@@ -149,6 +174,12 @@ func TestMTRResponsesUseMTRParameterBoundaries(t *testing.T) {
 		t.Fatalf("MTRReport returned error: %v", err)
 	}
 	assertMTRBoundaries(t, "report", report.Parameters, false)
+	if report.PathEnd == nil || report.PathEnd.Reason != trace.StopReasonDestination {
+		t.Fatalf("report path_end = %#v, want destination", report.PathEnd)
+	}
+	if len(report.Stats) != 1 || report.Stats[0].Geo == nil || report.Stats[0].Geo.Router == nil {
+		t.Fatalf("report geo = %#v, want schema-safe non-nil router", report.Stats)
+	}
 
 	raw, err := New().MTRRaw(context.Background(), MTRRawRequest{
 		TraceRequest: TraceRequest{Target: "192.0.2.1", DataProvider: "disable-geoip"},
@@ -158,6 +189,24 @@ func TestMTRResponsesUseMTRParameterBoundaries(t *testing.T) {
 		t.Fatalf("MTRRaw returned error: %v", err)
 	}
 	assertMTRBoundaries(t, "raw", raw.Parameters, true)
+	if raw.PathEnd == nil || raw.PathEnd.Reason != trace.StopReasonUnreachable || len(raw.PathEnd.Markers) != 1 || raw.PathEnd.Markers[0] != "!H" {
+		t.Fatalf("raw path_end = %#v, want unreachable !H", raw.PathEnd)
+	}
+}
+
+func TestNewTraceStopReasonCopiesStableFields(t *testing.T) {
+	core := &trace.StopReason{
+		Hop:       7,
+		Reason:    trace.StopReasonUnreachable,
+		Responses: []string{"ICMP Host Unreachable"},
+		Markers:   []string{"!H"},
+	}
+	got := NewTraceStopReason(core)
+	core.Responses[0] = "mutated"
+	core.Markers[0] = "mutated"
+	if got == nil || got.Hop != 7 || got.Reason != trace.StopReasonUnreachable || got.Responses[0] != "ICMP Host Unreachable" || got.Markers[0] != "!H" {
+		t.Fatalf("NewTraceStopReason() = %#v", got)
+	}
 }
 
 func TestMTUTraceInitializesDefaultLeoMoeRuntime(t *testing.T) {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -32,6 +32,26 @@ type Hop struct {
 	Attempts []Attempt `json:"attempts"`
 }
 
+// TraceStopReason is the stable snake_case API representation of a trace edge.
+type TraceStopReason struct {
+	Hop       int      `json:"hop"`
+	Reason    string   `json:"reason"`
+	Responses []string `json:"responses,omitempty"`
+	Markers   []string `json:"markers,omitempty"`
+}
+
+func NewTraceStopReason(reason *trace.StopReason) *TraceStopReason {
+	if reason == nil {
+		return nil
+	}
+	return &TraceStopReason{
+		Hop:       reason.Hop,
+		Reason:    reason.Reason,
+		Responses: append([]string(nil), reason.Responses...),
+		Markers:   append([]string(nil), reason.Markers...),
+	}
+}
+
 type TraceRequest struct {
 	Target           string `json:"target" jsonschema:"Target domain, IP, or URL host to trace"`
 	Protocol         string `json:"protocol,omitempty" jsonschema:"Probe protocol: icmp, tcp, or udp"`
@@ -72,6 +92,7 @@ type TraceResponse struct {
 	Hops         []Hop               `json:"hops"`
 	DurationMs   int64               `json:"duration_ms"`
 	Parameters   ParameterBoundaries `json:"parameters"`
+	StopReason   *TraceStopReason    `json:"stop_reason,omitempty"`
 }
 
 type MTRReportRequest struct {
@@ -94,6 +115,7 @@ type MTRReportResponse struct {
 	Stats      []trace.MTRHopStat  `json:"stats"`
 	DurationMs int64               `json:"duration_ms"`
 	Parameters ParameterBoundaries `json:"parameters"`
+	PathEnd    *TraceStopReason    `json:"path_end,omitempty"`
 }
 
 type MTRRawResponse struct {
@@ -104,6 +126,7 @@ type MTRRawResponse struct {
 	DurationMs int64                `json:"duration_ms"`
 	Warnings   []string             `json:"warnings,omitempty"`
 	Parameters ParameterBoundaries  `json:"parameters"`
+	PathEnd    *TraceStopReason     `json:"path_end,omitempty"`
 }
 
 type MTUTraceRequest struct {

--- a/printer/mtr_table.go
+++ b/printer/mtr_table.go
@@ -336,7 +336,7 @@ func formatReportHost(s trace.MTRHopStat, mode int, nameMode int, lang string, s
 	if len(s.MPLS) > 0 {
 		host += " " + strings.Join(s.MPLS, " ")
 	}
-	return host
+	return appendMTRResponseMarker(host, s)
 }
 
 // formatCompactReportHost 构建非 wide report 的精简 Host 文本。
@@ -349,7 +349,14 @@ func formatCompactReportHost(s trace.MTRHopStat, nameMode int, showIPs bool) str
 	if isWaitingHopStat(s) {
 		return "(waiting for reply)"
 	}
-	return formatMTRHostBase(s, nameMode, showIPs)
+	return appendMTRResponseMarker(formatMTRHostBase(s, nameMode, showIPs), s)
+}
+
+func appendMTRResponseMarker(host string, stat trace.MTRHopStat) string {
+	if stat.Response == nil || stat.Response.Kind != trace.MTRResponseUnreachable || stat.Response.Marker == "" {
+		return host
+	}
+	return host + " " + stat.Response.Marker
 }
 
 // formatMTRGeoData 返回简短 geo 描述（向后兼容，等效于英文 HostModeFull geo 部分）。

--- a/printer/mtr_table.go
+++ b/printer/mtr_table.go
@@ -353,10 +353,30 @@ func formatCompactReportHost(s trace.MTRHopStat, nameMode int, showIPs bool) str
 }
 
 func appendMTRResponseMarker(host string, stat trace.MTRHopStat) string {
-	if stat.Response == nil || stat.Response.Kind != trace.MTRResponseUnreachable || stat.Response.Marker == "" {
+	marker := mtrResponseMarker(stat)
+	if marker == "" {
 		return host
 	}
-	return host + " " + stat.Response.Marker
+	return host + " " + marker
+}
+
+func mtrResponseMarker(stat trace.MTRHopStat) string {
+	if stat.Response == nil || stat.Response.Kind != trace.MTRResponseUnreachable {
+		return ""
+	}
+	return stat.Response.Marker
+}
+
+func fitMTRHostWithMarker(host, marker string, width int) string {
+	if marker == "" {
+		return fitLeft(host, width)
+	}
+	markerW := displayWidth(marker)
+	if width <= markerW {
+		return fitLeft(marker, width)
+	}
+	hostW := width - markerW - 1
+	return fitLeft(host, hostW) + " " + marker
 }
 
 // formatMTRGeoData 返回简短 geo 描述（向后兼容，等效于英文 HostModeFull geo 部分）。
@@ -539,7 +559,7 @@ func prepareMTRReportHosts(stats []trace.MTRHopStat, opts MTRReportOptions, lang
 		return hosts, computeWideMTRReportHostWidth(hosts, opts.SrcHost)
 	}
 	hostColW := narrowMTRReportHostWidth()
-	truncateMTRReportHosts(hosts, hostColW)
+	truncateMTRReportHosts(hosts, stats, hostColW)
 	return hosts, hostColW
 }
 
@@ -575,11 +595,20 @@ func narrowMTRReportHostWidth() int {
 	}
 }
 
-func truncateMTRReportHosts(hosts []string, hostColW int) {
+func truncateMTRReportHosts(hosts []string, stats []trace.MTRHopStat, hostColW int) {
 	for i, h := range hosts {
-		if reportDisplayWidth(h) > hostColW {
-			hosts[i] = reportTruncateToWidth(h, hostColW)
+		marker := mtrResponseMarker(stats[i])
+		if marker != "" {
+			h = strings.TrimSuffix(h, " "+marker)
+			markerW := reportDisplayWidth(marker)
+			if hostColW <= markerW {
+				hosts[i] = reportTruncateToWidth(marker, hostColW)
+				continue
+			}
+			hosts[i] = reportTruncateToWidth(h, hostColW-markerW-1) + " " + marker
+			continue
 		}
+		hosts[i] = reportTruncateToWidth(h, hostColW)
 	}
 }
 

--- a/printer/mtr_table_test.go
+++ b/printer/mtr_table_test.go
@@ -2171,6 +2171,57 @@ func TestMTRHumanHostsShowOnlyUnreachableMarker(t *testing.T) {
 	}
 }
 
+func TestMTRHumanHostsKeepUnreachableMarkerWhenTruncated(t *testing.T) {
+	originalNoColor := color.NoColor
+	t.Cleanup(func() { color.NoColor = originalNoColor })
+	color.NoColor = true
+
+	stat := trace.MTRHopStat{
+		TTL:      1,
+		Host:     strings.Repeat("long-router-name-", 8),
+		IP:       "192.0.2.1",
+		Snt:      1,
+		Received: 1,
+		Response: &trace.MTRProbeResponse{Kind: trace.MTRResponseUnreachable, Marker: "!H"},
+	}
+
+	t.Run("default TUI", func(t *testing.T) {
+		output := mtrTUIRenderStringWithWidth(MTRTUIHeader{Target: "example.com"}, []trace.MTRHopStat{stat}, 80)
+		if !strings.Contains(output, "!H") {
+			t.Fatalf("truncated TUI host lost unreachable marker:\n%s", output)
+		}
+		if strings.Contains(output, stat.Host) {
+			t.Fatalf("test host was not truncated:\n%s", output)
+		}
+	})
+
+	t.Run("history TUI", func(t *testing.T) {
+		output := mtrTUIRenderStringWithWidth(MTRTUIHeader{
+			Target:      "example.com",
+			HistoryMode: true,
+		}, []trace.MTRHopStat{stat}, 64)
+		if !strings.Contains(output, "!H") {
+			t.Fatalf("truncated history host lost unreachable marker:\n%s", output)
+		}
+		if strings.Contains(output, stat.Host) {
+			t.Fatalf("test host was not truncated:\n%s", output)
+		}
+	})
+
+	t.Run("non-wide report", func(t *testing.T) {
+		hosts, width := prepareMTRReportHosts([]trace.MTRHopStat{stat}, MTRReportOptions{}, "en")
+		if !strings.Contains(hosts[0], "!H") {
+			t.Fatalf("truncated report host lost unreachable marker: %q", hosts[0])
+		}
+		if reportDisplayWidth(hosts[0]) > width {
+			t.Fatalf("report host width = %d, want <= %d: %q", reportDisplayWidth(hosts[0]), width, hosts[0])
+		}
+		if strings.Contains(hosts[0], stat.Host) {
+			t.Fatalf("test host was not truncated: %q", hosts[0])
+		}
+	})
+}
+
 func TestFormatMTRRawLineIgnoresStructuredResponse(t *testing.T) {
 	rec := trace.MTRRawRecord{
 		TTL:      4,

--- a/printer/mtr_table_test.go
+++ b/printer/mtr_table_test.go
@@ -2152,6 +2152,41 @@ func TestFormatMTRRawLine_TimeoutFixedColumns(t *testing.T) {
 	}
 }
 
+func TestMTRHumanHostsShowOnlyUnreachableMarker(t *testing.T) {
+	unreachable := trace.MTRHopStat{
+		TTL: 3,
+		IP:  "192.0.2.3",
+		Response: &trace.MTRProbeResponse{
+			Kind:   trace.MTRResponseUnreachable,
+			Marker: "!H",
+		},
+	}
+	if got := formatReportHost(unreachable, HostModeBase, HostNameIPOnly, "en", false); got != "192.0.2.3 !H" {
+		t.Fatalf("formatReportHost() = %q", got)
+	}
+	if got := appendMTRResponseMarker("192.0.2.3", trace.MTRHopStat{
+		Response: &trace.MTRProbeResponse{Kind: trace.MTRResponseDestination, Marker: "!H"},
+	}); got != "192.0.2.3" {
+		t.Fatalf("destination marker unexpectedly shown: %q", got)
+	}
+}
+
+func TestFormatMTRRawLineIgnoresStructuredResponse(t *testing.T) {
+	rec := trace.MTRRawRecord{
+		TTL:      4,
+		Success:  true,
+		IP:       "192.0.2.4",
+		Response: &trace.MTRProbeResponse{Kind: trace.MTRResponseUnreachable, Marker: "!H"},
+	}
+	line := FormatMTRRawLine(rec)
+	if got := strings.Count(line, "|"); got != 11 {
+		t.Fatalf("structured response changed raw 12-column contract: %q", line)
+	}
+	if strings.Contains(line, "!H") || strings.Contains(line, "unreachable") {
+		t.Fatalf("structured response leaked into raw columns: %q", line)
+	}
+}
+
 func TestMTRTUI_PacketsColorByLoss(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -586,7 +586,7 @@ func renderMTRTUIRows(b *strings.Builder, header MTRTUIHeader, stats []trace.MTR
 	for i, s := range stats {
 		hopPrefix := formatTUIHopPrefix(s.TTL, prevTTL, lo.prefixW)
 		prevTTL = s.TTL
-		renderDataRow(b, lo, hopPrefix, appendMTRResponseMarker(formatTUIHost(allParts[i], asnW), s), s)
+		renderDataRow(b, lo, hopPrefix, formatTUIHost(allParts[i], asnW), s)
 		renderMTRTUIMPLSRows(b, lo, s.MPLS, header.DisableMPLS)
 	}
 }
@@ -703,6 +703,10 @@ func centerIn(s string, width int) string {
 // 左侧为 prefix+hostText（含 tab），填充到 metricsStart 后拼接指标列，
 // 保证右侧指标列始终键齐。
 func renderDataRow(b *strings.Builder, lo mtrTUILayout, hopPrefix, host string, s trace.MTRHopStat) {
+	marker := mtrResponseMarker(s)
+	if marker != "" {
+		host = fitMTRHostWithMarker(host, marker, lo.metricsStart-1-displayWidthWithTabs(hopPrefix, tuiTabStop))
+	}
 	left := hopPrefix + host
 	leftW := displayWidthWithTabs(left, tuiTabStop)
 
@@ -872,7 +876,7 @@ func renderMTRTUIHistoryRows(b *strings.Builder, header MTRTUIHeader, stats []tr
 	for i, s := range stats {
 		hopPrefix := formatTUIHopPrefix(s.TTL, prevTTL, lo.prefixW)
 		prevTTL = s.TTL
-		host := appendMTRResponseMarker(formatTUIHost(allParts[i], asnW), s)
+		host := formatTUIHost(allParts[i], asnW)
 		renderMTRTUIHistoryRow(b, header, lo, hopPrefix, host, s, history[s.TTL], now)
 	}
 }
@@ -900,7 +904,7 @@ func renderMTRTUIHistoryRow(
 	if waiting {
 		hostSty = mtrTUIWaitColor
 	}
-	row := mtrTUIHopColor(hopPrefix) + hostSty(fitLeft(host, lo.hostW))
+	row := mtrTUIHopColor(hopPrefix) + hostSty(fitMTRHostWithMarker(host, mtrResponseMarker(stat), lo.hostW))
 
 	m := formatMTRMetricStrings(stat)
 	row += strings.Repeat(" ", tuiHistoryGap)

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -586,7 +586,7 @@ func renderMTRTUIRows(b *strings.Builder, header MTRTUIHeader, stats []trace.MTR
 	for i, s := range stats {
 		hopPrefix := formatTUIHopPrefix(s.TTL, prevTTL, lo.prefixW)
 		prevTTL = s.TTL
-		renderDataRow(b, lo, hopPrefix, formatTUIHost(allParts[i], asnW), s)
+		renderDataRow(b, lo, hopPrefix, appendMTRResponseMarker(formatTUIHost(allParts[i], asnW), s), s)
 		renderMTRTUIMPLSRows(b, lo, s.MPLS, header.DisableMPLS)
 	}
 }
@@ -872,7 +872,7 @@ func renderMTRTUIHistoryRows(b *strings.Builder, header MTRTUIHeader, stats []tr
 	for i, s := range stats {
 		hopPrefix := formatTUIHopPrefix(s.TTL, prevTTL, lo.prefixW)
 		prevTTL = s.TTL
-		host := formatTUIHost(allParts[i], asnW)
+		host := appendMTRResponseMarker(formatTUIHost(allParts[i], asnW), s)
 		renderMTRTUIHistoryRow(b, header, lo, hopPrefix, host, s, history[s.TTL], now)
 	}
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -10,14 +11,15 @@ import (
 	"github.com/nxtrace/NTrace-core/trace"
 )
 
-func TestPrintTraceStopReason(t *testing.T) {
-	previousOutput := color.Output
-	previousNoColor := color.NoColor
-	defer func() {
-		color.Output = previousOutput
-		color.NoColor = previousNoColor
-	}()
+var errTraceStopWriter = errors.New("trace stop writer failed")
 
+type failingTraceStopWriter struct{}
+
+func (failingTraceStopWriter) Write([]byte) (int, error) {
+	return 0, errTraceStopWriter
+}
+
+func TestFormatTraceStopReason(t *testing.T) {
 	tests := []struct {
 		name   string
 		reason *trace.StopReason
@@ -39,7 +41,7 @@ func TestPrintTraceStopReason(t *testing.T) {
 				Hop:       7,
 				Reason:    trace.StopReasonUnreachable,
 				Responses: []string{"ICMP Host Unreachable (!H)", "ICMP Network Unreachable (!N)"},
-				Details:   []string{"!H", "!N"},
+				Markers:   []string{"!H", "!N"},
 			},
 			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (ICMP Host Unreachable (!H), ICMP Network Unreachable (!N))",
 		},
@@ -48,6 +50,53 @@ func TestPrintTraceStopReason(t *testing.T) {
 			reason: &trace.StopReason{Hop: 30, Reason: trace.StopReasonMaxHops},
 			want:   "Trace Stopped: Maximum Hops Reached at Hop 30 (No Destination Response)",
 		},
+		{
+			name:   "unknown reason",
+			reason: &trace.StopReason{Hop: 9, Reason: "custom_stop"},
+			want:   "Trace Stopped: custom_stop at Hop 9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatTraceStopReason(tt.reason); got != tt.want {
+				t.Fatalf("FormatTraceStopReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteTraceStopReason(t *testing.T) {
+	reason := &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}}
+	var output bytes.Buffer
+	if err := WriteTraceStopReason(&output, reason); err != nil {
+		t.Fatalf("WriteTraceStopReason() error = %v", err)
+	}
+	if got, want := output.String(), "Trace Stopped: Destination Reached at Hop 5 (ICMP Echo Reply)\n"; got != want {
+		t.Fatalf("WriteTraceStopReason() = %q, want %q", got, want)
+	}
+	if err := WriteTraceStopReason(failingTraceStopWriter{}, reason); !errors.Is(err, errTraceStopWriter) {
+		t.Fatalf("WriteTraceStopReason() error = %v, want %v", err, errTraceStopWriter)
+	}
+}
+
+func TestPrintTraceStopReason(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	tests := []struct {
+		name   string
+		reason *trace.StopReason
+	}{
+		{name: "nil"},
+		{name: "destination", reason: &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination, Responses: []string{"ICMP Echo Reply"}}},
+		{name: "unreachable", reason: &trace.StopReason{Hop: 7, Reason: trace.StopReasonUnreachable, Responses: []string{"ICMP Host Unreachable (!H)"}, Markers: []string{"!H"}}},
+		{name: "max hops", reason: &trace.StopReason{Hop: 30, Reason: trace.StopReasonMaxHops}},
+		{name: "unknown reason", reason: &trace.StopReason{Hop: 9, Reason: "custom_stop"}},
 	}
 
 	for _, tt := range tests {
@@ -55,12 +104,30 @@ func TestPrintTraceStopReason(t *testing.T) {
 			var output bytes.Buffer
 			color.Output = &output
 			color.NoColor = true
-			PrintTraceStopReason(tt.reason)
+			if err := PrintTraceStopReason(tt.reason); err != nil {
+				t.Fatalf("PrintTraceStopReason() error = %v", err)
+			}
 
-			if got := strings.TrimSpace(output.String()); got != tt.want {
-				t.Fatalf("PrintTraceStopReason() = %q, want %q", got, tt.want)
+			if got, want := strings.TrimSpace(output.String()), FormatTraceStopReason(tt.reason); got != want {
+				t.Fatalf("PrintTraceStopReason() = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestPrintTraceStopReasonReturnsWriterError(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	color.Output = failingTraceStopWriter{}
+	color.NoColor = true
+	err := PrintTraceStopReason(&trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination})
+	if !errors.Is(err, errTraceStopWriter) {
+		t.Fatalf("PrintTraceStopReason() error = %v, want %v", err, errTraceStopWriter)
 	}
 }
 

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -25,23 +25,28 @@ func TestPrintTraceStopReason(t *testing.T) {
 	}{
 		{name: "nil"},
 		{
-			name:   "destination",
-			reason: &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination},
-			want:   "Trace Stopped: Destination Reached at Hop 5",
+			name: "destination",
+			reason: &trace.StopReason{
+				Hop:       5,
+				Reason:    trace.StopReasonDestination,
+				Responses: []string{"ICMP Echo Reply"},
+			},
+			want: "Trace Stopped: Destination Reached at Hop 5 (ICMP Echo Reply)",
 		},
 		{
 			name: "unreachable",
 			reason: &trace.StopReason{
-				Hop:     7,
-				Reason:  trace.StopReasonUnreachable,
-				Details: []string{"!H", "!N"},
+				Hop:       7,
+				Reason:    trace.StopReasonUnreachable,
+				Responses: []string{"ICMP Host Unreachable (!H)", "ICMP Network Unreachable (!N)"},
+				Details:   []string{"!H", "!N"},
 			},
-			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (!H, !N)",
+			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (ICMP Host Unreachable (!H), ICMP Network Unreachable (!N))",
 		},
 		{
 			name:   "max hops",
 			reason: &trace.StopReason{Hop: 30, Reason: trace.StopReasonMaxHops},
-			want:   "Trace Stopped: Maximum Hops Reached at Hop 30",
+			want:   "Trace Stopped: Maximum Hops Reached at Hop 30 (No Destination Response)",
 		},
 	}
 

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -1,5 +1,64 @@
 package printer
 
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestPrintTraceStopReason(t *testing.T) {
+	previousOutput := color.Output
+	previousNoColor := color.NoColor
+	defer func() {
+		color.Output = previousOutput
+		color.NoColor = previousNoColor
+	}()
+
+	tests := []struct {
+		name   string
+		reason *trace.StopReason
+		want   string
+	}{
+		{name: "nil"},
+		{
+			name:   "destination",
+			reason: &trace.StopReason{Hop: 5, Reason: trace.StopReasonDestination},
+			want:   "Trace Stopped: Destination Reached at Hop 5",
+		},
+		{
+			name: "unreachable",
+			reason: &trace.StopReason{
+				Hop:     7,
+				Reason:  trace.StopReasonUnreachable,
+				Details: []string{"!H", "!N"},
+			},
+			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (!H, !N)",
+		},
+		{
+			name:   "max hops",
+			reason: &trace.StopReason{Hop: 30, Reason: trace.StopReasonMaxHops},
+			want:   "Trace Stopped: Maximum Hops Reached at Hop 30",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			color.Output = &output
+			color.NoColor = true
+			PrintTraceStopReason(tt.reason)
+
+			if got := strings.TrimSpace(output.String()); got != tt.want {
+				t.Fatalf("PrintTraceStopReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // func TestPrintTraceRouteNav(t *testing.T) {
 // 	PrintTraceRouteNav(util.DomainLookUp("1.1.1.1", false), "1.1.1.1", "dataOrigin")
 // }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -46,6 +46,35 @@ func TestFormatTraceStopReason(t *testing.T) {
 			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (ICMP Host Unreachable (!H), ICMP Network Unreachable (!N))",
 		},
 		{
+			name: "unreachable markers kept outside response descriptions",
+			reason: &trace.StopReason{
+				Hop:       7,
+				Reason:    trace.StopReasonUnreachable,
+				Responses: []string{"ICMP Host Unreachable"},
+				Markers:   []string{"!H"},
+			},
+			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (ICMP Host Unreachable (!H))",
+		},
+		{
+			name: "marker-only unreachable",
+			reason: &trace.StopReason{
+				Hop:     7,
+				Reason:  trace.StopReasonUnreachable,
+				Markers: []string{"!N"},
+			},
+			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (!N)",
+		},
+		{
+			name: "markers are matched exactly and appended once",
+			reason: &trace.StopReason{
+				Hop:       7,
+				Reason:    trace.StopReasonUnreachable,
+				Responses: []string{"ICMP custom unreachable (!H2)"},
+				Markers:   []string{"!H", "!H"},
+			},
+			want: "Trace Stopped: No Continuing Route Observed at Hop 7 (ICMP custom unreachable (!H2) (!H))",
+		},
+		{
 			name:   "max hops",
 			reason: &trace.StopReason{Hop: 30, Reason: trace.StopReasonMaxHops},
 			want:   "Trace Stopped: Maximum Hops Reached at Hop 30 (No Destination Response)",

--- a/printer/trace_stop.go
+++ b/printer/trace_stop.go
@@ -19,20 +19,27 @@ func PrintTraceStopReason(reason *trace.StopReason) {
 	switch reason.Reason {
 	case trace.StopReasonDestination:
 		status := color.New(color.FgGreen, color.Bold).Sprint("Destination Reached")
-		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
+		fmt.Fprintf(color.Output, "%s %s at %s", label, status, hop)
+		printResponseDetails(reason.Responses)
+		fmt.Fprintln(color.Output)
 	case trace.StopReasonUnreachable:
 		status := color.New(color.FgRed, color.Bold).Sprint("No Continuing Route Observed")
 		fmt.Fprintf(color.Output, "%s %s at %s", label, status, hop)
-		if len(reason.Details) > 0 {
-			markers := color.New(color.FgRed, color.Bold).Sprint(strings.Join(reason.Details, ", "))
-			fmt.Fprintf(color.Output, " (%s)", markers)
-		}
+		printResponseDetails(reason.Responses)
 		fmt.Fprintln(color.Output)
 	case trace.StopReasonMaxHops:
 		status := color.New(color.FgYellow, color.Bold).Sprint("Maximum Hops Reached")
-		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
+		fmt.Fprintf(color.Output, "%s %s at %s (No Destination Response)\n", label, status, hop)
 	default:
 		status := color.New(color.FgYellow, color.Bold).Sprint(reason.Reason)
 		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
 	}
+}
+
+func printResponseDetails(details []string) {
+	if len(details) == 0 {
+		return
+	}
+	responses := color.New(color.FgWhite).Sprint(strings.Join(details, ", "))
+	fmt.Fprintf(color.Output, " (%s)", responses)
 }

--- a/printer/trace_stop.go
+++ b/printer/trace_stop.go
@@ -16,6 +16,40 @@ type traceStopLine struct {
 	suffix    string
 }
 
+func formatTraceStopResponses(reason *trace.StopReason) string {
+	responses := strings.Join(reason.Responses, ", ")
+	missing := make([]string, 0, len(reason.Markers))
+	seen := make(map[string]struct{}, len(reason.Markers))
+	for _, marker := range reason.Markers {
+		if marker == "" {
+			continue
+		}
+		if _, ok := seen[marker]; ok {
+			continue
+		}
+		seen[marker] = struct{}{}
+		markerToken := "(" + marker + ")"
+		found := false
+		for _, response := range reason.Responses {
+			if strings.Contains(response, markerToken) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, marker)
+		}
+	}
+	if len(missing) == 0 {
+		return responses
+	}
+	markers := strings.Join(missing, " ")
+	if responses == "" {
+		return markers
+	}
+	return responses + " (" + markers + ")"
+}
+
 func buildTraceStopLine(reason *trace.StopReason) (traceStopLine, bool) {
 	if reason == nil {
 		return traceStopLine{}, false
@@ -25,10 +59,10 @@ func buildTraceStopLine(reason *trace.StopReason) (traceStopLine, bool) {
 	switch reason.Reason {
 	case trace.StopReasonDestination:
 		line.status = "Destination Reached"
-		line.responses = strings.Join(reason.Responses, ", ")
+		line.responses = formatTraceStopResponses(reason)
 	case trace.StopReasonUnreachable:
 		line.status = "No Continuing Route Observed"
-		line.responses = strings.Join(reason.Responses, ", ")
+		line.responses = formatTraceStopResponses(reason)
 	case trace.StopReasonMaxHops:
 		line.status = "Maximum Hops Reached"
 		line.suffix = " (No Destination Response)"

--- a/printer/trace_stop.go
+++ b/printer/trace_stop.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/fatih/color"
@@ -9,37 +10,82 @@ import (
 	"github.com/nxtrace/NTrace-core/trace"
 )
 
-func PrintTraceStopReason(reason *trace.StopReason) {
+type traceStopLine struct {
+	status    string
+	responses string
+	suffix    string
+}
+
+func buildTraceStopLine(reason *trace.StopReason) (traceStopLine, bool) {
 	if reason == nil {
-		return
+		return traceStopLine{}, false
+	}
+
+	line := traceStopLine{}
+	switch reason.Reason {
+	case trace.StopReasonDestination:
+		line.status = "Destination Reached"
+		line.responses = strings.Join(reason.Responses, ", ")
+	case trace.StopReasonUnreachable:
+		line.status = "No Continuing Route Observed"
+		line.responses = strings.Join(reason.Responses, ", ")
+	case trace.StopReasonMaxHops:
+		line.status = "Maximum Hops Reached"
+		line.suffix = " (No Destination Response)"
+	default:
+		line.status = reason.Reason
+	}
+	return line, true
+}
+
+func (line traceStopLine) plain(hop int) string {
+	responses := ""
+	if line.responses != "" {
+		responses = " (" + line.responses + ")"
+	}
+	return fmt.Sprintf("Trace Stopped: %s at Hop %d%s%s", line.status, hop, responses, line.suffix)
+}
+
+// FormatTraceStopReason returns the canonical plain-text stop line without a trailing newline.
+func FormatTraceStopReason(reason *trace.StopReason) string {
+	line, ok := buildTraceStopLine(reason)
+	if !ok {
+		return ""
+	}
+	return line.plain(reason.Hop)
+}
+
+// WriteTraceStopReason writes the canonical plain-text stop line.
+func WriteTraceStopReason(w io.Writer, reason *trace.StopReason) error {
+	line := FormatTraceStopReason(reason)
+	if line == "" {
+		return nil
+	}
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// PrintTraceStopReason writes a styled stop line to the terminal output.
+func PrintTraceStopReason(reason *trace.StopReason) error {
+	line, ok := buildTraceStopLine(reason)
+	if !ok {
+		return nil
 	}
 
 	label := color.New(color.FgWhite, color.Bold).Sprint("Trace Stopped:")
 	hop := color.New(color.FgCyan, color.Bold).Sprintf("Hop %d", reason.Hop)
+	statusColor := color.FgYellow
 	switch reason.Reason {
 	case trace.StopReasonDestination:
-		status := color.New(color.FgGreen, color.Bold).Sprint("Destination Reached")
-		fmt.Fprintf(color.Output, "%s %s at %s", label, status, hop)
-		printResponseDetails(reason.Responses)
-		fmt.Fprintln(color.Output)
+		statusColor = color.FgGreen
 	case trace.StopReasonUnreachable:
-		status := color.New(color.FgRed, color.Bold).Sprint("No Continuing Route Observed")
-		fmt.Fprintf(color.Output, "%s %s at %s", label, status, hop)
-		printResponseDetails(reason.Responses)
-		fmt.Fprintln(color.Output)
-	case trace.StopReasonMaxHops:
-		status := color.New(color.FgYellow, color.Bold).Sprint("Maximum Hops Reached")
-		fmt.Fprintf(color.Output, "%s %s at %s (No Destination Response)\n", label, status, hop)
-	default:
-		status := color.New(color.FgYellow, color.Bold).Sprint(reason.Reason)
-		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
+		statusColor = color.FgRed
 	}
-}
-
-func printResponseDetails(details []string) {
-	if len(details) == 0 {
-		return
+	status := color.New(statusColor, color.Bold).Sprint(line.status)
+	responses := ""
+	if line.responses != "" {
+		responses = fmt.Sprintf(" (%s)", color.New(color.FgWhite).Sprint(line.responses))
 	}
-	responses := color.New(color.FgWhite).Sprint(strings.Join(details, ", "))
-	fmt.Fprintf(color.Output, " (%s)", responses)
+	_, err := fmt.Fprintf(color.Output, "%s %s at %s%s%s\n", label, status, hop, responses, line.suffix)
+	return err
 }

--- a/printer/trace_stop.go
+++ b/printer/trace_stop.go
@@ -1,0 +1,38 @@
+package printer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func PrintTraceStopReason(reason *trace.StopReason) {
+	if reason == nil {
+		return
+	}
+
+	label := color.New(color.FgWhite, color.Bold).Sprint("Trace Stopped:")
+	hop := color.New(color.FgCyan, color.Bold).Sprintf("Hop %d", reason.Hop)
+	switch reason.Reason {
+	case trace.StopReasonDestination:
+		status := color.New(color.FgGreen, color.Bold).Sprint("Destination Reached")
+		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
+	case trace.StopReasonUnreachable:
+		status := color.New(color.FgRed, color.Bold).Sprint("No Continuing Route Observed")
+		fmt.Fprintf(color.Output, "%s %s at %s", label, status, hop)
+		if len(reason.Details) > 0 {
+			markers := color.New(color.FgRed, color.Bold).Sprint(strings.Join(reason.Details, ", "))
+			fmt.Fprintf(color.Output, " (%s)", markers)
+		}
+		fmt.Fprintln(color.Output)
+	case trace.StopReasonMaxHops:
+		status := color.New(color.FgYellow, color.Bold).Sprint("Maximum Hops Reached")
+		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
+	default:
+		status := color.New(color.FgYellow, color.Bold).Sprint(reason.Reason)
+		fmt.Fprintf(color.Output, "%s %s at %s\n", label, status, hop)
+	}
+}

--- a/server/mcp_test.go
+++ b/server/mcp_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/nxtrace/NTrace-core/internal/service"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace"
 )
 
 type recordingMCPService struct {
@@ -55,21 +57,27 @@ func (s *recordingMCPService) Traceroute(_ context.Context, input service.TraceR
 	if err := s.record("nexttrace_traceroute", input); err != nil {
 		return service.TraceResponse{}, err
 	}
-	return service.TraceResponse{Target: "example.com", ResolvedIP: "93.184.216.34", Protocol: "icmp"}, nil
+	return service.TraceResponse{Target: "example.com", ResolvedIP: "93.184.216.34", Protocol: "icmp", StopReason: &service.TraceStopReason{Hop: 4, Reason: trace.StopReasonDestination}}, nil
 }
 
 func (s *recordingMCPService) MTRReport(_ context.Context, input service.MTRReportRequest) (service.MTRReportResponse, error) {
 	if err := s.record("nexttrace_mtr_report", input); err != nil {
 		return service.MTRReportResponse{}, err
 	}
-	return service.MTRReportResponse{Target: "example.com", ResolvedIP: "93.184.216.34", Protocol: "icmp"}, nil
+	return service.MTRReportResponse{
+		Target:     "example.com",
+		ResolvedIP: "93.184.216.34",
+		Protocol:   "icmp",
+		Stats:      []trace.MTRHopStat{{TTL: 1, Geo: &ipgeo.IPGeoData{Router: map[string][]string{}}}},
+		PathEnd:    &service.TraceStopReason{Hop: 4, Reason: trace.StopReasonDestination},
+	}, nil
 }
 
 func (s *recordingMCPService) MTRRaw(_ context.Context, input service.MTRRawRequest) (service.MTRRawResponse, error) {
 	if err := s.record("nexttrace_mtr_raw", input); err != nil {
 		return service.MTRRawResponse{}, err
 	}
-	return service.MTRRawResponse{Target: "example.com", ResolvedIP: "93.184.216.34", Protocol: "icmp"}, nil
+	return service.MTRRawResponse{Target: "example.com", ResolvedIP: "93.184.216.34", Protocol: "icmp", PathEnd: &service.TraceStopReason{Hop: 3, Reason: trace.StopReasonUnreachable}}, nil
 }
 
 func (s *recordingMCPService) MTUTrace(_ context.Context, input service.MTUTraceRequest) (service.MTUTraceResponse, error) {
@@ -175,6 +183,9 @@ func TestMCPHandlerRegistersAllToolsWithSchemas(t *testing.T) {
 		"packets",
 		"ip_version",
 	})
+	assertSchemaProperties(t, byName["nexttrace_traceroute"].OutputSchema, []string{"stop_reason"})
+	assertSchemaProperties(t, byName["nexttrace_mtr_report"].OutputSchema, []string{"path_end"})
+	assertSchemaProperties(t, byName["nexttrace_mtr_raw"].OutputSchema, []string{"path_end"})
 }
 
 func TestMCPHandlerCallsEveryToolWithStructuredContent(t *testing.T) {
@@ -339,6 +350,16 @@ func TestMCPHandlerCallsEveryToolWithStructuredContent(t *testing.T) {
 			structured := structuredContentMap(t, result)
 			if _, ok := structured[call.wantOutputKey]; !ok {
 				t.Fatalf("structuredContent missing %q: %#v", call.wantOutputKey, structured)
+			}
+			switch call.name {
+			case "nexttrace_traceroute":
+				if _, ok := structured["stop_reason"]; !ok {
+					t.Fatalf("structuredContent missing stop_reason: %#v", structured)
+				}
+			case "nexttrace_mtr_report", "nexttrace_mtr_raw":
+				if _, ok := structured["path_end"]; !ok {
+					t.Fatalf("structuredContent missing path_end: %#v", structured)
+				}
 			}
 			if svc.calls[call.name] != 1 {
 				t.Fatalf("service call count for %s = %d, want 1", call.name, svc.calls[call.name])

--- a/server/trace_handler.go
+++ b/server/trace_handler.go
@@ -100,14 +100,15 @@ type hopResponse struct {
 }
 
 type traceResponse struct {
-	Target       string        `json:"target"`
-	ResolvedIP   string        `json:"resolved_ip"`
-	Protocol     string        `json:"protocol"`
-	DataProvider string        `json:"data_provider"`
-	TraceMapURL  string        `json:"trace_map_url,omitempty"`
-	Language     string        `json:"language"`
-	Hops         []hopResponse `json:"hops"`
-	DurationMs   int64         `json:"duration_ms"`
+	Target       string                   `json:"target"`
+	ResolvedIP   string                   `json:"resolved_ip"`
+	Protocol     string                   `json:"protocol"`
+	DataProvider string                   `json:"data_provider"`
+	TraceMapURL  string                   `json:"trace_map_url,omitempty"`
+	Language     string                   `json:"language"`
+	Hops         []hopResponse            `json:"hops"`
+	DurationMs   int64                    `json:"duration_ms"`
+	StopReason   *service.TraceStopReason `json:"stop_reason,omitempty"`
 }
 
 type traceProtocolSelection struct {
@@ -328,6 +329,7 @@ func traceHandler(c *gin.Context) {
 		Language:     configured.Lang,
 		Hops:         convertHops(res, configured.Lang),
 		DurationMs:   duration.Milliseconds(),
+		StopReason:   service.NewTraceStopReason(res.StopReason),
 	}
 
 	log.Printf("[deploy] trace completed target=%s hops=%d duration=%s", sanitizeLogParam(setup.Target), len(response.Hops), duration)
@@ -468,7 +470,15 @@ func traceMapURLForResult(setup *traceExecution, res *trace.Result) string {
 	if setup == nil || res == nil || !setup.Config.Maptrace || !shouldGenerateMap(setup.DataProvider) {
 		return ""
 	}
-	payload, err := json.Marshal(res)
+	// Keep the historical tracemap payload shape stable. StopReason belongs to
+	// local CLI/API output and must not be sent to the external map service.
+	payload, err := json.Marshal(struct {
+		Hops        [][]trace.Hop
+		TraceMapUrl string
+	}{
+		Hops:        res.Hops,
+		TraceMapUrl: res.TraceMapUrl,
+	})
 	if err != nil {
 		return ""
 	}

--- a/server/trace_handler_test.go
+++ b/server/trace_handler_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/nxtrace/NTrace-core/internal/service"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
 )
@@ -183,6 +185,55 @@ func TestTraceHandler_RejectsOversizedJSONBody(t *testing.T) {
 	}
 }
 
+func TestTraceHandlerReturnsSnakeCaseStopReason(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldLookup := traceDomainLookupFn
+	oldTraceroute := traceTracerouteFn
+	defer func() {
+		traceDomainLookupFn = oldLookup
+		traceTracerouteFn = oldTraceroute
+	}()
+	traceDomainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		return net.ParseIP("192.0.2.1"), nil
+	}
+	traceTracerouteFn = func(trace.Method, trace.Config) (*trace.Result, error) {
+		return &trace.Result{
+			Hops: [][]trace.Hop{{{TTL: 1, Success: true, Address: &net.IPAddr{IP: net.ParseIP("198.51.100.8")}}}},
+			StopReason: &trace.StopReason{
+				Hop:       1,
+				Reason:    trace.StopReasonUnreachable,
+				Responses: []string{"ICMP Host Unreachable from 198.51.100.8"},
+				Markers:   []string{"!H"},
+			},
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/trace", strings.NewReader(`{"target":"example.test","data_provider":"disable-geoip","disable_maptrace":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	traceHandler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	var reason service.TraceStopReason
+	if err := json.Unmarshal(body["stop_reason"], &reason); err != nil {
+		t.Fatalf("stop_reason decode: %v body=%s", err, w.Body.String())
+	}
+	if reason.Reason != trace.StopReasonUnreachable || reason.Hop != 1 || len(reason.Markers) != 1 || reason.Markers[0] != "!H" {
+		t.Fatalf("stop_reason = %#v", reason)
+	}
+	if _, ok := body["StopReason"]; ok {
+		t.Fatalf("REST leaked core PascalCase StopReason: %s", w.Body.String())
+	}
+}
+
 func TestExecuteMTRRaw_PerHopDoesNotMutateSessionGlobals(t *testing.T) {
 	oldRunMTRRaw := traceRunMTRRawFn
 	defer func() { traceRunMTRRawFn = oldRunMTRRaw }()
@@ -279,6 +330,16 @@ func TestTraceMapURLForResult_UsesRequestScopedMapHelper(t *testing.T) {
 		if payload == "" {
 			t.Fatal("payload should not be empty")
 		}
+		var body map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(payload), &body); err != nil {
+			t.Fatalf("invalid tracemap payload: %v", err)
+		}
+		if _, ok := body["StopReason"]; ok {
+			t.Fatalf("tracemap payload leaked StopReason: %s", payload)
+		}
+		if _, ok := body["Hops"]; !ok {
+			t.Fatalf("tracemap payload lost historical Hops field: %s", payload)
+		}
 		return "https://map.example.test", nil
 	}
 
@@ -287,7 +348,8 @@ func TestTraceMapURLForResult_UsesRequestScopedMapHelper(t *testing.T) {
 		DataProvider: "IPInfo",
 		Config:       trace.Config{Maptrace: true},
 	}, &trace.Result{
-		Hops: [][]trace.Hop{{{TTL: 1}}},
+		Hops:       [][]trace.Hop{{{TTL: 1}}},
+		StopReason: &trace.StopReason{Hop: 1, Reason: trace.StopReasonDestination},
 	})
 
 	if got != "https://map.example.test" {

--- a/server/web/assets/app.js
+++ b/server/web/assets/app.js
@@ -53,7 +53,6 @@ let mtrRenderScheduled = false;
 let mtrRenderTimer = null;
 let mtrRenderRAF = null;
 let mtrRenderLastAt = 0;
-let mtrRawKnownFinalTTL = Infinity;
 const traceFormHelpers = globalThis.NextTraceForm || {};
 
 const uiText = {
@@ -104,6 +103,12 @@ const uiText = {
     metaDuration: '耗时',
     metaIterations: '持续轮次',
     metaMap: '地图',
+	metaStopReason: '终止原因',
+	metaPathEnd: '路径终点',
+	reasonDestination: '已到达目标',
+	reasonUnreachable: '网络不可达',
+	reasonMaxHops: '已达到最大跳数',
+	reasonUnknown: '未知原因',
     mapOpen: '打开地图',
     attemptLabelHost: '主机',
     attemptLabelAddress: '地址',
@@ -170,6 +175,12 @@ const uiText = {
     metaDuration: 'Duration',
     metaIterations: 'Iterations',
     metaMap: 'Map',
+	metaStopReason: 'Stop reason',
+	metaPathEnd: 'Path end',
+	reasonDestination: 'Destination reached',
+	reasonUnreachable: 'Network unreachable',
+	reasonMaxHops: 'Maximum hops reached',
+	reasonUnknown: 'Unknown reason',
     mapOpen: 'Open map',
     attemptLabelHost: 'Host',
     attemptLabelAddress: 'IP',
@@ -279,7 +290,6 @@ function clearResult(resetState = false) {
     mtrRawAggStore = new Map();
     mtrRawOrderSeq = 0;
     mtrRenderLastAt = 0;
-    mtrRawKnownFinalTTL = Infinity;
     stopBtn.classList.add('hidden');
     stopBtn.disabled = true;
   }
@@ -303,6 +313,12 @@ function renderMeta(summary = {}) {
     // t('mapOpen') is assumed not user-supplied; escape only the URL
     rows.push(`${t('metaMap')}：<a href="${escapeHTML(summary.trace_map_url)}" target="_blank" rel="noreferrer">${t('mapOpen')}</a>`);
   }
+	if (summary.stop_reason) {
+		rows.push(`${t('metaStopReason')}：<strong>${escapeHTML(formatTraceStopReason(summary.stop_reason))}</strong>`);
+	}
+	if (summary.path_end) {
+		rows.push(`${t('metaPathEnd')}：<strong>${escapeHTML(formatTraceStopReason(summary.path_end))}</strong>`);
+	}
   if (rows.length === 0) {
     resultMetaNode.classList.add('hidden');
     resultMetaNode.innerHTML = '';
@@ -310,6 +326,28 @@ function renderMeta(summary = {}) {
   }
   resultMetaNode.innerHTML = rows.map((line) => `<div>${line}</div>`).join('');
   resultMetaNode.classList.remove('hidden');
+}
+
+function formatTraceStopReason(reason) {
+	if (window.nextTraceReason) {
+		return window.nextTraceReason.format(reason, currentLang);
+	}
+	if (!reason) {
+		return '';
+	}
+	const labels = {
+		destination_reached: t('reasonDestination'),
+		unreachable: t('reasonUnreachable'),
+		max_hops: t('reasonMaxHops'),
+	};
+	const parts = [`#${Number(reason.hop) || '?'}`, labels[reason.reason] || t('reasonUnknown')];
+	if (Array.isArray(reason.responses) && reason.responses.length > 0) {
+		parts.push(reason.responses.join(', '));
+	}
+	if (Array.isArray(reason.markers) && reason.markers.length > 0) {
+		parts.push(reason.markers.join(' '));
+	}
+	return parts.join(' — ');
 }
 
 function renderAttemptsGrouped(attempts) {
@@ -771,6 +809,11 @@ function handleSocketMessage(event) {
       scheduleMTRRender();
       break;
     }
+	case 'path_end': {
+		latestSummary = {...latestSummary, path_end: msg.data || null};
+		scheduleMTRRender();
+		break;
+	}
     case 'complete': {
       traceCompleted = true;
       submitBtn.disabled = false;
@@ -778,6 +821,9 @@ function handleSocketMessage(event) {
         if (msg.data && typeof msg.data.iteration === 'number') {
           latestSummary = {...latestSummary, iteration: msg.data.iteration};
         }
+		if (msg.data && Object.prototype.hasOwnProperty.call(msg.data, 'path_end')) {
+			latestSummary = {...latestSummary, path_end: msg.data.path_end || null};
+		}
         stopBtn.disabled = true;
         stopBtn.classList.add('hidden');
         if (msg.data && Array.isArray(msg.data.stats)) {
@@ -1088,26 +1134,6 @@ function ingestMTRRawRecord(rec) {
   }
   const ttl = Number(rec.ttl);
 
-  // --- knownFinalTTL truncation (mirrors server-side logic) ---
-  // Drop probes beyond the known destination TTL.
-  if (ttl > mtrRawKnownFinalTTL) {
-    return;
-  }
-  // Detect destination: success + IP matches resolved target.
-  const resolvedIP = latestSummary && latestSummary.resolved_ip
-    ? String(latestSummary.resolved_ip).trim() : '';
-  const recIP = rec.ip ? String(rec.ip).trim() : '';
-  if (rec.success && recIP && resolvedIP && recIP === resolvedIP && ttl < mtrRawKnownFinalTTL) {
-    mtrRawKnownFinalTTL = ttl;
-    // Prune stale entries whose TTL exceeds the new boundary.
-    for (const [k, v] of mtrRawAggStore) {
-      if (v.ttl > mtrRawKnownFinalTTL) {
-        mtrRawAggStore.delete(k);
-      }
-    }
-  }
-  // --- end truncation ---
-
   const key = mtrRawKey(rec);
   let row = mtrRawAggStore.get(key);
   if (!row) {
@@ -1202,20 +1228,30 @@ function ingestMTRRawRecord(rec) {
     });
     row.mpls = Array.from(existing);
   }
+	if (rec.response) {
+		row.response = {...rec.response};
+	}
 
   recomputeMTRRawDerived(row);
 }
 
 function buildMTRStatsFromRawAgg() {
-  const rows = Array.from(mtrRawAggStore.values())
+	let rows = Array.from(mtrRawAggStore.values())
     .sort((a, b) => (a.ttl - b.ttl) || (a._order - b._order))
     .map((row) => {
       const out = {...row};
+		delete out.response;
+		if (window.nextTraceMTRPath) {
+			out.response = window.nextTraceMTRPath.responseForRow(out, latestSummary.path_end);
+		}
       delete out._sum_ms;
       delete out._order;
       return out;
     });
-  mtrStatsStore = rows;
+	if (window.nextTraceMTRPath) {
+		rows = window.nextTraceMTRPath.filterRows(rows, latestSummary.path_end);
+	}
+	mtrStatsStore = rows;
   return rows;
 }
 
@@ -1303,6 +1339,14 @@ function renderMTRStats(stats) {
       mplsDiv.textContent = mplsText;
       hostCell.appendChild(mplsDiv);
     }
+	const marker = stat && stat.response && stat.response.kind === 'unreachable'
+		? String(stat.response.marker || '').trim() : '';
+	if (marker) {
+		const markerSpan = document.createElement('span');
+		markerSpan.className = 'mtr-response-marker';
+		markerSpan.textContent = ` ${marker}`;
+		hostCell.appendChild(markerSpan);
+	}
 
     tbody.appendChild(row);
   });

--- a/server/web/assets/app.js
+++ b/server/web/assets/app.js
@@ -103,12 +103,12 @@ const uiText = {
     metaDuration: '耗时',
     metaIterations: '持续轮次',
     metaMap: '地图',
-	metaStopReason: '终止原因',
-	metaPathEnd: '路径终点',
-	reasonDestination: '已到达目标',
-	reasonUnreachable: '网络不可达',
-	reasonMaxHops: '已达到最大跳数',
-	reasonUnknown: '未知原因',
+    metaStopReason: '终止原因',
+    metaPathEnd: '路径终点',
+    reasonDestination: '已到达目标',
+    reasonUnreachable: '网络不可达',
+    reasonMaxHops: '已达到最大跳数',
+    reasonUnknown: '未知原因',
     mapOpen: '打开地图',
     attemptLabelHost: '主机',
     attemptLabelAddress: '地址',
@@ -175,12 +175,12 @@ const uiText = {
     metaDuration: 'Duration',
     metaIterations: 'Iterations',
     metaMap: 'Map',
-	metaStopReason: 'Stop reason',
-	metaPathEnd: 'Path end',
-	reasonDestination: 'Destination reached',
-	reasonUnreachable: 'Network unreachable',
-	reasonMaxHops: 'Maximum hops reached',
-	reasonUnknown: 'Unknown reason',
+    metaStopReason: 'Stop reason',
+    metaPathEnd: 'Path end',
+    reasonDestination: 'Destination reached',
+    reasonUnreachable: 'Network unreachable',
+    reasonMaxHops: 'Maximum hops reached',
+    reasonUnknown: 'Unknown reason',
     mapOpen: 'Open map',
     attemptLabelHost: 'Host',
     attemptLabelAddress: 'IP',
@@ -313,12 +313,12 @@ function renderMeta(summary = {}) {
     // t('mapOpen') is assumed not user-supplied; escape only the URL
     rows.push(`${t('metaMap')}：<a href="${escapeHTML(summary.trace_map_url)}" target="_blank" rel="noreferrer">${t('mapOpen')}</a>`);
   }
-	if (summary.stop_reason) {
-		rows.push(`${t('metaStopReason')}：<strong>${escapeHTML(formatTraceStopReason(summary.stop_reason))}</strong>`);
-	}
-	if (summary.path_end) {
-		rows.push(`${t('metaPathEnd')}：<strong>${escapeHTML(formatTraceStopReason(summary.path_end))}</strong>`);
-	}
+  if (summary.stop_reason) {
+    rows.push(`${t('metaStopReason')}：<strong>${escapeHTML(formatTraceStopReason(summary.stop_reason))}</strong>`);
+  }
+  if (summary.path_end) {
+    rows.push(`${t('metaPathEnd')}：<strong>${escapeHTML(formatTraceStopReason(summary.path_end))}</strong>`);
+  }
   if (rows.length === 0) {
     resultMetaNode.classList.add('hidden');
     resultMetaNode.innerHTML = '';
@@ -329,25 +329,25 @@ function renderMeta(summary = {}) {
 }
 
 function formatTraceStopReason(reason) {
-	if (window.nextTraceReason) {
-		return window.nextTraceReason.format(reason, currentLang);
-	}
-	if (!reason) {
-		return '';
-	}
-	const labels = {
-		destination_reached: t('reasonDestination'),
-		unreachable: t('reasonUnreachable'),
-		max_hops: t('reasonMaxHops'),
-	};
-	const parts = [`#${Number(reason.hop) || '?'}`, labels[reason.reason] || t('reasonUnknown')];
-	if (Array.isArray(reason.responses) && reason.responses.length > 0) {
-		parts.push(reason.responses.join(', '));
-	}
-	if (Array.isArray(reason.markers) && reason.markers.length > 0) {
-		parts.push(reason.markers.join(' '));
-	}
-	return parts.join(' — ');
+  if (window.nextTraceReason) {
+    return window.nextTraceReason.format(reason, currentLang);
+  }
+  if (!reason) {
+    return '';
+  }
+  const labels = {
+    destination_reached: t('reasonDestination'),
+    unreachable: t('reasonUnreachable'),
+    max_hops: t('reasonMaxHops'),
+  };
+  const parts = [`#${Number(reason.hop) || '?'}`, labels[reason.reason] || t('reasonUnknown')];
+  if (Array.isArray(reason.responses) && reason.responses.length > 0) {
+    parts.push(reason.responses.join(', '));
+  }
+  if (Array.isArray(reason.markers) && reason.markers.length > 0) {
+    parts.push(reason.markers.join(' '));
+  }
+  return parts.join(' — ');
 }
 
 function renderAttemptsGrouped(attempts) {
@@ -809,11 +809,11 @@ function handleSocketMessage(event) {
       scheduleMTRRender();
       break;
     }
-	case 'path_end': {
-		latestSummary = {...latestSummary, path_end: msg.data || null};
-		scheduleMTRRender();
-		break;
-	}
+    case 'path_end': {
+      latestSummary = {...latestSummary, path_end: msg.data || null};
+      scheduleMTRRender();
+      break;
+    }
     case 'complete': {
       traceCompleted = true;
       submitBtn.disabled = false;
@@ -821,9 +821,9 @@ function handleSocketMessage(event) {
         if (msg.data && typeof msg.data.iteration === 'number') {
           latestSummary = {...latestSummary, iteration: msg.data.iteration};
         }
-		if (msg.data && Object.prototype.hasOwnProperty.call(msg.data, 'path_end')) {
-			latestSummary = {...latestSummary, path_end: msg.data.path_end || null};
-		}
+        if (msg.data && Object.prototype.hasOwnProperty.call(msg.data, 'path_end')) {
+          latestSummary = {...latestSummary, path_end: msg.data.path_end || null};
+        }
         stopBtn.disabled = true;
         stopBtn.classList.add('hidden');
         if (msg.data && Array.isArray(msg.data.stats)) {
@@ -1228,30 +1228,30 @@ function ingestMTRRawRecord(rec) {
     });
     row.mpls = Array.from(existing);
   }
-	if (rec.response) {
-		row.response = {...rec.response};
-	}
+  if (rec.response) {
+    row.response = {...rec.response};
+  }
 
   recomputeMTRRawDerived(row);
 }
 
 function buildMTRStatsFromRawAgg() {
-	let rows = Array.from(mtrRawAggStore.values())
+  let rows = Array.from(mtrRawAggStore.values())
     .sort((a, b) => (a.ttl - b.ttl) || (a._order - b._order))
     .map((row) => {
       const out = {...row};
-		delete out.response;
-		if (window.nextTraceMTRPath) {
-			out.response = window.nextTraceMTRPath.responseForRow(out, latestSummary.path_end);
-		}
+      delete out.response;
+      if (window.nextTraceMTRPath) {
+        out.response = window.nextTraceMTRPath.responseForRow(out, latestSummary.path_end);
+      }
       delete out._sum_ms;
       delete out._order;
       return out;
     });
-	if (window.nextTraceMTRPath) {
-		rows = window.nextTraceMTRPath.filterRows(rows, latestSummary.path_end);
-	}
-	mtrStatsStore = rows;
+  if (window.nextTraceMTRPath) {
+    rows = window.nextTraceMTRPath.filterRows(rows, latestSummary.path_end);
+  }
+  mtrStatsStore = rows;
   return rows;
 }
 
@@ -1339,14 +1339,14 @@ function renderMTRStats(stats) {
       mplsDiv.textContent = mplsText;
       hostCell.appendChild(mplsDiv);
     }
-	const marker = stat && stat.response && stat.response.kind === 'unreachable'
-		? String(stat.response.marker || '').trim() : '';
-	if (marker) {
-		const markerSpan = document.createElement('span');
-		markerSpan.className = 'mtr-response-marker';
-		markerSpan.textContent = ` ${marker}`;
-		hostCell.appendChild(markerSpan);
-	}
+    const marker = stat && stat.response && stat.response.kind === 'unreachable'
+      ? String(stat.response.marker || '').trim() : '';
+    if (marker) {
+      const markerSpan = document.createElement('span');
+      markerSpan.className = 'mtr-response-marker';
+      markerSpan.textContent = ` ${marker}`;
+      hostCell.appendChild(markerSpan);
+    }
 
     tbody.appendChild(row);
   });

--- a/server/web/assets/mtr_path.js
+++ b/server/web/assets/mtr_path.js
@@ -1,0 +1,42 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  if (root) {
+    root.nextTraceMTRPath = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  function pathEndTTL(pathEnd) {
+    if (!pathEnd) {
+      return Infinity;
+    }
+    const ttl = Number(pathEnd.hop);
+    return Number.isFinite(ttl) && ttl > 0 ? ttl : Infinity;
+  }
+
+  function filterRows(rows, pathEnd) {
+    const boundary = pathEndTTL(pathEnd);
+    if (!Array.isArray(rows) || boundary === Infinity) {
+      return Array.isArray(rows) ? rows : [];
+    }
+    return rows.filter((row) => Number(row && row.ttl) <= boundary);
+  }
+
+  function responseForRow(row, pathEnd) {
+    if (!row || !pathEnd || pathEnd.reason !== 'unreachable' || Number(row.ttl) !== Number(pathEnd.hop)) {
+      return undefined;
+    }
+    const markers = Array.isArray(pathEnd.markers) ? pathEnd.markers : [];
+    return {
+      kind: 'unreachable',
+      marker: markers[0] || '',
+    };
+  }
+
+  return {
+    pathEndTTL,
+    filterRows,
+    responseForRow,
+  };
+});

--- a/server/web/assets/mtr_truncation.test.cjs
+++ b/server/web/assets/mtr_truncation.test.cjs
@@ -1,179 +1,59 @@
-/**
- * Tests for the mtrRawKnownFinalTTL truncation logic in app.js.
- *
- * Since ingestMTRRawRecord lives inside app.js (a browser script with DOM
- * dependencies), we replicate the minimal subset of state and logic here to
- * exercise the truncation behaviour in isolation under Node.js.
- */
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-// --- Minimal replica of app.js globals & helpers needed for truncation ---
+const {pathEndTTL, filterRows, responseForRow} = require('./mtr_path.js');
 
-function createCtx(resolvedIP) {
-  const ctx = {
-    mtrRawAggStore: new Map(),
-    mtrRawOrderSeq: 0,
-    mtrRawKnownFinalTTL: Infinity,
-    latestSummary: { resolved_ip: resolvedIP },
-  };
+const rows = [
+  {ttl: 1, ip: '192.0.2.1'},
+  {ttl: 2, ip: '198.51.100.2'},
+  {ttl: 3, ip: '203.0.113.3'},
+  {ttl: 4, ip: '203.0.113.4'},
+];
 
-  function mtrRawKey(rec) {
-    const ttl = Number(rec && rec.ttl);
-    const ip = rec && rec.ip ? String(rec.ip).trim() : '';
-    const host = rec && rec.host ? String(rec.host).trim().toLowerCase() : '';
-    if (ip) return `${ttl}|ip:${ip}`;
-    if (host) return `${ttl}|host:${host}`;
-    return `${ttl}|unknown`;
-  }
+test('target-IP transit does not infer a path edge', () => {
+  const records = [
+    {ttl: 2, ip: '203.0.113.10', response: {kind: 'transit'}},
+    {ttl: 3, ip: '203.0.113.3', response: {kind: 'transit'}},
+  ];
 
-  /** Mirrors the truncation + ingestion logic from app.js ingestMTRRawRecord */
-  ctx.ingest = function ingest(rec) {
-    if (!rec || !Number.isFinite(Number(rec.ttl))) return;
-    const ttl = Number(rec.ttl);
-
-    if (ttl > ctx.mtrRawKnownFinalTTL) return;
-
-    const resolvedIP = ctx.latestSummary && ctx.latestSummary.resolved_ip
-      ? String(ctx.latestSummary.resolved_ip).trim() : '';
-    const recIP = rec.ip ? String(rec.ip).trim() : '';
-    if (rec.success && recIP && resolvedIP && recIP === resolvedIP && ttl < ctx.mtrRawKnownFinalTTL) {
-      ctx.mtrRawKnownFinalTTL = ttl;
-      for (const [k, v] of ctx.mtrRawAggStore) {
-        if (v.ttl > ctx.mtrRawKnownFinalTTL) {
-          ctx.mtrRawAggStore.delete(k);
-        }
-      }
-    }
-
-    const key = mtrRawKey(rec);
-    let row = ctx.mtrRawAggStore.get(key);
-    if (!row) {
-      row = {
-        ttl, host: '', ip: '',
-        sent: 0, received: 0,
-        _order: ctx.mtrRawOrderSeq++,
-      };
-      ctx.mtrRawAggStore.set(key, row);
-    }
-    row.sent += 1;
-    if (rec.ip) row.ip = String(rec.ip).trim();
-    if (rec.host) row.host = String(rec.host).trim();
-    if (rec.success) row.received += 1;
-  };
-
-  ctx.ttls = function () {
-    return Array.from(ctx.mtrRawAggStore.values())
-      .sort((a, b) => a.ttl - b.ttl || a._order - b._order)
-      .map((r) => r.ttl);
-  };
-
-  ctx.rows = function () {
-    return Array.from(ctx.mtrRawAggStore.values())
-      .sort((a, b) => a.ttl - b.ttl || a._order - b._order);
-  };
-
-  return ctx;
-}
-
-// --- Tests ---
-
-test('drops records beyond knownFinalTTL', () => {
-  const ctx = createCtx('10.0.0.1');
-  // Simulate: TTL 1-3 arrive, then TTL 2 hits destination.
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 3, ip: '10.0.0.5', success: true }); // not destination
-  ctx.ingest({ ttl: 2, ip: '10.0.0.1', success: true }); // destination!
-
-  assert.equal(ctx.mtrRawKnownFinalTTL, 2);
-  // TTL 3 should have been pruned.
-  assert.deepEqual(ctx.ttls(), [1, 2]);
-
-  // Further TTL 3 records should be silently dropped.
-  ctx.ingest({ ttl: 3, ip: '10.0.0.5', success: true });
-  assert.deepEqual(ctx.ttls(), [1, 2]);
+  assert.equal(pathEndTTL(null), Infinity);
+  assert.deepEqual(filterRows(records, null), records);
 });
 
-test('prunes stale high-TTL entries when finalTTL lowers', () => {
-  const ctx = createCtx('10.0.0.1');
-  // Initial burst: TTL 1-5 all arrive before any destination is known.
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 2, ip: '10.0.0.2', success: true });
-  ctx.ingest({ ttl: 3, ip: '10.0.0.3', success: true });
-  ctx.ingest({ ttl: 4, ip: '10.0.0.4', success: true });
-  ctx.ingest({ ttl: 5, ip: '10.0.0.1', success: true }); // first destination at TTL 5
-  assert.equal(ctx.mtrRawKnownFinalTTL, 5);
-  assert.deepEqual(ctx.ttls(), [1, 2, 3, 4, 5]);
-
-  // Later: destination found at lower TTL 3.
-  ctx.ingest({ ttl: 3, ip: '10.0.0.1', success: true });
-  assert.equal(ctx.mtrRawKnownFinalTTL, 3);
-  // TTL 4 and 5 should be pruned; TTL 3 now has two paths (10.0.0.3 + 10.0.0.1).
-  const ips = ctx.rows().map((r) => `${r.ttl}:${r.ip}`);
-  assert.deepEqual(ips, ['1:192.168.0.1', '2:10.0.0.2', '3:10.0.0.3', '3:10.0.0.1']);
-  // No TTL > 3 remains.
-  assert.ok(ctx.ttls().every((t) => t <= 3));
+test('different-source destination path_end truncates by semantic hop', () => {
+  const pathEnd = {hop: 2, reason: 'destination_reached'};
+  assert.equal(pathEndTTL(pathEnd), 2);
+  assert.deepEqual(filterRows(rows, pathEnd), rows.slice(0, 2));
 });
 
-test('timeout records at high TTL are also dropped once finalTTL is set', () => {
-  const ctx = createCtx('10.0.0.1');
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 2, ip: '10.0.0.1', success: true }); // destination
-  assert.equal(ctx.mtrRawKnownFinalTTL, 2);
-
-  // Late-arriving timeout for TTL 5 should be silently dropped.
-  ctx.ingest({ ttl: 5, success: false });
-  assert.deepEqual(ctx.ttls(), [1, 2]);
+test('unreachable path_end is provisional and null reopens preserved rows', () => {
+  const pathEnd = {hop: 2, reason: 'unreachable', markers: ['!H']};
+  assert.deepEqual(filterRows(rows, pathEnd), rows.slice(0, 2));
+  assert.deepEqual(filterRows(rows, null), rows);
 });
 
-test('non-destination IP at same TTL does not trigger truncation', () => {
-  const ctx = createCtx('10.0.0.1');
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 2, ip: '10.0.0.2', success: true }); // not destination
-  ctx.ingest({ ttl: 3, ip: '10.0.0.3', success: true }); // not destination
-
-  assert.equal(ctx.mtrRawKnownFinalTTL, Infinity);
-  assert.deepEqual(ctx.ttls(), [1, 2, 3]);
+test('lower path_end filters stale higher rows without mutating storage', () => {
+  const stored = rows.map((row) => ({...row}));
+  assert.deepEqual(filterRows(stored, {hop: 4, reason: 'destination_reached'}), stored);
+  assert.deepEqual(filterRows(stored, {hop: 2, reason: 'destination_reached'}), stored.slice(0, 2));
+  assert.equal(stored.length, 4);
 });
 
-test('does not crash with missing latestSummary.resolved_ip', () => {
-  const ctx = createCtx('');
-  ctx.ingest({ ttl: 1, ip: '10.0.0.1', success: true });
-  ctx.ingest({ ttl: 2, ip: '10.0.0.1', success: true });
-  // Without resolved_ip, nothing should be truncated.
-  assert.equal(ctx.mtrRawKnownFinalTTL, Infinity);
-  assert.deepEqual(ctx.ttls(), [1, 2]);
+test('invalid or missing path_end leaves rows visible', () => {
+  assert.equal(pathEndTTL({hop: 0, reason: 'unreachable'}), Infinity);
+  assert.equal(pathEndTTL({hop: 'invalid'}), Infinity);
+  assert.deepEqual(filterRows(rows, {hop: 0}), rows);
+  assert.deepEqual(filterRows(undefined, null), []);
 });
 
-test('reset clears knownFinalTTL (simulated clearResult)', () => {
-  const ctx = createCtx('10.0.0.1');
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 2, ip: '10.0.0.1', success: true });
-  assert.equal(ctx.mtrRawKnownFinalTTL, 2);
+test('unreachable marker follows the current path edge, not a stale raw response', () => {
+  const row = {ttl: 2, response: {kind: 'unreachable', marker: '!H'}};
 
-  // Simulate clearResult(true).
-  ctx.mtrRawAggStore = new Map();
-  ctx.mtrRawOrderSeq = 0;
-  ctx.mtrRawKnownFinalTTL = Infinity;
-
-  assert.equal(ctx.mtrRawKnownFinalTTL, Infinity);
-
-  // New session should work fresh.
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 5, ip: '10.0.0.1', success: true });
-  assert.equal(ctx.mtrRawKnownFinalTTL, 5);
-  assert.deepEqual(ctx.ttls(), [1, 5]);
-});
-
-test('destination at TTL equal to current finalTTL does not re-prune', () => {
-  const ctx = createCtx('10.0.0.1');
-  ctx.ingest({ ttl: 1, ip: '192.168.0.1', success: true });
-  ctx.ingest({ ttl: 3, ip: '10.0.0.1', success: true }); // set finalTTL=3
-  ctx.ingest({ ttl: 2, ip: '10.0.0.2', success: true });
-  assert.equal(ctx.mtrRawKnownFinalTTL, 3);
-
-  // Same TTL destination (ttl === mtrRawKnownFinalTTL): should not lower.
-  ctx.ingest({ ttl: 3, ip: '10.0.0.1', success: true });
-  assert.equal(ctx.mtrRawKnownFinalTTL, 3);
-  assert.deepEqual(ctx.ttls(), [1, 2, 3]);
+  assert.equal(responseForRow(row, null), undefined);
+  assert.equal(responseForRow(row, {hop: 3, reason: 'unreachable', markers: ['!N']}), undefined);
+  assert.deepEqual(responseForRow(row, {hop: 2, reason: 'unreachable', markers: ['!H']}), {
+    kind: 'unreachable',
+    marker: '!H',
+  });
+  assert.equal(responseForRow(row, {hop: 2, reason: 'destination_reached'}), undefined);
 });

--- a/server/web/assets/mtr_truncation.test.cjs
+++ b/server/web/assets/mtr_truncation.test.cjs
@@ -1,7 +1,48 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
 
-const {pathEndTTL, filterRows, responseForRow} = require('./mtr_path.js');
+const mtrPath = require('./mtr_path.js');
+const {pathEndTTL, filterRows, responseForRow} = mtrPath;
+
+function loadAppRawIngestor() {
+  const classList = {add() {}, remove() {}, toggle() {}};
+  const element = () => ({
+    classList,
+    dataset: {},
+    parentElement: {classList},
+    addEventListener() {},
+  });
+  const context = vm.createContext({
+    console,
+    document: {
+      body: {classList},
+      getElementById: element,
+      addEventListener() {},
+    },
+    window: {
+      location: {protocol: 'http:', host: 'example.test'},
+      nextTraceMTRPath: mtrPath,
+    },
+  });
+  const appPath = path.join(__dirname, 'app.js');
+  vm.runInContext(fs.readFileSync(appPath, 'utf8'), context, {filename: appPath});
+
+  return (records, summary) => {
+    context.__records = records;
+    context.__summary = summary;
+    vm.runInContext(`
+      mtrRawAggStore = new Map();
+      mtrRawOrderSeq = 0;
+      latestSummary = __summary;
+      __records.forEach(ingestMTRRawRecord);
+      globalThis.__rows = buildMTRStatsFromRawAgg();
+    `, context);
+    return JSON.parse(JSON.stringify(context.__rows));
+  };
+}
 
 const rows = [
   {ttl: 1, ip: '192.0.2.1'},
@@ -11,13 +52,17 @@ const rows = [
 ];
 
 test('target-IP transit does not infer a path edge', () => {
+  const ingest = loadAppRawIngestor();
   const records = [
     {ttl: 2, ip: '203.0.113.10', response: {kind: 'transit'}},
     {ttl: 3, ip: '203.0.113.3', response: {kind: 'transit'}},
   ];
 
   assert.equal(pathEndTTL(null), Infinity);
-  assert.deepEqual(filterRows(records, null), records);
+  assert.deepEqual(ingest(records, {resolved_ip: '203.0.113.10', path_end: null}).map(({ttl, ip}) => ({ttl, ip})), [
+    {ttl: 2, ip: '203.0.113.10'},
+    {ttl: 3, ip: '203.0.113.3'},
+  ]);
 });
 
 test('different-source destination path_end truncates by semantic hop', () => {

--- a/server/web/assets/trace_reason.js
+++ b/server/web/assets/trace_reason.js
@@ -1,0 +1,41 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  if (root) {
+    root.nextTraceReason = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  const labels = {
+    cn: {
+      destination_reached: '已到达目标',
+      unreachable: '网络不可达',
+      max_hops: '已达到最大跳数',
+      unknown: '未知原因',
+    },
+    en: {
+      destination_reached: 'Destination reached',
+      unreachable: 'Network unreachable',
+      max_hops: 'Maximum hops reached',
+      unknown: 'Unknown reason',
+    },
+  };
+
+  function format(reason, lang) {
+    if (!reason) {
+      return '';
+    }
+    const texts = labels[lang] || labels.en;
+    const parts = [`#${Number(reason.hop) || '?'}`, texts[reason.reason] || texts.unknown];
+    if (Array.isArray(reason.responses) && reason.responses.length > 0) {
+      parts.push(reason.responses.join(', '));
+    }
+    if (Array.isArray(reason.markers) && reason.markers.length > 0) {
+      parts.push(reason.markers.join(' '));
+    }
+    return parts.join(' — ');
+  }
+
+  return {format};
+});

--- a/server/web/assets/trace_reason.test.cjs
+++ b/server/web/assets/trace_reason.test.cjs
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {format} = require('./trace_reason.js');
+
+test('formats every stable stop reason in Chinese and English', () => {
+  const cases = [
+    ['destination_reached', '已到达目标', 'Destination reached'],
+    ['unreachable', '网络不可达', 'Network unreachable'],
+    ['max_hops', '已达到最大跳数', 'Maximum hops reached'],
+    ['future_reason', '未知原因', 'Unknown reason'],
+  ];
+  cases.forEach(([reason, cn, en]) => {
+    assert.match(format({hop: 4, reason}, 'cn'), new RegExp(cn));
+    assert.match(format({hop: 4, reason}, 'en'), new RegExp(en));
+  });
+});
+
+test('includes response descriptions and machine markers', () => {
+  assert.equal(
+    format({hop: 7, reason: 'unreachable', responses: ['ICMP Host Unreachable'], markers: ['!H']}, 'en'),
+    '#7 — Network unreachable — ICMP Host Unreachable — !H',
+  );
+});

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -105,6 +105,8 @@
   </footer>
 
   <script src="/assets/mtr_agg.js" defer></script>
+  <script src="/assets/mtr_path.js" defer></script>
+  <script src="/assets/trace_reason.js" defer></script>
   <script src="/assets/trace_form.js" defer></script>
   <script src="/assets/app.js" defer></script>
 </body>

--- a/server/ws_handler.go
+++ b/server/ws_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 
+	"github.com/nxtrace/NTrace-core/internal/service"
 	"github.com/nxtrace/NTrace-core/trace"
 )
 
@@ -335,6 +336,7 @@ func runSingleTrace(ctx context.Context, session *wsTraceSession, setup *traceEx
 		Language:     setup.Config.Lang,
 		Hops:         convertHops(res, setup.Config.Lang),
 		DurationMs:   duration.Milliseconds(),
+		StopReason:   service.NewTraceStopReason(res.StopReason),
 	}
 
 	if err := session.send(wsEnvelope{Type: "complete", Data: final}); err != nil {
@@ -348,12 +350,19 @@ func runMTRTrace(parentCtx context.Context, session *wsTraceSession, setup *trac
 	maxPerHop := setup.Req.MaxRounds // 0 = unlimited
 
 	iteration := 0
+	var pathEnd *service.TraceStopReason
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
 	err := executeMTRRaw(ctx, session, setup, trace.MTRRawOptions{
 		HopInterval: hopInterval,
 		MaxPerHop:   maxPerHop,
+		OnPathEnd: func(reason *trace.StopReason) {
+			pathEnd = service.NewTraceStopReason(reason)
+			if err := session.send(wsEnvelope{Type: "path_end", Data: pathEnd}); err != nil {
+				cancel()
+			}
+		},
 	}, func(rec trace.MTRRawRecord) {
 		if rec.Iteration > iteration {
 			iteration = rec.Iteration
@@ -369,7 +378,7 @@ func runMTRTrace(parentCtx context.Context, session *wsTraceSession, setup *trac
 	}
 
 	if !session.closed.Load() {
-		_ = session.send(wsEnvelope{Type: "complete", Data: gin.H{"iteration": iteration}})
+		_ = session.send(wsEnvelope{Type: "complete", Data: gin.H{"iteration": iteration, "path_end": pathEnd}})
 	}
 }
 

--- a/server/ws_handler_test.go
+++ b/server/ws_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -328,6 +329,53 @@ func TestRunMTRTraceCancellationDoesNotInventPathEnd(t *testing.T) {
 	}
 	if string(data) != `{"iteration":0,"path_end":null}` {
 		t.Fatalf("cancel complete data = %s", data)
+	}
+}
+
+func TestRunSingleTraceCompleteUsesSnakeCaseStopReason(t *testing.T) {
+	oldTraceroute := traceTracerouteFn
+	t.Cleanup(func() { traceTracerouteFn = oldTraceroute })
+	traceTracerouteFn = func(trace.Method, trace.Config) (*trace.Result, error) {
+		return &trace.Result{
+			StopReason: &trace.StopReason{
+				Hop:       4,
+				Reason:    trace.StopReasonUnreachable,
+				Responses: []string{"ICMP Host Unreachable"},
+				Markers:   []string{"!H"},
+			},
+		}, nil
+	}
+
+	conn := newFakeWSConn(false)
+	session := newWSTraceSession(conn, "en", 4)
+	runSingleTrace(context.Background(), session, &traceExecution{
+		Target:       "example.test",
+		Protocol:     "ICMP",
+		DataProvider: "disable-geoip",
+		Method:       trace.ICMPTrace,
+		IP:           net.ParseIP("192.0.2.1"),
+		Config:       trace.Config{Lang: "en"},
+	})
+	session.finish()
+
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	if len(conn.writes) != 1 || conn.writes[0].Type != "complete" {
+		t.Fatalf("envelopes = %#v, want one complete", conn.writes)
+	}
+	data, err := json.Marshal(conn.writes[0].Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("complete data decode: %v", err)
+	}
+	if _, ok := fields["stop_reason"]; !ok {
+		t.Fatalf("complete data missing stop_reason: %s", data)
+	}
+	if _, ok := fields["StopReason"]; ok {
+		t.Fatalf("complete data leaked core StopReason key: %s", data)
 	}
 }
 

--- a/server/ws_handler_test.go
+++ b/server/ws_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/nxtrace/NTrace-core/trace"
 )
 
 type fakeWSConn struct {
@@ -246,6 +248,86 @@ func TestWSTraceSessionClose_IsIdempotent(t *testing.T) {
 	}
 	if conn.deadlineCount != 0 {
 		t.Fatalf("SetWriteDeadline called %d times during close path, want 0", conn.deadlineCount)
+	}
+}
+
+func TestRunMTRTraceStreamsPathEndAndCompleteState(t *testing.T) {
+	oldRun := traceRunMTRRawFn
+	defer func() { traceRunMTRRawFn = oldRun }()
+	traceRunMTRRawFn = func(_ context.Context, _ trace.Method, _ trace.Config, opts trace.MTRRawOptions, onRecord trace.MTRRawOnRecord) error {
+		opts.OnPathEnd(&trace.StopReason{Hop: 3, Reason: trace.StopReasonUnreachable, Markers: []string{"!H"}})
+		onRecord(trace.MTRRawRecord{Iteration: 1, TTL: 3, Success: true, IP: "192.0.2.3", Response: &trace.MTRProbeResponse{Kind: trace.MTRResponseUnreachable, Marker: "!H"}})
+		opts.OnPathEnd(nil)
+		return nil
+	}
+
+	conn := newFakeWSConn(false)
+	session := newWSTraceSession(conn, "en", 8)
+	runMTRTrace(context.Background(), session, &traceExecution{
+		Method: trace.ICMPTrace,
+		Config: trace.Config{MaxHops: 5},
+		Req:    traceRequest{HopIntervalMs: 1, MaxRounds: 1},
+	})
+	session.finish()
+
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	var types []string
+	for _, write := range conn.writes {
+		types = append(types, write.Type)
+	}
+	want := []string{"path_end", "mtr_raw", "path_end", "complete"}
+	if len(types) != len(want) {
+		t.Fatalf("envelopes = %v, want %v", types, want)
+	}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Fatalf("envelopes = %v, want %v", types, want)
+		}
+	}
+	reopenData, err := json.Marshal(conn.writes[2].Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(reopenData) != "null" {
+		t.Fatalf("reopen path_end data = %s, want null", reopenData)
+	}
+	data, err := json.Marshal(conn.writes[len(conn.writes)-1].Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"iteration":1,"path_end":null}` {
+		t.Fatalf("complete data = %s", data)
+	}
+}
+
+func TestRunMTRTraceCancellationDoesNotInventPathEnd(t *testing.T) {
+	oldRun := traceRunMTRRawFn
+	defer func() { traceRunMTRRawFn = oldRun }()
+	traceRunMTRRawFn = func(_ context.Context, _ trace.Method, _ trace.Config, _ trace.MTRRawOptions, _ trace.MTRRawOnRecord) error {
+		return context.Canceled
+	}
+
+	conn := newFakeWSConn(false)
+	session := newWSTraceSession(conn, "en", 8)
+	runMTRTrace(context.Background(), session, &traceExecution{
+		Method: trace.ICMPTrace,
+		Config: trace.Config{MaxHops: 5},
+		Req:    traceRequest{HopIntervalMs: 1, MaxRounds: 3},
+	})
+	session.finish()
+
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	if len(conn.writes) != 1 || conn.writes[0].Type != "complete" {
+		t.Fatalf("cancel envelopes = %#v, want only complete", conn.writes)
+	}
+	data, err := json.Marshal(conn.writes[0].Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"iteration":0,"path_end":null}` {
+		t.Fatalf("cancel complete data = %s", data)
 	}
 }
 

--- a/skills/nexttrace/references/cli-fallback.md
+++ b/skills/nexttrace/references/cli-fallback.md
@@ -13,7 +13,9 @@ nexttrace --udp -p 33494 example.com
 nexttrace --json example.com
 ```
 
-JSON includes optional `StopReason` with lowercase nested fields `hop`, `reason`, `responses`, and `markers`. Use `reason` as the reachability conclusion; do not compare the last hop IP with the target.
+JSON includes optional `StopReason` with lowercase nested fields `hop`, `reason`, `responses`, and `markers`. `responses` contains human-readable descriptions; `markers` contains machine-readable codes. Use `reason` as the reachability conclusion; do not compare the last hop IP with the target.
+
+Normal traceroute output precedence is `--json` > `--table` > `--classic` > `--raw` > `--output` > realtime. A higher-priority mode that overrides an explicit output file emits a warning on stderr.
 
 ## MTR
 
@@ -22,7 +24,7 @@ nexttrace --report example.com
 nexttrace --mtr --raw -q 5 example.com
 ```
 
-MTR raw stdout remains a fixed 12-column stream. Semantic unreachable diagnostics are written to stderr so stdout parsers remain compatible.
+MTR raw stdout remains a fixed 12-column stream. Semantic unreachable diagnostics are written to stderr so stdout parsers remain compatible. In unbounded MTR, an unreachable edge is provisional and later transit evidence can reopen the path; use the final `path_end` from bounded structured output as the authoritative boundary.
 
 ## MTU
 

--- a/skills/nexttrace/references/cli-fallback.md
+++ b/skills/nexttrace/references/cli-fallback.md
@@ -13,12 +13,16 @@ nexttrace --udp -p 33494 example.com
 nexttrace --json example.com
 ```
 
+JSON includes optional `StopReason` with lowercase nested fields `hop`, `reason`, `responses`, and `markers`. Use `reason` as the reachability conclusion; do not compare the last hop IP with the target.
+
 ## MTR
 
 ```bash
 nexttrace --report example.com
 nexttrace --mtr --raw -q 5 example.com
 ```
+
+MTR raw stdout remains a fixed 12-column stream. Semantic unreachable diagnostics are written to stderr so stdout parsers remain compatible.
 
 ## MTU
 

--- a/skills/nexttrace/references/mcp-tools.md
+++ b/skills/nexttrace/references/mcp-tools.md
@@ -54,7 +54,9 @@ Supported:
 }
 ```
 
-Output includes `target`, `resolved_ip`, `protocol`, `data_provider`, `language`, `hops[]`, and `duration_ms`.
+Output includes `target`, `resolved_ip`, `protocol`, `data_provider`, `language`, `hops[]`, `duration_ms`, and optional `stop_reason`.
+
+`stop_reason.reason` is one of `destination_reached`, `unreachable`, or `max_hops`; use it as the authoritative conclusion instead of comparing the last responder IP with `resolved_ip`. `responses[]` contains human-readable evidence and `markers[]` contains machine markers.
 
 Respect its parameter boundaries. Do not switch from ICMP to TCP/UDP because some hops drop packets; ask or report the limitation first. Keep explicit TCP/UDP ports, and remember omitted ports default to TCP `80` and UDP `33494`.
 
@@ -62,7 +64,7 @@ Final answer shape: use [output-templates.md](output-templates.md#nexttrace_trac
 
 ### `nexttrace_mtr_report`
 
-Runs bounded MTR and returns aggregated `stats[]`.
+Runs bounded MTR and returns aggregated `stats[]` plus optional `path_end`.
 
 Adds:
 
@@ -72,6 +74,8 @@ Adds:
 Use this for loss, jitter, and repeated RTT comparison.
 
 Respect its parameter boundaries. Use this for repeated local statistics, not for worldwide probe selection. Do not summarize a lossy intermediate hop as destination failure without checking later hops and final-hop stats.
+
+`path_end` is the server's semantic path boundary, not the reason the MTR session ended. Its shape matches `stop_reason`. A missing `path_end` means the bounded run ended early or no path boundary was established.
 
 Final answer shape: use [output-templates.md](output-templates.md#nexttrace_mtr_report).
 
@@ -88,6 +92,8 @@ Adds:
 If neither `max_per_hop` nor `duration_ms` is set, NextTrace bounds output with a small default and reports a warning.
 
 Respect its parameter boundaries. Raw output is probe-level records, not a final path table. Accept the bounded default or set `max_per_hop` / `duration_ms`; do not request unbounded raw streams through MCP.
+
+Each record can include `response: {kind, description, marker}`. The final optional `path_end` is authoritative; do not infer it from `record.ip == resolved_ip`.
 
 Final answer shape: use [output-templates.md](output-templates.md#nexttrace_mtr_raw).
 

--- a/skills/nexttrace/references/output-templates.md
+++ b/skills/nexttrace/references/output-templates.md
@@ -10,6 +10,8 @@ Use these templates when turning NextTrace MCP `structuredContent` into a user-f
 - Use only fields present in `structuredContent`. Omit unknown values instead of guessing.
 - Keep raw data short. Link or quote only the key lines from `raw_output` when it materially changes the conclusion.
 - Choose the Chinese or English template based on the user's language. Do not output both languages unless requested.
+- For traceroute reachability, use `stop_reason.reason`; do not infer completion from the final responder IP.
+- For MTR path boundaries, use `path_end`; it describes the known path edge, not why the MTR session itself stopped.
 
 ## `nexttrace_capabilities`
 
@@ -58,6 +60,7 @@ English template:
 | 协议 | `<protocol>` |
 | Geo 数据源 | `<data_provider>` |
 | 耗时 | `<duration_ms> ms` |
+| 终止原因 | `<stop_reason.reason>`（TTL `<stop_reason.hop>`；`<stop_reason.responses/markers>`） |
 
 **关键路径**
 
@@ -85,6 +88,7 @@ English template:
 | Protocol | `<protocol>` |
 | Geo source | `<data_provider>` |
 | Duration | `<duration_ms> ms` |
+| Stop reason | `<stop_reason.reason>` (TTL `<stop_reason.hop>`; `<stop_reason.responses/markers>`) |
 
 **Key Path**
 
@@ -113,6 +117,7 @@ English template:
 | 解析 IP | `<resolved_ip>` |
 | 协议 | `<protocol>` |
 | 采样耗时 | `<duration_ms> ms` |
+| 路径终点 | `<path_end.reason>`（TTL `<path_end.hop>`；缺失时不要推断） |
 
 **最终 hop**
 
@@ -141,6 +146,7 @@ English template:
 | Resolved IP | `<resolved_ip>` |
 | Protocol | `<protocol>` |
 | Duration | `<duration_ms> ms` |
+| Path end | `<path_end.reason>` (TTL `<path_end.hop>`; do not infer when absent) |
 
 **Final Hop**
 
@@ -173,12 +179,13 @@ English template:
 | 记录数 | `<len(records)>` |
 | 耗时 | `<duration_ms> ms` |
 | Warning | `<warnings[]>` |
+| 路径终点 | `<path_end.reason>`（TTL `<path_end.hop>`；缺失时不要推断） |
 
 **关键记录**
 
 | Iter | TTL | IP / Host | RTT | ASN / 地理 | 状态 |
 | --- | --- | --- | --- | --- | --- |
-| `<record.iteration>` | `<record.ttl>` | `<record.ip>` / `<record.host>` | `<record.rtt_ms> ms` | `<record.asn>` `<record.country/prov/city>` | `<record.success>` |
+| `<record.iteration>` | `<record.ttl>` | `<record.ip>` / `<record.host>` | `<record.rtt_ms> ms` | `<record.asn>` `<record.country/prov/city>` | `<record.response.kind/marker or record.success>` |
 ```
 
 English template:
@@ -197,12 +204,13 @@ English template:
 | Records | `<len(records)>` |
 | Duration | `<duration_ms> ms` |
 | Warnings | `<warnings[]>` |
+| Path end | `<path_end.reason>` (TTL `<path_end.hop>`; do not infer when absent) |
 
 **Key Records**
 
 | Iter | TTL | IP / Host | RTT | ASN / Location | Status |
 | --- | --- | --- | --- | --- | --- |
-| `<record.iteration>` | `<record.ttl>` | `<record.ip>` / `<record.host>` | `<record.rtt_ms> ms` | `<record.asn>` `<record.country/prov/city>` | `<record.success>` |
+| `<record.iteration>` | `<record.ttl>` | `<record.ip>` / `<record.host>` | `<record.rtt_ms> ms` | `<record.asn>` `<record.country/prov/city>` | `<record.response.kind/marker or record.success>` |
 ```
 
 ## `nexttrace_mtu_trace`

--- a/trace/icmp_ipv4.go
+++ b/trace/icmp_ipv4.go
@@ -78,7 +78,8 @@ func (t *ICMPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFu
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
-			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+			if t.res.stopAfterTTL(ttl, t.MaxHops) {
+				t.final.Store(int32(ttl))
 				cancel(errNaturalDone) // 标记为“自然完成”
 				return
 			}
@@ -170,23 +171,10 @@ func (t *ICMPTracer) dropSent(seq int) {
 	delete(t.sentAt, seq)
 }
 
-func (t *ICMPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string) {
+func (t *ICMPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		return
 	}
-
-	if ip := util.AddrIP(peer); ip != nil && ip.Equal(t.DstIP) {
-		for {
-			old := t.final.Load()
-			if old != -1 && ttl >= int(old) {
-				break
-			}
-			if t.final.CompareAndSwap(old, int32(ttl)) {
-				break
-			}
-		}
-	}
-
 	h := Hop{
 		Success: true,
 		Address: peer,
@@ -194,7 +182,7 @@ func (t *ICMPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duratio
 		RTT:     rtt,
 		MPLS:    mpls,
 	}
-	t.res.addWithGeoAsync(h, i, t.NumMeasurements, t.MaxAttempts, t.Config)
+	t.res.addMatchedHop(h, response, &t.final, i, t.NumMeasurements, t.MaxAttempts, t.Config)
 }
 
 func (t *ICMPTracer) matchWorker(ctx context.Context) {
@@ -236,7 +224,7 @@ func (t *ICMPTracer) matchWorker(ctx context.Context) {
 
 			if t.clearPending(task.seq) {
 				rtt := task.finish.Sub(start)
-				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls)
+				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls, task.response)
 			}
 			t.dropSent(task.seq)
 		}
@@ -357,7 +345,7 @@ func (t *ICMPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		seq: seq, peer: msg.Peer, finish: finish, mpls: mpls,
+		seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环

--- a/trace/icmp_ipv4.go
+++ b/trace/icmp_ipv4.go
@@ -53,10 +53,7 @@ func (t *ICMPTracer) waitAllReady(ctx context.Context) {
 }
 
 func (t *ICMPTracer) ttlComp(ttl int) bool {
-	idx := ttl - 1
-	t.res.lock.RLock()
-	defer t.res.lock.RUnlock()
-	return idx < len(t.res.Hops) && len(t.res.Hops[idx]) >= t.NumMeasurements
+	return t.res.ttlDisplayComplete(ttl, t.NumMeasurements)
 }
 
 func (t *ICMPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
@@ -67,22 +64,14 @@ func (t *ICMPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFu
 	defer ticker.Stop()
 
 	for {
-		if t.AsyncPrinter != nil {
-			t.AsyncPrinter(&t.res)
-		}
-
-		// 接收的时候检查一下是不是 3 跳都齐了
-		if t.ttlComp(ttl + 1) {
-			if t.RealtimePrinter != nil {
-				t.res.waitGeo(ctx, ttl)
-				t.RealtimePrinter(&t.res, ttl)
-			}
-			ttl++
-			if t.res.stopAfterTTL(ttl, t.MaxHops) {
-				t.final.Store(int32(ttl))
-				cancel(errNaturalDone) // 标记为“自然完成”
-				return
-			}
+		nextTTL, stop := advanceStableTracePrint(
+			ctx, &t.res, ttl, t.MaxHops, t.NumMeasurements, &t.final,
+			t.AsyncPrinter, t.RealtimePrinter,
+		)
+		ttl = nextTTL
+		if stop {
+			cancel(errNaturalDone)
+			return
 		}
 
 		select {
@@ -94,20 +83,35 @@ func (t *ICMPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFu
 }
 
 func (t *ICMPTracer) launchTTL(ctx context.Context, s *internal.ICMPSpec, ttl int) {
+	t.wg.Add(1)
 	go func(ttl int) {
+		defer t.wg.Done()
+		defer t.res.markTTLLaunchDone(ttl)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
 
+			if !t.res.markAttemptLaunched(ttl, i, &t.final) {
+				return
+			}
 			t.wg.Add(1)
 			go func(ttl, i int) {
-				if err := t.send(ctx, s, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
+				defer t.wg.Done()
+				err := t.send(ctx, s, ttl, i)
+				if err != nil && !errors.Is(err, context.Canceled) {
 					if util.EnvDevMode {
 						panic(err)
 					}
 					fmt.Fprintf(os.Stderr, "send error (ttl=%d, attempt=%d): %v\n", ttl, i, err)
+				}
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+						t.res.addFailedAttempt(Hop{TTL: ttl, Error: err}, &t.final, i, t.NumMeasurements, t.MaxAttempts)
+					} else {
+						t.res.settleAttempt(ttl, i)
+					}
 				}
 			}(ttl, i)
 
@@ -173,6 +177,7 @@ func (t *ICMPTracer) dropSent(seq int) {
 
 func (t *ICMPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return
 	}
 	h := Hop{
@@ -315,6 +320,7 @@ func (t *ICMPTracer) Execute() (res *Result, err error) {
 
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
+				t.res.markTTLLaunchDone(ttl)
 				return
 			}
 
@@ -353,10 +359,9 @@ func (t *ICMPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time
 }
 
 func (t *ICMPTracer) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int) error {
-	defer t.wg.Done()
-
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -366,11 +371,13 @@ func (t *ICMPTracer) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int)
 	defer t.sem.Release(1)
 
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -401,21 +408,17 @@ func (t *ICMPTracer) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int)
 
 	// 登记 pending，并启动超时守护
 	t.markPending(seq)
+	t.wg.Add(1)
 	go func(seq, ttl, i int) {
+		defer t.wg.Done()
 		if !waitForTraceDelay(ctx, t.Timeout) {
 			_ = t.clearPending(seq)
+			t.res.settleAttempt(ttl, i)
 			return
 		}
 		if !t.clearPending(seq) {
 			return
 		}
-		if f := t.final.Load(); f != -1 && ttl > int(f) {
-			return
-		}
-		if t.ttlComp(ttl) {
-			return
-		}
-
 		h := Hop{
 			Success: false,
 			Address: nil,
@@ -424,7 +427,7 @@ func (t *ICMPTracer) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int)
 			Error:   errHopLimitTimeout,
 		}
 
-		_, _ = t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
+		t.res.addTimeout(h, &t.final, i, t.NumMeasurements, t.MaxAttempts)
 		t.dropSent(seq)
 	}(seq, ttl, i)
 

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -78,7 +78,8 @@ func (t *ICMPTracerv6) PrintFunc(ctx context.Context, cancel context.CancelCause
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
-			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+			if t.res.stopAfterTTL(ttl, t.MaxHops) {
+				t.final.Store(int32(ttl))
 				cancel(errNaturalDone) // 标记为“自然完成”
 				return
 			}
@@ -170,23 +171,10 @@ func (t *ICMPTracerv6) dropSent(seq int) {
 	delete(t.sentAt, seq)
 }
 
-func (t *ICMPTracerv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string) {
+func (t *ICMPTracerv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		return
 	}
-
-	if ip := util.AddrIP(peer); ip != nil && ip.Equal(t.DstIP) {
-		for {
-			old := t.final.Load()
-			if old != -1 && ttl >= int(old) {
-				break
-			}
-			if t.final.CompareAndSwap(old, int32(ttl)) {
-				break
-			}
-		}
-	}
-
 	h := Hop{
 		Success: true,
 		Address: peer,
@@ -194,7 +182,7 @@ func (t *ICMPTracerv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Durat
 		RTT:     rtt,
 		MPLS:    mpls,
 	}
-	t.res.addWithGeoAsync(h, i, t.NumMeasurements, t.MaxAttempts, t.Config)
+	t.res.addMatchedHop(h, response, &t.final, i, t.NumMeasurements, t.MaxAttempts, t.Config)
 }
 
 func (t *ICMPTracerv6) matchWorker(ctx context.Context) {
@@ -236,7 +224,7 @@ func (t *ICMPTracerv6) matchWorker(ctx context.Context) {
 
 			if t.clearPending(task.seq) {
 				rtt := task.finish.Sub(start)
-				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls)
+				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls, task.response)
 			}
 			t.dropSent(task.seq)
 		}
@@ -357,7 +345,7 @@ func (t *ICMPTracerv6) handleICMPMessage(msg internal.ReceivedMessage, finish ti
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		seq: seq, peer: msg.Peer, finish: finish, mpls: mpls,
+		seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -53,10 +53,7 @@ func (t *ICMPTracerv6) waitAllReady(ctx context.Context) {
 }
 
 func (t *ICMPTracerv6) ttlComp(ttl int) bool {
-	idx := ttl - 1
-	t.res.lock.RLock()
-	defer t.res.lock.RUnlock()
-	return idx < len(t.res.Hops) && len(t.res.Hops[idx]) >= t.NumMeasurements
+	return t.res.ttlDisplayComplete(ttl, t.NumMeasurements)
 }
 
 func (t *ICMPTracerv6) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
@@ -67,22 +64,14 @@ func (t *ICMPTracerv6) PrintFunc(ctx context.Context, cancel context.CancelCause
 	defer ticker.Stop()
 
 	for {
-		if t.AsyncPrinter != nil {
-			t.AsyncPrinter(&t.res)
-		}
-
-		// 接收的时候检查一下是不是 3 跳都齐了
-		if t.ttlComp(ttl + 1) {
-			if t.RealtimePrinter != nil {
-				t.res.waitGeo(ctx, ttl)
-				t.RealtimePrinter(&t.res, ttl)
-			}
-			ttl++
-			if t.res.stopAfterTTL(ttl, t.MaxHops) {
-				t.final.Store(int32(ttl))
-				cancel(errNaturalDone) // 标记为“自然完成”
-				return
-			}
+		nextTTL, stop := advanceStableTracePrint(
+			ctx, &t.res, ttl, t.MaxHops, t.NumMeasurements, &t.final,
+			t.AsyncPrinter, t.RealtimePrinter,
+		)
+		ttl = nextTTL
+		if stop {
+			cancel(errNaturalDone)
+			return
 		}
 
 		select {
@@ -94,20 +83,35 @@ func (t *ICMPTracerv6) PrintFunc(ctx context.Context, cancel context.CancelCause
 }
 
 func (t *ICMPTracerv6) launchTTL(ctx context.Context, s *internal.ICMPSpec, ttl int) {
+	t.wg.Add(1)
 	go func(ttl int) {
+		defer t.wg.Done()
+		defer t.res.markTTLLaunchDone(ttl)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
 
+			if !t.res.markAttemptLaunched(ttl, i, &t.final) {
+				return
+			}
 			t.wg.Add(1)
 			go func(ttl, i int) {
-				if err := t.send(ctx, s, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
+				defer t.wg.Done()
+				err := t.send(ctx, s, ttl, i)
+				if err != nil && !errors.Is(err, context.Canceled) {
 					if util.EnvDevMode {
 						panic(err)
 					}
 					fmt.Fprintf(os.Stderr, "send error (ttl=%d, attempt=%d): %v\n", ttl, i, err)
+				}
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+						t.res.addFailedAttempt(Hop{TTL: ttl, Error: err}, &t.final, i, t.NumMeasurements, t.MaxAttempts)
+					} else {
+						t.res.settleAttempt(ttl, i)
+					}
 				}
 			}(ttl, i)
 
@@ -173,6 +177,7 @@ func (t *ICMPTracerv6) dropSent(seq int) {
 
 func (t *ICMPTracerv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return
 	}
 	h := Hop{
@@ -315,6 +320,7 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
+				t.res.markTTLLaunchDone(ttl)
 				return
 			}
 
@@ -353,10 +359,9 @@ func (t *ICMPTracerv6) handleICMPMessage(msg internal.ReceivedMessage, finish ti
 }
 
 func (t *ICMPTracerv6) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int) error {
-	defer t.wg.Done()
-
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -366,11 +371,13 @@ func (t *ICMPTracerv6) send(ctx context.Context, s *internal.ICMPSpec, ttl, i in
 	defer t.sem.Release(1)
 
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -404,18 +411,15 @@ func (t *ICMPTracerv6) send(ctx context.Context, s *internal.ICMPSpec, ttl, i in
 
 	// 登记 pending，并启动超时守护
 	t.markPending(seq)
+	t.wg.Add(1)
 	go func(seq, ttl, i int) {
+		defer t.wg.Done()
 		if !waitForTraceDelay(ctx, t.Timeout) {
 			_ = t.clearPending(seq)
+			t.res.settleAttempt(ttl, i)
 			return
 		}
 		if !t.clearPending(seq) {
-			return
-		}
-		if f := t.final.Load(); f != -1 && ttl > int(f) {
-			return
-		}
-		if t.ttlComp(ttl) {
 			return
 		}
 
@@ -427,7 +431,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, s *internal.ICMPSpec, ttl, i in
 			Error:   errHopLimitTimeout,
 		}
 
-		_, _ = t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
+		t.res.addTimeout(h, &t.final, i, t.NumMeasurements, t.MaxAttempts)
 		t.dropSent(seq)
 	}(seq, ttl, i)
 

--- a/trace/internal/icmp_common.go
+++ b/trace/internal/icmp_common.go
@@ -88,7 +88,7 @@ func (s *ICMPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, int,
 	}
 	response := classifySocketICMPResponse(s.IPVersion, rm, msg.Msg)
 
-	if seq, ok := matchSocketICMPEchoReply(s.IPVersion, rm, s.EchoID); ok {
+	if seq, ok := matchSocketICMPEchoReply(s.IPVersion, rm, s.EchoID, msg.Peer, s.DstIP); ok {
 		return finish, seq, response, true
 	}
 

--- a/trace/internal/icmp_common.go
+++ b/trace/internal/icmp_common.go
@@ -67,34 +67,36 @@ func (s *ICMPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onIC
 			if !ok {
 				return
 			}
-			finish, seq, ok := s.decodeICMPSocketMessage(msg)
+			finish, seq, response, ok := s.decodeICMPSocketMessage(msg)
 			if ok {
+				msg.ICMP = response
 				onICMP(msg, finish, seq)
 			}
 		}
 	}
 }
 
-func (s *ICMPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, int, bool) {
+func (s *ICMPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, int, ICMPResponse, bool) {
 	if msg.Err != nil {
-		return time.Time{}, 0, false
+		return time.Time{}, 0, ICMPResponse{}, false
 	}
 
 	finish := time.Now()
 	rm, ok := parseSocketICMPMessage(s.IPVersion, msg.Msg)
 	if !ok {
-		return finish, 0, false
+		return finish, 0, ICMPResponse{}, false
 	}
+	response := classifySocketICMPResponse(s.IPVersion, rm, msg.Msg)
 
-	if seq, ok := matchSocketICMPEchoReply(s.IPVersion, rm, util.AddrIP(msg.Peer), s.DstIP, s.EchoID); ok {
-		return finish, seq, true
+	if seq, ok := matchSocketICMPEchoReply(s.IPVersion, rm, s.EchoID); ok {
+		return finish, seq, response, true
 	}
 
 	data, ok := extractSocketICMPPayload(s.IPVersion, rm, s.DstIP)
 	if !ok {
-		return finish, 0, false
+		return finish, 0, ICMPResponse{}, false
 	}
 
 	seq, ok := extractEmbeddedICMPSeq(data, s.EchoID)
-	return finish, seq, ok
+	return finish, seq, response, ok
 }

--- a/trace/internal/icmp_decode.go
+++ b/trace/internal/icmp_decode.go
@@ -40,12 +40,13 @@ func parseSocketICMPMessage(ipVersion int, raw []byte) (*icmp.Message, bool) {
 	return rm, true
 }
 
-func matchSocketICMPEchoReply(ipVersion int, rm *icmp.Message, echoID int) (int, bool) {
+func matchSocketICMPEchoReply(ipVersion int, rm *icmp.Message, echoID int, peer net.Addr, dstIP net.IP) (int, bool) {
 	if !isSocketICMPEchoReply(ipVersion, rm) {
 		return 0, false
 	}
 	echo, ok := rm.Body.(*icmp.Echo)
-	if !ok || echo == nil || echo.ID != echoID {
+	peerIP := util.AddrIP(peer)
+	if !ok || echo == nil || echo.ID != echoID || peerIP == nil || !peerIP.Equal(dstIP) {
 		return 0, false
 	}
 	return echo.Seq, true
@@ -79,12 +80,21 @@ func classifyICMPResponse(ipVersion, typeID, code, info int) ICMPResponse {
 		case typeID == 0:
 			response.Kind = ICMPResponseEchoReply
 			response.Description = "ICMP Echo Reply"
-		case typeID == 11:
+		case typeID == 11 && code == 0:
 			response.Kind = ICMPResponseTransit
 			response.Description = "ICMP Time Exceeded"
+		case typeID == 11:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
+			if code == 1 {
+				response.Description = "ICMP Fragment Reassembly Time Exceeded"
+			} else {
+				response.Description = fmt.Sprintf("ICMP Time Exceeded (Code %d)", code)
+			}
 		case typeID == 3 && code == 3:
 			response.Kind = ICMPResponsePortUnreachable
 			response.Description = "ICMP Port Unreachable"
+			response.Marker = "!<3-3>"
 		case typeID == 3:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = ipv4UnreachableMarker(code, info)
@@ -103,12 +113,21 @@ func classifyICMPResponse(ipVersion, typeID, code, info int) ICMPResponse {
 		case typeID == 129:
 			response.Kind = ICMPResponseEchoReply
 			response.Description = "ICMPv6 Echo Reply"
-		case typeID == 3:
+		case typeID == 3 && code == 0:
 			response.Kind = ICMPResponseTransit
 			response.Description = "ICMPv6 Time Exceeded"
+		case typeID == 3:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
+			if code == 1 {
+				response.Description = "ICMPv6 Fragment Reassembly Time Exceeded"
+			} else {
+				response.Description = fmt.Sprintf("ICMPv6 Time Exceeded (Code %d)", code)
+			}
 		case typeID == 1 && code == 4:
 			response.Kind = ICMPResponsePortUnreachable
 			response.Description = "ICMPv6 Port Unreachable"
+			response.Marker = "!<1-4>"
 		case typeID == 1:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = ipv6UnreachableMarker(code)
@@ -206,7 +225,9 @@ func ipv6UnreachableDescription(code int) string {
 		return "ICMPv6 No Route to Destination"
 	case 1:
 		return "ICMPv6 Administratively Prohibited"
-	case 2, 3:
+	case 2:
+		return "ICMPv6 Beyond Scope of Source Address"
+	case 3:
 		return "ICMPv6 Address Unreachable"
 	default:
 		return fmt.Sprintf("ICMPv6 Destination Unreachable (Code %d)", code)

--- a/trace/internal/icmp_decode.go
+++ b/trace/internal/icmp_decode.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"encoding/binary"
+	"fmt"
 	"net"
 
 	"golang.org/x/net/icmp"
@@ -9,6 +11,21 @@ import (
 
 	"github.com/nxtrace/NTrace-core/util"
 )
+
+type ICMPResponseKind uint8
+
+const (
+	ICMPResponseUnknown ICMPResponseKind = iota
+	ICMPResponseTransit
+	ICMPResponseEchoReply
+	ICMPResponsePortUnreachable
+	ICMPResponseUnreachable
+)
+
+type ICMPResponse struct {
+	Kind   ICMPResponseKind
+	Marker string
+}
 
 func parseSocketICMPMessage(ipVersion int, raw []byte) (*icmp.Message, bool) {
 	protocol := 1
@@ -22,10 +39,7 @@ func parseSocketICMPMessage(ipVersion int, raw []byte) (*icmp.Message, bool) {
 	return rm, true
 }
 
-func matchSocketICMPEchoReply(ipVersion int, rm *icmp.Message, peerIP, dstIP net.IP, echoID int) (int, bool) {
-	if peerIP == nil || !peerIP.Equal(dstIP) {
-		return 0, false
-	}
+func matchSocketICMPEchoReply(ipVersion int, rm *icmp.Message, echoID int) (int, bool) {
 	if !isSocketICMPEchoReply(ipVersion, rm) {
 		return 0, false
 	}
@@ -34,6 +48,117 @@ func matchSocketICMPEchoReply(ipVersion int, rm *icmp.Message, peerIP, dstIP net
 		return 0, false
 	}
 	return echo.Seq, true
+}
+
+func classifySocketICMPResponse(ipVersion int, rm *icmp.Message, raw []byte) ICMPResponse {
+	if rm == nil {
+		return ICMPResponse{}
+	}
+
+	typeID, ok := icmpTypeID(rm.Type)
+	if !ok {
+		return ICMPResponse{}
+	}
+
+	info := 0
+	if ipVersion == 4 && typeID == 3 && rm.Code == 4 && len(raw) >= 8 {
+		info = int(binary.BigEndian.Uint16(raw[6:8]))
+	}
+	if body, ok := rm.Body.(*icmp.PacketTooBig); ok && body != nil {
+		info = body.MTU
+	}
+	return classifyICMPResponse(ipVersion, typeID, rm.Code, info)
+}
+
+func classifyICMPResponse(ipVersion, typeID, code, info int) ICMPResponse {
+	response := ICMPResponse{}
+	switch ipVersion {
+	case 4:
+		switch {
+		case typeID == 0:
+			response.Kind = ICMPResponseEchoReply
+		case typeID == 11 && code == 0:
+			response.Kind = ICMPResponseTransit
+		case typeID == 3 && code == 3:
+			response.Kind = ICMPResponsePortUnreachable
+		case typeID == 3:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = ipv4UnreachableMarker(code, info)
+		default:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
+		}
+	case 6:
+		switch {
+		case typeID == 129:
+			response.Kind = ICMPResponseEchoReply
+		case typeID == 3 && code == 0:
+			response.Kind = ICMPResponseTransit
+		case typeID == 1 && code == 4:
+			response.Kind = ICMPResponsePortUnreachable
+		case typeID == 1:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = ipv6UnreachableMarker(code)
+		case typeID == 2:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = fragmentationMarker(info)
+		default:
+			response.Kind = ICMPResponseUnreachable
+			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
+		}
+	}
+	return response
+}
+
+func icmpTypeID(messageType icmp.Type) (int, bool) {
+	switch value := messageType.(type) {
+	case ipv4.ICMPType:
+		return int(value), true
+	case ipv6.ICMPType:
+		return int(value), true
+	default:
+		return 0, false
+	}
+}
+
+func ipv4UnreachableMarker(code, info int) string {
+	switch code {
+	case 0, 6, 8, 11:
+		return "!N"
+	case 1, 7, 12:
+		return "!H"
+	case 2:
+		return "!P"
+	case 4:
+		return fragmentationMarker(info)
+	case 5:
+		return "!S"
+	case 9, 10, 13:
+		return "!X"
+	case 14:
+		return "!V"
+	case 15:
+		return "!C"
+	default:
+		return fmt.Sprintf("!<%d>", code)
+	}
+}
+
+func ipv6UnreachableMarker(code int) string {
+	switch code {
+	case 0:
+		return "!N"
+	case 1:
+		return "!X"
+	case 2, 3:
+		return "!H"
+	default:
+		return fmt.Sprintf("!<%d>", code)
+	}
+}
+
+func fragmentationMarker(mtu int) string {
+	return fmt.Sprintf("!F-%d", mtu)
 }
 
 func isSocketICMPEchoReply(ipVersion int, rm *icmp.Message) bool {
@@ -74,6 +199,9 @@ func extractSocketICMPv4Body(rm *icmp.Message) ([]byte, bool) {
 	case ipv4.ICMPTypeDestinationUnreachable:
 		body, ok := rm.Body.(*icmp.DstUnreach)
 		return icmpDstUnreachData(body, ok)
+	case ipv4.ICMPTypeParameterProblem:
+		body, ok := rm.Body.(*icmp.ParamProb)
+		return icmpParamProbData(body, ok)
 	default:
 		return nil, false
 	}
@@ -90,6 +218,9 @@ func extractSocketICMPv6Body(rm *icmp.Message) ([]byte, bool) {
 	case ipv6.ICMPTypeDestinationUnreachable:
 		body, ok := rm.Body.(*icmp.DstUnreach)
 		return icmpDstUnreachData(body, ok)
+	case ipv6.ICMPTypeParameterProblem:
+		body, ok := rm.Body.(*icmp.ParamProb)
+		return icmpParamProbData(body, ok)
 	default:
 		return nil, false
 	}
@@ -110,6 +241,13 @@ func icmpDstUnreachData(body *icmp.DstUnreach, ok bool) ([]byte, bool) {
 }
 
 func icmpPacketTooBigData(body *icmp.PacketTooBig, ok bool) ([]byte, bool) {
+	if !ok || body == nil {
+		return nil, false
+	}
+	return body.Data, true
+}
+
+func icmpParamProbData(body *icmp.ParamProb, ok bool) ([]byte, bool) {
 	if !ok || body == nil {
 		return nil, false
 	}

--- a/trace/internal/icmp_decode.go
+++ b/trace/internal/icmp_decode.go
@@ -23,8 +23,9 @@ const (
 )
 
 type ICMPResponse struct {
-	Kind   ICMPResponseKind
-	Marker string
+	Kind        ICMPResponseKind
+	Description string
+	Marker      string
 }
 
 func parseSocketICMPMessage(ipVersion int, raw []byte) (*icmp.Message, bool) {
@@ -77,34 +78,53 @@ func classifyICMPResponse(ipVersion, typeID, code, info int) ICMPResponse {
 		switch {
 		case typeID == 0:
 			response.Kind = ICMPResponseEchoReply
-		case typeID == 11 && code == 0:
+			response.Description = "ICMP Echo Reply"
+		case typeID == 11:
 			response.Kind = ICMPResponseTransit
+			response.Description = "ICMP Time Exceeded"
 		case typeID == 3 && code == 3:
 			response.Kind = ICMPResponsePortUnreachable
+			response.Description = "ICMP Port Unreachable"
 		case typeID == 3:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = ipv4UnreachableMarker(code, info)
+			response.Description = ipv4UnreachableDescription(code, info)
+		case typeID == 12:
+			response.Kind = ICMPResponseUnreachable
+			response.Description = "ICMP Parameter Problem"
+			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
 		default:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
+			response.Description = fmt.Sprintf("ICMP Type %d Code %d", typeID, code)
 		}
 	case 6:
 		switch {
 		case typeID == 129:
 			response.Kind = ICMPResponseEchoReply
-		case typeID == 3 && code == 0:
+			response.Description = "ICMPv6 Echo Reply"
+		case typeID == 3:
 			response.Kind = ICMPResponseTransit
+			response.Description = "ICMPv6 Time Exceeded"
 		case typeID == 1 && code == 4:
 			response.Kind = ICMPResponsePortUnreachable
+			response.Description = "ICMPv6 Port Unreachable"
 		case typeID == 1:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = ipv6UnreachableMarker(code)
+			response.Description = ipv6UnreachableDescription(code)
 		case typeID == 2:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = fragmentationMarker(info)
+			response.Description = "ICMPv6 Packet Too Big"
+		case typeID == 4:
+			response.Kind = ICMPResponseUnreachable
+			response.Description = "ICMPv6 Parameter Problem"
+			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
 		default:
 			response.Kind = ICMPResponseUnreachable
 			response.Marker = fmt.Sprintf("!<%d-%d>", typeID, code)
+			response.Description = fmt.Sprintf("ICMPv6 Type %d Code %d", typeID, code)
 		}
 	}
 	return response
@@ -144,6 +164,29 @@ func ipv4UnreachableMarker(code, info int) string {
 	}
 }
 
+func ipv4UnreachableDescription(code, info int) string {
+	switch code {
+	case 0, 6, 8, 11:
+		return "ICMP Network Unreachable"
+	case 1, 7, 12:
+		return "ICMP Host Unreachable"
+	case 2:
+		return "ICMP Protocol Unreachable"
+	case 4:
+		return fmt.Sprintf("ICMP Fragmentation Needed (MTU %d)", info)
+	case 5:
+		return "ICMP Source Route Failed"
+	case 9, 10, 13:
+		return "ICMP Administratively Prohibited"
+	case 14:
+		return "ICMP Host Precedence Violation"
+	case 15:
+		return "ICMP Precedence Cutoff"
+	default:
+		return fmt.Sprintf("ICMP Destination Unreachable (Code %d)", code)
+	}
+}
+
 func ipv6UnreachableMarker(code int) string {
 	switch code {
 	case 0:
@@ -154,6 +197,19 @@ func ipv6UnreachableMarker(code int) string {
 		return "!H"
 	default:
 		return fmt.Sprintf("!<%d>", code)
+	}
+}
+
+func ipv6UnreachableDescription(code int) string {
+	switch code {
+	case 0:
+		return "ICMPv6 No Route to Destination"
+	case 1:
+		return "ICMPv6 Administratively Prohibited"
+	case 2, 3:
+		return "ICMPv6 Address Unreachable"
+	default:
+		return fmt.Sprintf("ICMPv6 Destination Unreachable (Code %d)", code)
 	}
 }
 

--- a/trace/internal/icmp_decode_test.go
+++ b/trace/internal/icmp_decode_test.go
@@ -39,6 +39,7 @@ func buildIPv6InnerPacket(dstIP net.IP, echoID, seq int) []byte {
 }
 
 func TestMatchSocketICMPEchoReplyIPv4(t *testing.T) {
+	dstIP := net.ParseIP("192.0.2.1")
 	raw := mustMarshalICMP(t, icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
 		Code: 0,
@@ -49,13 +50,14 @@ func TestMatchSocketICMPEchoReplyIPv4(t *testing.T) {
 	if !ok {
 		t.Fatalf("parseSocketICMPMessage() ok = false")
 	}
-	seq, ok := matchSocketICMPEchoReply(4, rm, 7)
+	seq, ok := matchSocketICMPEchoReply(4, rm, 7, &net.IPAddr{IP: dstIP}, dstIP)
 	if !ok || seq != 11 {
 		t.Fatalf("matchSocketICMPEchoReply() = (%d, %v), want (11, true)", seq, ok)
 	}
 }
 
 func TestMatchSocketICMPEchoReplyIPv6(t *testing.T) {
+	dstIP := net.ParseIP("2001:db8::1")
 	raw := mustMarshalICMP(t, icmp.Message{
 		Type: ipv6.ICMPTypeEchoReply,
 		Code: 0,
@@ -66,13 +68,13 @@ func TestMatchSocketICMPEchoReplyIPv6(t *testing.T) {
 	if !ok {
 		t.Fatalf("parseSocketICMPMessage() ok = false")
 	}
-	seq, ok := matchSocketICMPEchoReply(6, rm, 9)
+	seq, ok := matchSocketICMPEchoReply(6, rm, 9, &net.IPAddr{IP: dstIP}, dstIP)
 	if !ok || seq != 21 {
 		t.Fatalf("matchSocketICMPEchoReply() = (%d, %v), want (21, true)", seq, ok)
 	}
 }
 
-func TestDecodeICMPSocketEchoReplyDoesNotRequireDestinationSourceIP(t *testing.T) {
+func TestDecodeICMPSocketEchoReplyRejectsNonDestinationSourceIP(t *testing.T) {
 	raw := mustMarshalICMP(t, icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
 		Code: 0,
@@ -83,12 +85,76 @@ func TestDecodeICMPSocketEchoReplyDoesNotRequireDestinationSourceIP(t *testing.T
 		EchoID:    7,
 		DstIP:     net.ParseIP("192.0.2.1"),
 	}
-	_, seq, response, ok := spec.decodeICMPSocketMessage(ReceivedMessage{
+	_, _, _, ok := spec.decodeICMPSocketMessage(ReceivedMessage{
 		Peer: &net.IPAddr{IP: net.ParseIP("192.0.2.2")},
 		Msg:  raw,
 	})
-	if !ok || seq != 11 || response.Kind != ICMPResponseEchoReply {
-		t.Fatalf("decodeICMPSocketMessage() = (_, %d, %#v, %v), want (_, 11, EchoReply, true)", seq, response, ok)
+	if ok {
+		t.Fatal("decodeICMPSocketMessage() ok = true, want false for non-destination Echo Reply source")
+	}
+}
+
+func TestDecodeICMPSocketErrorAllowsAlternateOuterSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		ipVersion int
+		dstIP     net.IP
+		peerIP    net.IP
+		echoID    int
+		seq       int
+		message   icmp.Message
+	}{
+		{
+			name:      "IPv4",
+			ipVersion: 4,
+			dstIP:     net.ParseIP("192.0.2.1"),
+			peerIP:    net.ParseIP("198.51.100.1"),
+			echoID:    7,
+			seq:       11,
+			message: icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 0, Body: &icmp.TimeExceeded{
+				Data: buildIPv4InnerPacket(net.ParseIP("192.0.2.1"), 7, 11),
+			}},
+		},
+		{
+			name:      "IPv6",
+			ipVersion: 6,
+			dstIP:     net.ParseIP("2001:db8::1"),
+			peerIP:    net.ParseIP("2001:db8::ffff"),
+			echoID:    9,
+			seq:       21,
+			message: icmp.Message{Type: ipv6.ICMPTypeTimeExceeded, Code: 0, Body: &icmp.TimeExceeded{
+				Data: buildIPv6InnerPacket(net.ParseIP("2001:db8::1"), 9, 21),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &ICMPSpec{IPVersion: tt.ipVersion, EchoID: tt.echoID, DstIP: tt.dstIP}
+			_, seq, response, ok := spec.decodeICMPSocketMessage(ReceivedMessage{
+				Peer: &net.IPAddr{IP: tt.peerIP},
+				Msg:  mustMarshalICMP(t, tt.message),
+			})
+			if !ok || seq != tt.seq || response.Kind != ICMPResponseTransit {
+				t.Fatalf("decodeICMPSocketMessage() = (_, %d, %#v, %v), want (_, %d, Transit, true)", seq, response, ok, tt.seq)
+			}
+		})
+	}
+}
+
+func TestDecodeICMPSocketErrorRejectsWrongEmbeddedIdentifier(t *testing.T) {
+	dstIP := net.ParseIP("192.0.2.1")
+	raw := mustMarshalICMP(t, icmp.Message{
+		Type: ipv4.ICMPTypeTimeExceeded,
+		Code: 0,
+		Body: &icmp.TimeExceeded{Data: buildIPv4InnerPacket(dstIP, 8, 11)},
+	})
+	spec := &ICMPSpec{IPVersion: 4, EchoID: 7, DstIP: dstIP}
+	if _, _, _, ok := spec.decodeICMPSocketMessage(ReceivedMessage{
+		Peer: &net.IPAddr{IP: net.ParseIP("198.51.100.1")},
+		Msg:  raw,
+	}); ok {
+		t.Fatal("decodeICMPSocketMessage() ok = true, want false for wrong embedded Echo ID")
 	}
 }
 
@@ -109,11 +175,20 @@ func TestClassifySocketICMPResponse(t *testing.T) {
 			wantDetail: "ICMP Time Exceeded",
 		},
 		{
-			name:       "IPv4 fragment reassembly transit",
+			name:       "IPv4 fragment reassembly timeout",
 			ipVersion:  4,
 			message:    icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 1, Body: &icmp.TimeExceeded{}},
-			wantKind:   ICMPResponseTransit,
-			wantDetail: "ICMP Time Exceeded",
+			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMP Fragment Reassembly Time Exceeded",
+			wantMarker: "!<11-1>",
+		},
+		{
+			name:       "IPv4 unknown time exceeded code",
+			ipVersion:  4,
+			message:    icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 2, Body: &icmp.TimeExceeded{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMP Time Exceeded (Code 2)",
+			wantMarker: "!<11-2>",
 		},
 		{
 			name:       "IPv4 host unreachable",
@@ -129,6 +204,15 @@ func TestClassifySocketICMPResponse(t *testing.T) {
 			message:    icmp.Message{Type: ipv4.ICMPTypeDestinationUnreachable, Code: 3, Body: &icmp.DstUnreach{}},
 			wantKind:   ICMPResponsePortUnreachable,
 			wantDetail: "ICMP Port Unreachable",
+			wantMarker: "!<3-3>",
+		},
+		{
+			name:       "IPv6 port unreachable",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeDestinationUnreachable, Code: 4, Body: &icmp.DstUnreach{}},
+			wantKind:   ICMPResponsePortUnreachable,
+			wantDetail: "ICMPv6 Port Unreachable",
+			wantMarker: "!<1-4>",
 		},
 		{
 			name:       "IPv6 administratively prohibited",
@@ -139,11 +223,43 @@ func TestClassifySocketICMPResponse(t *testing.T) {
 			wantMarker: "!X",
 		},
 		{
-			name:       "IPv6 fragment reassembly transit",
+			name:       "IPv6 transit",
 			ipVersion:  6,
-			message:    icmp.Message{Type: ipv6.ICMPTypeTimeExceeded, Code: 1, Body: &icmp.TimeExceeded{}},
+			message:    icmp.Message{Type: ipv6.ICMPTypeTimeExceeded, Code: 0, Body: &icmp.TimeExceeded{}},
 			wantKind:   ICMPResponseTransit,
 			wantDetail: "ICMPv6 Time Exceeded",
+		},
+		{
+			name:       "IPv6 fragment reassembly timeout",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeTimeExceeded, Code: 1, Body: &icmp.TimeExceeded{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMPv6 Fragment Reassembly Time Exceeded",
+			wantMarker: "!<3-1>",
+		},
+		{
+			name:       "IPv6 unknown time exceeded code",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeTimeExceeded, Code: 2, Body: &icmp.TimeExceeded{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMPv6 Time Exceeded (Code 2)",
+			wantMarker: "!<3-2>",
+		},
+		{
+			name:       "IPv6 beyond scope",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeDestinationUnreachable, Code: 2, Body: &icmp.DstUnreach{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMPv6 Beyond Scope of Source Address",
+			wantMarker: "!H",
+		},
+		{
+			name:       "IPv6 address unreachable",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeDestinationUnreachable, Code: 3, Body: &icmp.DstUnreach{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMPv6 Address Unreachable",
+			wantMarker: "!H",
 		},
 		{
 			name:       "IPv6 packet too big",

--- a/trace/internal/icmp_decode_test.go
+++ b/trace/internal/icmp_decode_test.go
@@ -98,39 +98,59 @@ func TestClassifySocketICMPResponse(t *testing.T) {
 		ipVersion  int
 		message    icmp.Message
 		wantKind   ICMPResponseKind
+		wantDetail string
 		wantMarker string
 	}{
 		{
-			name:      "IPv4 transit",
-			ipVersion: 4,
-			message:   icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 0, Body: &icmp.TimeExceeded{}},
-			wantKind:  ICMPResponseTransit,
+			name:       "IPv4 transit",
+			ipVersion:  4,
+			message:    icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 0, Body: &icmp.TimeExceeded{}},
+			wantKind:   ICMPResponseTransit,
+			wantDetail: "ICMP Time Exceeded",
+		},
+		{
+			name:       "IPv4 fragment reassembly transit",
+			ipVersion:  4,
+			message:    icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 1, Body: &icmp.TimeExceeded{}},
+			wantKind:   ICMPResponseTransit,
+			wantDetail: "ICMP Time Exceeded",
 		},
 		{
 			name:       "IPv4 host unreachable",
 			ipVersion:  4,
 			message:    icmp.Message{Type: ipv4.ICMPTypeDestinationUnreachable, Code: 1, Body: &icmp.DstUnreach{}},
 			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMP Host Unreachable",
 			wantMarker: "!H",
 		},
 		{
-			name:      "IPv4 port unreachable",
-			ipVersion: 4,
-			message:   icmp.Message{Type: ipv4.ICMPTypeDestinationUnreachable, Code: 3, Body: &icmp.DstUnreach{}},
-			wantKind:  ICMPResponsePortUnreachable,
+			name:       "IPv4 port unreachable",
+			ipVersion:  4,
+			message:    icmp.Message{Type: ipv4.ICMPTypeDestinationUnreachable, Code: 3, Body: &icmp.DstUnreach{}},
+			wantKind:   ICMPResponsePortUnreachable,
+			wantDetail: "ICMP Port Unreachable",
 		},
 		{
 			name:       "IPv6 administratively prohibited",
 			ipVersion:  6,
 			message:    icmp.Message{Type: ipv6.ICMPTypeDestinationUnreachable, Code: 1, Body: &icmp.DstUnreach{}},
 			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMPv6 Administratively Prohibited",
 			wantMarker: "!X",
+		},
+		{
+			name:       "IPv6 fragment reassembly transit",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeTimeExceeded, Code: 1, Body: &icmp.TimeExceeded{}},
+			wantKind:   ICMPResponseTransit,
+			wantDetail: "ICMPv6 Time Exceeded",
 		},
 		{
 			name:       "IPv6 packet too big",
 			ipVersion:  6,
 			message:    icmp.Message{Type: ipv6.ICMPTypePacketTooBig, Code: 0, Body: &icmp.PacketTooBig{MTU: 1280}},
 			wantKind:   ICMPResponseUnreachable,
+			wantDetail: "ICMPv6 Packet Too Big",
 			wantMarker: "!F-1280",
 		},
 	}
@@ -143,8 +163,8 @@ func TestClassifySocketICMPResponse(t *testing.T) {
 				t.Fatalf("parseSocketICMPMessage() ok = false")
 			}
 			got := classifySocketICMPResponse(tt.ipVersion, rm, raw)
-			if got.Kind != tt.wantKind || got.Marker != tt.wantMarker {
-				t.Fatalf("classifySocketICMPResponse() = (%v, %q), want (%v, %q)", got.Kind, got.Marker, tt.wantKind, tt.wantMarker)
+			if got.Kind != tt.wantKind || got.Description != tt.wantDetail || got.Marker != tt.wantMarker {
+				t.Fatalf("classifySocketICMPResponse() = (%v, %q, %q), want (%v, %q, %q)", got.Kind, got.Description, got.Marker, tt.wantKind, tt.wantDetail, tt.wantMarker)
 			}
 		})
 	}

--- a/trace/internal/icmp_decode_test.go
+++ b/trace/internal/icmp_decode_test.go
@@ -39,7 +39,6 @@ func buildIPv6InnerPacket(dstIP net.IP, echoID, seq int) []byte {
 }
 
 func TestMatchSocketICMPEchoReplyIPv4(t *testing.T) {
-	dstIP := net.ParseIP("1.1.1.1")
 	raw := mustMarshalICMP(t, icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
 		Code: 0,
@@ -50,14 +49,13 @@ func TestMatchSocketICMPEchoReplyIPv4(t *testing.T) {
 	if !ok {
 		t.Fatalf("parseSocketICMPMessage() ok = false")
 	}
-	seq, ok := matchSocketICMPEchoReply(4, rm, dstIP, dstIP, 7)
+	seq, ok := matchSocketICMPEchoReply(4, rm, 7)
 	if !ok || seq != 11 {
 		t.Fatalf("matchSocketICMPEchoReply() = (%d, %v), want (11, true)", seq, ok)
 	}
 }
 
 func TestMatchSocketICMPEchoReplyIPv6(t *testing.T) {
-	dstIP := net.ParseIP("2001:db8::1")
 	raw := mustMarshalICMP(t, icmp.Message{
 		Type: ipv6.ICMPTypeEchoReply,
 		Code: 0,
@@ -68,9 +66,87 @@ func TestMatchSocketICMPEchoReplyIPv6(t *testing.T) {
 	if !ok {
 		t.Fatalf("parseSocketICMPMessage() ok = false")
 	}
-	seq, ok := matchSocketICMPEchoReply(6, rm, dstIP, dstIP, 9)
+	seq, ok := matchSocketICMPEchoReply(6, rm, 9)
 	if !ok || seq != 21 {
 		t.Fatalf("matchSocketICMPEchoReply() = (%d, %v), want (21, true)", seq, ok)
+	}
+}
+
+func TestDecodeICMPSocketEchoReplyDoesNotRequireDestinationSourceIP(t *testing.T) {
+	raw := mustMarshalICMP(t, icmp.Message{
+		Type: ipv4.ICMPTypeEchoReply,
+		Code: 0,
+		Body: &icmp.Echo{ID: 7, Seq: 11},
+	})
+	spec := &ICMPSpec{
+		IPVersion: 4,
+		EchoID:    7,
+		DstIP:     net.ParseIP("192.0.2.1"),
+	}
+	_, seq, response, ok := spec.decodeICMPSocketMessage(ReceivedMessage{
+		Peer: &net.IPAddr{IP: net.ParseIP("192.0.2.2")},
+		Msg:  raw,
+	})
+	if !ok || seq != 11 || response.Kind != ICMPResponseEchoReply {
+		t.Fatalf("decodeICMPSocketMessage() = (_, %d, %#v, %v), want (_, 11, EchoReply, true)", seq, response, ok)
+	}
+}
+
+func TestClassifySocketICMPResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		ipVersion  int
+		message    icmp.Message
+		wantKind   ICMPResponseKind
+		wantMarker string
+	}{
+		{
+			name:      "IPv4 transit",
+			ipVersion: 4,
+			message:   icmp.Message{Type: ipv4.ICMPTypeTimeExceeded, Code: 0, Body: &icmp.TimeExceeded{}},
+			wantKind:  ICMPResponseTransit,
+		},
+		{
+			name:       "IPv4 host unreachable",
+			ipVersion:  4,
+			message:    icmp.Message{Type: ipv4.ICMPTypeDestinationUnreachable, Code: 1, Body: &icmp.DstUnreach{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantMarker: "!H",
+		},
+		{
+			name:      "IPv4 port unreachable",
+			ipVersion: 4,
+			message:   icmp.Message{Type: ipv4.ICMPTypeDestinationUnreachable, Code: 3, Body: &icmp.DstUnreach{}},
+			wantKind:  ICMPResponsePortUnreachable,
+		},
+		{
+			name:       "IPv6 administratively prohibited",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypeDestinationUnreachable, Code: 1, Body: &icmp.DstUnreach{}},
+			wantKind:   ICMPResponseUnreachable,
+			wantMarker: "!X",
+		},
+		{
+			name:       "IPv6 packet too big",
+			ipVersion:  6,
+			message:    icmp.Message{Type: ipv6.ICMPTypePacketTooBig, Code: 0, Body: &icmp.PacketTooBig{MTU: 1280}},
+			wantKind:   ICMPResponseUnreachable,
+			wantMarker: "!F-1280",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := mustMarshalICMP(t, tt.message)
+			rm, ok := parseSocketICMPMessage(tt.ipVersion, raw)
+			if !ok {
+				t.Fatalf("parseSocketICMPMessage() ok = false")
+			}
+			got := classifySocketICMPResponse(tt.ipVersion, rm, raw)
+			if got.Kind != tt.wantKind || got.Marker != tt.wantMarker {
+				t.Fatalf("classifySocketICMPResponse() = (%v, %q), want (%v, %q)", got.Kind, got.Marker, tt.wantKind, tt.wantMarker)
+			}
+		})
 	}
 }
 

--- a/trace/internal/icmp_windows.go
+++ b/trace/internal/icmp_windows.go
@@ -121,7 +121,7 @@ func (s *ICMPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{},
 		}
 
 		msg := packet.message()
-		if seq, ok := packet.echoReplyFor(s.EchoID); ok {
+		if seq, ok := packet.echoReplyFor(s.EchoID, s.DstIP); ok {
 			onICMP(msg, finish, seq)
 			continue
 		}

--- a/trace/internal/icmp_windows.go
+++ b/trace/internal/icmp_windows.go
@@ -121,7 +121,7 @@ func (s *ICMPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{},
 		}
 
 		msg := packet.message()
-		if seq, ok := packet.echoReplyFor(s.DstIP, s.EchoID); ok {
+		if seq, ok := packet.echoReplyFor(s.EchoID); ok {
 			onICMP(msg, finish, seq)
 			continue
 		}

--- a/trace/internal/packet_listener.go
+++ b/trace/internal/packet_listener.go
@@ -11,6 +11,7 @@ type ReceivedMessage struct {
 	Peer net.Addr
 	Msg  []byte
 	Err  error
+	ICMP ICMPResponse
 }
 
 // PacketListener 负责监听网络数据包并通过通道传递接收到的消息

--- a/trace/internal/tcp_common.go
+++ b/trace/internal/tcp_common.go
@@ -43,25 +43,26 @@ func (s *TCPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICM
 			if !ok {
 				return
 			}
-			finish, data, ok := s.decodeICMPSocketMessage(msg)
+			finish, data, response, ok := s.decodeICMPSocketMessage(msg)
 			if ok {
+				msg.ICMP = response
 				onICMP(msg, finish, data)
 			}
 		}
 	}
 }
 
-func (s *TCPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, []byte, bool) {
+func (s *TCPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, []byte, ICMPResponse, bool) {
 	if msg.Err != nil {
-		return time.Time{}, nil, false
+		return time.Time{}, nil, ICMPResponse{}, false
 	}
 
 	finish := time.Now()
 	rm, ok := parseSocketICMPMessage(s.IPVersion, msg.Msg)
 	if !ok {
-		return finish, nil, false
+		return finish, nil, ICMPResponse{}, false
 	}
 
 	data, ok := extractSocketICMPPayload(s.IPVersion, rm, s.DstIP)
-	return finish, data, ok
+	return finish, data, classifySocketICMPResponse(s.IPVersion, rm, msg.Msg), ok
 }

--- a/trace/internal/tcp_darwin.go
+++ b/trace/internal/tcp_darwin.go
@@ -87,8 +87,8 @@ func (s *TCPSpec) captureDevice() string {
 
 func (s *TCPSpec) tcpCaptureFilter() string {
 	return fmt.Sprintf(
-		"%s and tcp and src host %s and dst host %s and src port %d",
-		tcpIPVersionPrefix(s.IPVersion), s.DstIP.String(), s.SrcIP.String(), s.DstPort,
+		"%s and tcp and dst host %s and src port %d",
+		tcpIPVersionPrefix(s.IPVersion), s.SrcIP.String(), s.DstPort,
 	)
 }
 

--- a/trace/internal/tcp_darwin_test.go
+++ b/trace/internal/tcp_darwin_test.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package internal
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDarwinTCPCaptureFilterAllowsAlternateRemoteSource(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *TCPSpec
+		want string
+	}{
+		{
+			name: "IPv4",
+			spec: &TCPSpec{
+				IPVersion: 4,
+				SrcIP:     net.ParseIP("192.0.2.10"),
+				DstIP:     net.ParseIP("198.51.100.20"),
+				DstPort:   443,
+			},
+			want: "ip and tcp and dst host 192.0.2.10 and src port 443",
+		},
+		{
+			name: "IPv6",
+			spec: &TCPSpec{
+				IPVersion: 6,
+				SrcIP:     net.ParseIP("2001:db8::10"),
+				DstIP:     net.ParseIP("2001:db8::20"),
+				DstPort:   8443,
+			},
+			want: "ip6 and tcp and dst host 2001:db8::10 and src port 8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.spec.tcpCaptureFilter(); got != tt.want {
+				t.Fatalf("tcpCaptureFilter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/trace/internal/tcp_probe_decode.go
+++ b/trace/internal/tcp_probe_decode.go
@@ -19,9 +19,11 @@ func tcpProbeReply(tcp *layers.TCP) (seq int, ack int, ok bool) {
 		return 0, 0, false
 	}
 	if tcp.ACK && tcp.RST {
+		// A non-zero ack tells the caller this was a RST/ACK response.
 		return 0, int(tcp.Ack), true
 	}
 	if tcp.ACK && tcp.SYN {
+		// A zero ack return value tells the caller this was a SYN/ACK response.
 		return int(tcp.Ack) - 1, 0, true
 	}
 	return 0, 0, false

--- a/trace/internal/tcp_unix.go
+++ b/trace/internal/tcp_unix.go
@@ -93,10 +93,6 @@ func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func
 			}
 			finish := time.Now()
 
-			if ip := util.AddrIP(msg.Peer); ip == nil || !ip.Equal(s.DstIP) {
-				continue
-			}
-
 			// 解包
 			packet := gopacket.NewPacket(msg.Msg, layers.LayerTypeTCP, gopacket.Default)
 			if packet.ErrorLayer() != nil {

--- a/trace/internal/tcp_windows.go
+++ b/trace/internal/tcp_windows.go
@@ -128,7 +128,7 @@ func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func
 
 	sniffHandle, closeHandleTCP := openWinDivertSniffHandle(
 		ctx,
-		winDivertTCPFilter(s.IPVersion, s.DstIP, s.SrcIP, s.DstPort),
+		winDivertTCPFilter(s.IPVersion, s.SrcIP, s.DstPort),
 		"ListenTCP",
 	)
 	defer closeHandleTCP()

--- a/trace/internal/udp_common.go
+++ b/trace/internal/udp_common.go
@@ -43,25 +43,26 @@ func (s *UDPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICM
 			if !ok {
 				return
 			}
-			finish, data, ok := s.decodeICMPSocketMessage(msg)
+			finish, data, response, ok := s.decodeICMPSocketMessage(msg)
 			if ok {
+				msg.ICMP = response
 				onICMP(msg, finish, data)
 			}
 		}
 	}
 }
 
-func (s *UDPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, []byte, bool) {
+func (s *UDPSpec) decodeICMPSocketMessage(msg ReceivedMessage) (time.Time, []byte, ICMPResponse, bool) {
 	if msg.Err != nil {
-		return time.Time{}, nil, false
+		return time.Time{}, nil, ICMPResponse{}, false
 	}
 
 	finish := time.Now()
 	rm, ok := parseSocketICMPMessage(s.IPVersion, msg.Msg)
 	if !ok {
-		return finish, nil, false
+		return finish, nil, ICMPResponse{}, false
 	}
 
 	data, ok := extractSocketICMPPayload(s.IPVersion, rm, s.DstIP)
-	return finish, data, ok
+	return finish, data, classifySocketICMPResponse(s.IPVersion, rm, msg.Msg), ok
 }

--- a/trace/internal/windivert_sniff_windows.go
+++ b/trace/internal/windivert_sniff_windows.go
@@ -4,6 +4,7 @@ package internal
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"log"
 	"net"
@@ -21,6 +22,7 @@ type winDivertICMPPacket struct {
 	peerIP    net.IP
 	outer     []byte
 	errorData []byte
+	response  ICMPResponse
 	echoID    int
 	echoSeq   int
 	echoReply bool
@@ -132,6 +134,7 @@ func decodeWinDivertICMPv4Packet(pkt gopacket.Packet, raw []byte) (*winDivertICM
 		ipVersion: 4,
 		peerIP:    ip4.SrcIP,
 		outer:     raw,
+		response:  classifyICMPResponse(4, int(ic4.TypeCode.Type()), int(ic4.TypeCode.Code()), int(ic4.Seq)),
 	}
 
 	switch ic4.TypeCode.Type() {
@@ -140,7 +143,7 @@ func decodeWinDivertICMPv4Packet(pkt gopacket.Packet, raw []byte) (*winDivertICM
 		packet.echoID = int(ic4.Id)
 		packet.echoSeq = int(ic4.Seq)
 		return packet, true
-	case layers.ICMPv4TypeTimeExceeded, layers.ICMPv4TypeDestinationUnreachable:
+	case layers.ICMPv4TypeTimeExceeded, layers.ICMPv4TypeDestinationUnreachable, layers.ICMPv4TypeParameterProblem:
 		packet.errorData = ic4.Payload
 		return packet, true
 	default:
@@ -162,6 +165,7 @@ func decodeWinDivertICMPv6Packet(pkt gopacket.Packet, raw []byte) (*winDivertICM
 		ipVersion: 6,
 		peerIP:    ip6.SrcIP,
 		outer:     raw,
+		response:  classifyICMPResponse(6, int(ic6.TypeCode.Type()), int(ic6.TypeCode.Code()), 0),
 	}
 
 	switch ic6.TypeCode.Type() {
@@ -174,7 +178,10 @@ func decodeWinDivertICMPv6Packet(pkt gopacket.Packet, raw []byte) (*winDivertICM
 		packet.echoID = int(echo.Identifier)
 		packet.echoSeq = int(echo.SeqNumber)
 		return packet, true
-	case layers.ICMPv6TypeTimeExceeded, layers.ICMPv6TypePacketTooBig, layers.ICMPv6TypeDestinationUnreachable:
+	case layers.ICMPv6TypeTimeExceeded, layers.ICMPv6TypePacketTooBig, layers.ICMPv6TypeDestinationUnreachable, layers.ICMPv6TypeParameterProblem:
+		if ic6.TypeCode.Type() == layers.ICMPv6TypePacketTooBig {
+			packet.response = classifyICMPResponse(6, int(ic6.TypeCode.Type()), int(ic6.TypeCode.Code()), int(binary.BigEndian.Uint32(ic6.Payload[:4])))
+		}
 		packet.errorData = ic6.Payload[4:]
 		return packet, true
 	default:
@@ -186,11 +193,12 @@ func (p *winDivertICMPPacket) message() ReceivedMessage {
 	return ReceivedMessage{
 		Peer: &net.IPAddr{IP: p.peerIP},
 		Msg:  p.outer,
+		ICMP: p.response,
 	}
 }
 
-func (p *winDivertICMPPacket) echoReplyFor(dstIP net.IP, echoID int) (int, bool) {
-	if !p.echoReply || !p.peerIP.Equal(dstIP) || p.echoID != echoID {
+func (p *winDivertICMPPacket) echoReplyFor(echoID int) (int, bool) {
+	if !p.echoReply || p.echoID != echoID {
 		return 0, false
 	}
 	return p.echoSeq, true

--- a/trace/internal/windivert_sniff_windows.go
+++ b/trace/internal/windivert_sniff_windows.go
@@ -41,16 +41,16 @@ func winDivertICMPFilter(ipVersion int, srcIP net.IP) string {
 	return fmt.Sprintf("inbound and icmpv6 and ipv6.DstAddr == %s", srcIP.String())
 }
 
-func winDivertTCPFilter(ipVersion int, dstIP, srcIP net.IP, dstPort int) string {
+func winDivertTCPFilter(ipVersion int, srcIP net.IP, dstPort int) string {
 	if ipVersion == 4 {
 		return fmt.Sprintf(
-			"inbound and tcp and ip.SrcAddr == %s and ip.DstAddr == %s and tcp.SrcPort == %d",
-			dstIP.String(), srcIP.String(), dstPort,
+			"inbound and tcp and ip.DstAddr == %s and tcp.SrcPort == %d",
+			srcIP.String(), dstPort,
 		)
 	}
 	return fmt.Sprintf(
-		"inbound and tcp and ipv6.SrcAddr == %s and ipv6.DstAddr == %s and tcp.SrcPort == %d",
-		dstIP.String(), srcIP.String(), dstPort,
+		"inbound and tcp and ipv6.DstAddr == %s and tcp.SrcPort == %d",
+		srcIP.String(), dstPort,
 	)
 }
 
@@ -197,8 +197,8 @@ func (p *winDivertICMPPacket) message() ReceivedMessage {
 	}
 }
 
-func (p *winDivertICMPPacket) echoReplyFor(echoID int) (int, bool) {
-	if !p.echoReply || p.echoID != echoID {
+func (p *winDivertICMPPacket) echoReplyFor(echoID int, dstIP net.IP) (int, bool) {
+	if !p.echoReply || p.echoID != echoID || !p.peerIP.Equal(dstIP) {
 		return 0, false
 	}
 	return p.echoSeq, true

--- a/trace/internal/windivert_sniff_windows_test.go
+++ b/trace/internal/windivert_sniff_windows_test.go
@@ -6,12 +6,80 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 
 	wd "github.com/xjasonlyu/windivert-go"
 	"golang.org/x/sys/windows"
 )
+
+func TestWinDivertTCPFilterAllowsAlternateRemoteSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		ipVersion int
+		srcIP     net.IP
+		port      int
+		want      string
+	}{
+		{
+			name:      "IPv4",
+			ipVersion: 4,
+			srcIP:     net.ParseIP("192.0.2.10"),
+			port:      443,
+			want:      "inbound and tcp and ip.DstAddr == 192.0.2.10 and tcp.SrcPort == 443",
+		},
+		{
+			name:      "IPv6",
+			ipVersion: 6,
+			srcIP:     net.ParseIP("2001:db8::10"),
+			port:      8443,
+			want:      "inbound and tcp and ipv6.DstAddr == 2001:db8::10 and tcp.SrcPort == 8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := winDivertTCPFilter(tt.ipVersion, tt.srcIP, tt.port); got != tt.want {
+				t.Fatalf("winDivertTCPFilter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWinDivertEchoReplyRequiresDestinationSource(t *testing.T) {
+	dstIP := net.ParseIP("2001:db8::1")
+	packet := &winDivertICMPPacket{
+		peerIP:    dstIP,
+		echoReply: true,
+		echoID:    7,
+		echoSeq:   11,
+	}
+	if seq, ok := packet.echoReplyFor(7, dstIP); !ok || seq != 11 {
+		t.Fatalf("echoReplyFor() = (%d, %v), want (11, true)", seq, ok)
+	}
+
+	packet.peerIP = net.ParseIP("2001:db8::2")
+	if _, ok := packet.echoReplyFor(7, dstIP); ok {
+		t.Fatal("echoReplyFor() ok = true, want false for non-destination source")
+	}
+}
+
+func TestWinDivertICMPErrorAllowsAlternateOuterSource(t *testing.T) {
+	dstIP := net.ParseIP("192.0.2.1")
+	packet := &winDivertICMPPacket{
+		ipVersion: 4,
+		peerIP:    net.ParseIP("198.51.100.1"),
+		errorData: buildIPv4InnerPacket(dstIP, 7, 11),
+	}
+	data, ok := packet.errorPayloadFor(dstIP)
+	if !ok {
+		t.Fatal("errorPayloadFor() ok = false, want true for alternate outer source")
+	}
+	if seq, ok := extractEmbeddedICMPSeq(data, 7); !ok || seq != 11 {
+		t.Fatalf("extractEmbeddedICMPSeq() = (%d, %v), want (11, true)", seq, ok)
+	}
+}
 
 func TestOpenWinDivertSniffHandlePanicsInDevMode(t *testing.T) {
 	oldOpen := openWinDivertSniffCall

--- a/trace/mtr_loop_runtime.go
+++ b/trace/mtr_loop_runtime.go
@@ -19,6 +19,7 @@ type mtrLoopRuntime struct {
 	iteration         int
 	consecutiveErrors int
 	backoff           time.Duration
+	pathTracker       *mtrPathTracker
 }
 
 func newMTRLoopRuntime(
@@ -37,7 +38,7 @@ func newMTRLoopRuntime(
 	if opts.ProgressThrottle <= 0 {
 		opts.ProgressThrottle = 200 * time.Millisecond
 	}
-	return &mtrLoopRuntime{
+	rt := &mtrLoopRuntime{
 		ctx:        ctx,
 		prober:     prober,
 		config:     config,
@@ -48,6 +49,8 @@ func newMTRLoopRuntime(
 		bo:         bo,
 		backoff:    bo.Initial,
 	}
+	rt.pathTracker = newMTRPathTracker(opts.MaxRounds > 0, config.MaxHops, opts.OnPathEnd)
+	return rt
 }
 
 func (rt *mtrLoopRuntime) run() error {
@@ -74,6 +77,7 @@ func (rt *mtrLoopRuntime) run() error {
 
 		rt.recordSuccess(res)
 		if rt.opts.MaxRounds > 0 && rt.iteration >= rt.opts.MaxRounds {
+			rt.pathTracker.completeAtMaxHops()
 			return nil
 		}
 		if err := rt.waitInterval(); err != nil {
@@ -92,8 +96,22 @@ func (rt *mtrLoopRuntime) snapshotContextError() error {
 
 func (rt *mtrLoopRuntime) emitSnapshot() {
 	if rt.onSnapshot != nil {
-		rt.onSnapshot(rt.iteration, rt.agg.Snapshot())
+		rt.onSnapshot(rt.iteration, rt.snapshotStats())
 	}
+}
+
+func (rt *mtrLoopRuntime) snapshotStats() []MTRHopStat {
+	return rt.decorateSnapshot(rt.agg.Snapshot())
+}
+
+func (rt *mtrLoopRuntime) decorateSnapshot(stats []MTRHopStat) []MTRHopStat {
+	if pathEnd := rt.pathTracker.pathEnd(); pathEnd != nil && pathEnd.Hop > 0 {
+		stats = filterMTRStatsAtPathEnd(stats, pathEnd.Hop)
+	}
+	for i := range stats {
+		stats[i].Response = mtrProbeResponseForStat(rt.pathTracker, stats[i])
+	}
+	return stats
 }
 
 func (rt *mtrLoopRuntime) handleReset() {
@@ -108,6 +126,7 @@ func (rt *mtrLoopRuntime) handleReset() {
 	if resetter, ok := rt.prober.(mtrResetter); ok {
 		resetter.resetFinalTTL()
 	}
+	rt.pathTracker.reset()
 }
 
 func (rt *mtrLoopRuntime) waitWhilePaused() error {
@@ -171,7 +190,7 @@ func (rt *mtrLoopRuntime) emitPreview(peeker mtrPeeker) {
 		return
 	}
 	preview := rt.agg.Clone()
-	rt.onSnapshot(rt.iteration+1, preview.Update(partial, 1))
+	rt.onSnapshot(rt.iteration+1, rt.decorateSnapshot(preview.Update(partial, 1)))
 }
 
 func (rt *mtrLoopRuntime) handleProbeError(err error) (bool, error) {
@@ -216,11 +235,22 @@ func (rt *mtrLoopRuntime) recordSuccess(res *Result) {
 	rt.consecutiveErrors = 0
 	rt.backoff = rt.bo.Initial
 	rt.iteration++
+	rt.observeResultResponses(res)
 
 	stats := rt.agg.Update(res, 1)
 	if rt.onSnapshot != nil {
-		rt.onSnapshot(rt.iteration, stats)
+		rt.onSnapshot(rt.iteration, rt.decorateSnapshot(stats))
 	}
+}
+
+func (rt *mtrLoopRuntime) observeResultResponses(res *Result) {
+	if res == nil {
+		return
+	}
+	for ttl := range res.responses {
+		rt.pathTracker.observe(ttl, bestMTRProbeResponse(res, ttl))
+	}
+	rt.pathTracker.observeStopReason(res.StopReason)
 }
 
 func (rt *mtrLoopRuntime) waitInterval() error {

--- a/trace/mtr_raw.go
+++ b/trace/mtr_raw.go
@@ -29,26 +29,29 @@ type MTRRawOptions struct {
 	// It is mainly for callers that need per-round locking or global-state setup.
 	// Legacy round-based mode only.
 	RunRound func(method Method, cfg Config) (*Result, error)
+	// OnPathEnd is called when the semantic path edge changes. nil reopens it.
+	OnPathEnd func(*StopReason)
 }
 
 // MTRRawRecord is one stream record emitted by MTR raw mode.
 // It keeps the same information family as classic --raw output.
 type MTRRawRecord struct {
-	Iteration int      `json:"iteration"`
-	TTL       int      `json:"ttl"`
-	Success   bool     `json:"success"`
-	IP        string   `json:"ip,omitempty"`
-	Host      string   `json:"host,omitempty"`
-	RTTMs     float64  `json:"rtt_ms"`
-	ASN       string   `json:"asn,omitempty"`
-	Country   string   `json:"country,omitempty"`
-	Prov      string   `json:"prov,omitempty"`
-	City      string   `json:"city,omitempty"`
-	District  string   `json:"district,omitempty"`
-	Owner     string   `json:"owner,omitempty"`
-	Lat       float64  `json:"lat"`
-	Lng       float64  `json:"lng"`
-	MPLS      []string `json:"mpls,omitempty"`
+	Iteration int               `json:"iteration"`
+	TTL       int               `json:"ttl"`
+	Success   bool              `json:"success"`
+	IP        string            `json:"ip,omitempty"`
+	Host      string            `json:"host,omitempty"`
+	RTTMs     float64           `json:"rtt_ms"`
+	ASN       string            `json:"asn,omitempty"`
+	Country   string            `json:"country,omitempty"`
+	Prov      string            `json:"prov,omitempty"`
+	City      string            `json:"city,omitempty"`
+	District  string            `json:"district,omitempty"`
+	Owner     string            `json:"owner,omitempty"`
+	Lat       float64           `json:"lat"`
+	Lng       float64           `json:"lng"`
+	MPLS      []string          `json:"mpls,omitempty"`
+	Response  *MTRProbeResponse `json:"response,omitempty"`
 }
 
 // MTRRawOnRecord is called for each probe event.
@@ -75,7 +78,6 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 	roundCfg.MaxAttempts = 1
 	roundCfg.AsyncPrinter = nil
 	roundCfg.RealtimePrinter = nil
-
 	if roundCfg.MaxHops == 0 {
 		roundCfg.MaxHops = 30
 	}
@@ -117,6 +119,7 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 		FillGeo:          true,
 		BaseConfig:       roundCfg,
 		DstIP:            roundCfg.DstIP,
+		OnPathEnd:        opts.OnPathEnd,
 	}, nil, func(result mtrProbeResult, iteration int, _ time.Time) {
 		if onRecord == nil {
 			return
@@ -138,11 +141,15 @@ func runMTRRawRoundBased(ctx context.Context, method Method, cfg Config, opts MT
 	roundCfg.MaxAttempts = 1
 	roundCfg.AsyncPrinter = nil
 	roundCfg.RealtimePrinter = nil
+	if roundCfg.MaxHops == 0 {
+		roundCfg.MaxHops = 30
+	}
 
 	runRound := opts.RunRound
 	if runRound == nil {
 		runRound = mtrRawTracerouteFn
 	}
+	pathTracker := newMTRPathTracker(opts.MaxRounds > 0, roundCfg.MaxHops, opts.OnPathEnd)
 
 	iteration := 0
 	for {
@@ -178,14 +185,16 @@ func runMTRRawRoundBased(ctx context.Context, method Method, cfg Config, opts MT
 			for i := start; i < end; i++ {
 				h := res.Hops[ttl][i]
 				rec := buildMTRRawRecord(iteration, h, cfgForRound)
+				rec.Response = bestMTRProbeResponse(res, h.TTL)
 				onRecord(rec)
 			}
 		}
 
 		done := make(chan struct{})
 		var traceErr error
+		var roundRes *Result
 		go func() {
-			_, traceErr = runRound(method, cfgForRound)
+			roundRes, traceErr = runRound(method, cfgForRound)
 			close(done)
 		}()
 
@@ -201,8 +210,15 @@ func runMTRRawRoundBased(ctx context.Context, method Method, cfg Config, opts MT
 		if traceErr != nil {
 			return traceErr
 		}
+		if roundRes != nil {
+			for ttl := range roundRes.responses {
+				pathTracker.observe(ttl, bestMTRProbeResponse(roundRes, ttl))
+			}
+			pathTracker.observeStopReason(roundRes.StopReason)
+		}
 
 		if opts.MaxRounds > 0 && iteration >= opts.MaxRounds {
+			pathTracker.completeAtMaxHops()
 			return nil
 		}
 
@@ -308,6 +324,7 @@ func newMTRRawRecord(iteration int, pr mtrProbeResult) MTRRawRecord {
 		Iteration: iteration,
 		TTL:       pr.TTL,
 		Success:   pr.Success && pr.Addr != nil,
+		Response:  cloneMTRProbeResponse(pr.Response),
 	}
 	if pr.Addr != nil {
 		rec.IP = addrToIPString(pr.Addr)

--- a/trace/mtr_raw.go
+++ b/trace/mtr_raw.go
@@ -118,7 +118,6 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 		ParallelRequests: roundCfg.ParallelRequests,
 		FillGeo:          true,
 		BaseConfig:       roundCfg,
-		DstIP:            roundCfg.DstIP,
 		OnPathEnd:        opts.OnPathEnd,
 	}, nil, func(result mtrProbeResult, iteration int, _ time.Time) {
 		if onRecord == nil {

--- a/trace/mtr_raw_test.go
+++ b/trace/mtr_raw_test.go
@@ -15,7 +15,13 @@ func TestRunMTRRaw_EmitsPerAttemptRecords(t *testing.T) {
 	t.Cleanup(func() { mtrRawTracerouteFn = old })
 
 	mtrRawTracerouteFn = func(_ Method, cfg Config) (*Result, error) {
-		res := &Result{Hops: make([][]Hop, 2)}
+		res := &Result{
+			Hops: make([][]Hop, 2),
+			responses: map[int][]probeResponse{
+				1: {{kind: probeResponseTransit, detail: "ICMP Time Exceeded"}},
+				2: {{kind: probeResponseUnreachable, detail: "ICMP Host Unreachable", marker: "!H"}},
+			},
+		}
 		res.Hops[0] = []Hop{{
 			Success:  true,
 			Address:  &net.IPAddr{IP: net.ParseIP("1.1.1.1")},
@@ -40,8 +46,8 @@ func TestRunMTRRaw_EmitsPerAttemptRecords(t *testing.T) {
 		}}
 
 		if cfg.RealtimePrinter != nil {
-			cfg.RealtimePrinter(res, 0)
-			cfg.RealtimePrinter(res, 1)
+			cfg.RealtimePrinter(res.snapshotThroughTTL(1), 0)
+			cfg.RealtimePrinter(res.snapshotThroughTTL(2), 1)
 		}
 		return res, nil
 	}
@@ -69,6 +75,12 @@ func TestRunMTRRaw_EmitsPerAttemptRecords(t *testing.T) {
 	if records[1].Success || records[1].TTL != 2 {
 		t.Fatalf("unexpected timeout record: %+v", records[1])
 	}
+	if records[0].Response == nil || records[0].Response.Kind != MTRResponseTransit {
+		t.Fatalf("first record response = %#v, want transit", records[0].Response)
+	}
+	if records[1].Response == nil || records[1].Response.Kind != MTRResponseUnreachable || records[1].Response.Marker != "!H" {
+		t.Fatalf("second record response = %#v, want unreachable !H", records[1].Response)
+	}
 }
 
 func TestRunMTRRaw_RespectsMaxRoundsAndInterval(t *testing.T) {
@@ -95,6 +107,25 @@ func TestRunMTRRaw_RespectsMaxRoundsAndInterval(t *testing.T) {
 	// Three rounds wait twice at 20ms each; allow a small scheduler tolerance below 40ms.
 	if time.Since(start) < 38*time.Millisecond {
 		t.Fatalf("interval appears not applied, elapsed=%v", time.Since(start))
+	}
+}
+
+func TestRunMTRRaw_RoundBasedNaturalCompletionReportsDefaultMaxHops(t *testing.T) {
+	var pathEnd *StopReason
+	err := RunMTRRaw(context.Background(), ICMPTrace, Config{}, MTRRawOptions{
+		MaxRounds: 1,
+		RunRound: func(_ Method, _ Config) (*Result, error) {
+			return &Result{Hops: make([][]Hop, 30)}, nil
+		},
+		OnPathEnd: func(reason *StopReason) {
+			pathEnd = cloneStopReason(reason)
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunMTRRaw returned error: %v", err)
+	}
+	if pathEnd == nil || pathEnd.Hop != 30 || pathEnd.Reason != StopReasonMaxHops {
+		t.Fatalf("path end = %#v, want max_hops at default hop 30", pathEnd)
 	}
 }
 

--- a/trace/mtr_response.go
+++ b/trace/mtr_response.go
@@ -21,10 +21,14 @@ const (
 )
 
 type mtrTTLEvidence struct {
-	destination *MTRProbeResponse
-	transit     *MTRProbeResponse
-	unreachable *MTRProbeResponse
-	live        *MTRProbeResponse
+	destination          *MTRProbeResponse
+	transit              *MTRProbeResponse
+	unreachable          *MTRProbeResponse
+	live                 *MTRProbeResponse
+	destinationResponses map[string]struct{}
+	destinationMarkers   map[string]struct{}
+	unreachableResponses map[string]struct{}
+	unreachableMarkers   map[string]struct{}
 }
 
 // mtrPathTracker owns the response evidence used to derive an MTR path edge.
@@ -48,6 +52,13 @@ func newMTRPathTracker(bounded bool, maxHops int, onChange func(*StopReason)) *m
 }
 
 func (t *mtrPathTracker) observe(ttl int, response *MTRProbeResponse) bool {
+	if response == nil {
+		return false
+	}
+	return t.observeWithDetails(ttl, response, []string{response.Description}, []string{response.Marker})
+}
+
+func (t *mtrPathTracker) observeWithDetails(ttl int, response *MTRProbeResponse, responses, markers []string) bool {
 	if t == nil || ttl <= 0 || response == nil {
 		return false
 	}
@@ -64,6 +75,10 @@ func (t *mtrPathTracker) observe(ttl int, response *MTRProbeResponse) bool {
 
 	if response.Kind == MTRResponseDestination {
 		evidence.destination = response
+		if t.bounded {
+			addMTRStopDetails(&evidence.destinationResponses, responses)
+			addMTRStopDetails(&evidence.destinationMarkers, markers)
+		}
 	} else if evidence.destination == nil {
 		if t.bounded {
 			switch response.Kind {
@@ -71,6 +86,8 @@ func (t *mtrPathTracker) observe(ttl int, response *MTRProbeResponse) bool {
 				evidence.transit = response
 			case MTRResponseUnreachable:
 				evidence.unreachable = response
+				addMTRStopDetails(&evidence.unreachableResponses, responses)
+				addMTRStopDetails(&evidence.unreachableMarkers, markers)
 			}
 		} else {
 			evidence.live = response
@@ -93,7 +110,7 @@ func (t *mtrPathTracker) observeStopReason(reason *StopReason) bool {
 	default:
 		return false
 	}
-	return t.observe(reason.Hop, response)
+	return t.observeWithDetails(reason.Hop, response, reason.Responses, reason.Markers)
 }
 
 func (t *mtrPathTracker) responseAt(ttl int) *MTRProbeResponse {
@@ -146,26 +163,22 @@ func (t *mtrPathTracker) reset() bool {
 }
 
 func (t *mtrPathTracker) recompute() bool {
-	var next *StopReason
 	ttls := make([]int, 0, len(t.evidence))
 	for ttl := range t.evidence {
 		ttls = append(ttls, ttl)
 	}
 	sort.Ints(ttls)
+
+	var next *StopReason
 	for _, ttl := range ttls {
 		response := t.responseAt(ttl)
-		if response == nil {
-			continue
-		}
-		switch response.Kind {
-		case MTRResponseDestination:
-			next = stopReasonFromMTRResponse(ttl, StopReasonDestination, response)
-		case MTRResponseUnreachable:
-			next = stopReasonFromMTRResponse(ttl, StopReasonUnreachable, response)
-		}
-		if next != nil {
+		if response != nil && response.Kind == MTRResponseDestination {
+			next = t.stopReasonFromEvidence(ttl, StopReasonDestination, response)
 			break
 		}
+	}
+	if next == nil {
+		next = t.firstUnreachable(ttls)
 	}
 	if reflect.DeepEqual(t.current, next) {
 		return false
@@ -173,6 +186,48 @@ func (t *mtrPathTracker) recompute() bool {
 	t.current = next
 	t.notify()
 	return true
+}
+
+func (t *mtrPathTracker) firstUnreachable(ttls []int) *StopReason {
+	for _, ttl := range ttls {
+		response := t.responseAt(ttl)
+		if response != nil && response.Kind == MTRResponseUnreachable {
+			return t.stopReasonFromEvidence(ttl, StopReasonUnreachable, response)
+		}
+	}
+	return nil
+}
+
+func (t *mtrPathTracker) stopReasonFromEvidence(ttl int, reason string, response *MTRProbeResponse) *StopReason {
+	result := stopReasonFromMTRResponse(ttl, reason, response)
+	if !t.bounded {
+		return result
+	}
+	evidence := t.evidence[ttl]
+	if evidence == nil {
+		return result
+	}
+	switch reason {
+	case StopReasonDestination:
+		result.Responses = sortedResponseDetails(evidence.destinationResponses)
+		result.Markers = sortedResponseDetails(evidence.destinationMarkers)
+	case StopReasonUnreachable:
+		result.Responses = sortedResponseDetails(evidence.unreachableResponses)
+		result.Markers = sortedResponseDetails(evidence.unreachableMarkers)
+	}
+	return result
+}
+
+func addMTRStopDetails(details *map[string]struct{}, values []string) {
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if *details == nil {
+			*details = make(map[string]struct{})
+		}
+		(*details)[value] = struct{}{}
+	}
 }
 
 func (t *mtrPathTracker) notify() {

--- a/trace/mtr_response.go
+++ b/trace/mtr_response.go
@@ -1,0 +1,334 @@
+package trace
+
+import (
+	"net"
+	"reflect"
+	"sort"
+)
+
+// MTRProbeResponse describes the semantic result of one MTR probe.
+type MTRProbeResponse struct {
+	Kind        string `json:"kind"`
+	Description string `json:"description,omitempty"`
+	Marker      string `json:"marker,omitempty"`
+	responderIP string
+}
+
+const (
+	MTRResponseTransit     = "transit"
+	MTRResponseDestination = "destination"
+	MTRResponseUnreachable = "unreachable"
+)
+
+type mtrTTLEvidence struct {
+	destination *MTRProbeResponse
+	transit     *MTRProbeResponse
+	unreachable *MTRProbeResponse
+	live        *MTRProbeResponse
+}
+
+// mtrPathTracker owns the response evidence used to derive an MTR path edge.
+// Bounded runs accumulate evidence; unbounded runs keep destination evidence
+// sticky while allowing later transit replies to reopen provisional edges.
+type mtrPathTracker struct {
+	bounded  bool
+	maxHops  int
+	evidence map[int]*mtrTTLEvidence
+	current  *StopReason
+	onChange func(*StopReason)
+}
+
+func newMTRPathTracker(bounded bool, maxHops int, onChange func(*StopReason)) *mtrPathTracker {
+	return &mtrPathTracker{
+		bounded:  bounded,
+		maxHops:  maxHops,
+		evidence: make(map[int]*mtrTTLEvidence),
+		onChange: onChange,
+	}
+}
+
+func (t *mtrPathTracker) observe(ttl int, response *MTRProbeResponse) bool {
+	if t == nil || ttl <= 0 || response == nil {
+		return false
+	}
+	if response.Kind != MTRResponseDestination && response.Kind != MTRResponseTransit && response.Kind != MTRResponseUnreachable {
+		return false
+	}
+
+	evidence := t.evidence[ttl]
+	if evidence == nil {
+		evidence = &mtrTTLEvidence{}
+		t.evidence[ttl] = evidence
+	}
+	response = cloneMTRProbeResponse(response)
+
+	if response.Kind == MTRResponseDestination {
+		evidence.destination = response
+	} else if evidence.destination == nil {
+		if t.bounded {
+			switch response.Kind {
+			case MTRResponseTransit:
+				evidence.transit = response
+			case MTRResponseUnreachable:
+				evidence.unreachable = response
+			}
+		} else {
+			evidence.live = response
+		}
+	}
+	return t.recompute()
+}
+
+func (t *mtrPathTracker) observeStopReason(reason *StopReason) bool {
+	if t == nil || reason == nil || reason.Hop <= 0 {
+		return false
+	}
+	response := &MTRProbeResponse{Description: firstString(reason.Responses)}
+	switch reason.Reason {
+	case StopReasonDestination:
+		response.Kind = MTRResponseDestination
+	case StopReasonUnreachable:
+		response.Kind = MTRResponseUnreachable
+		response.Marker = firstString(reason.Markers)
+	default:
+		return false
+	}
+	return t.observe(reason.Hop, response)
+}
+
+func (t *mtrPathTracker) responseAt(ttl int) *MTRProbeResponse {
+	if t == nil {
+		return nil
+	}
+	evidence := t.evidence[ttl]
+	if evidence == nil {
+		return nil
+	}
+	if evidence.destination != nil {
+		return cloneMTRProbeResponse(evidence.destination)
+	}
+	if t.bounded {
+		if evidence.transit != nil {
+			return cloneMTRProbeResponse(evidence.transit)
+		}
+		return cloneMTRProbeResponse(evidence.unreachable)
+	}
+	return cloneMTRProbeResponse(evidence.live)
+}
+
+func (t *mtrPathTracker) pathEnd() *StopReason {
+	if t == nil {
+		return nil
+	}
+	return cloneStopReason(t.current)
+}
+
+func (t *mtrPathTracker) completeAtMaxHops() bool {
+	if t == nil || t.current != nil || t.maxHops <= 0 {
+		return false
+	}
+	t.current = &StopReason{Hop: t.maxHops, Reason: StopReasonMaxHops}
+	t.notify()
+	return true
+}
+
+func (t *mtrPathTracker) reset() bool {
+	if t == nil {
+		return false
+	}
+	hadPathEnd := t.current != nil
+	t.evidence = make(map[int]*mtrTTLEvidence)
+	t.current = nil
+	if hadPathEnd {
+		t.notify()
+	}
+	return hadPathEnd
+}
+
+func (t *mtrPathTracker) recompute() bool {
+	var next *StopReason
+	ttls := make([]int, 0, len(t.evidence))
+	for ttl := range t.evidence {
+		ttls = append(ttls, ttl)
+	}
+	sort.Ints(ttls)
+	for _, ttl := range ttls {
+		response := t.responseAt(ttl)
+		if response == nil {
+			continue
+		}
+		switch response.Kind {
+		case MTRResponseDestination:
+			next = stopReasonFromMTRResponse(ttl, StopReasonDestination, response)
+		case MTRResponseUnreachable:
+			next = stopReasonFromMTRResponse(ttl, StopReasonUnreachable, response)
+		}
+		if next != nil {
+			break
+		}
+	}
+	if reflect.DeepEqual(t.current, next) {
+		return false
+	}
+	t.current = next
+	t.notify()
+	return true
+}
+
+func (t *mtrPathTracker) notify() {
+	if t.onChange != nil {
+		t.onChange(cloneStopReason(t.current))
+	}
+}
+
+func stopReasonFromMTRResponse(ttl int, reason string, response *MTRProbeResponse) *StopReason {
+	result := &StopReason{Hop: ttl, Reason: reason}
+	if response == nil {
+		return result
+	}
+	if response.Description != "" {
+		result.Responses = []string{response.Description}
+	}
+	if response.Marker != "" {
+		result.Markers = []string{response.Marker}
+	}
+	return result
+}
+
+func cloneMTRProbeResponse(response *MTRProbeResponse) *MTRProbeResponse {
+	if response == nil {
+		return nil
+	}
+	clone := *response
+	return &clone
+}
+
+func mtrProbeResponseWithPeer(response *MTRProbeResponse, peer net.Addr) *MTRProbeResponse {
+	response = cloneMTRProbeResponse(response)
+	if response != nil {
+		response.responderIP = mtrAddrString(peer)
+	}
+	return response
+}
+
+func mtrProbeResponseForStat(tracker *mtrPathTracker, stat MTRHopStat) *MTRProbeResponse {
+	response := tracker.responseAt(stat.TTL)
+	if response == nil || response.responderIP == "" || response.responderIP == stat.IP {
+		return response
+	}
+	return nil
+}
+
+func cloneStopReason(reason *StopReason) *StopReason {
+	if reason == nil {
+		return nil
+	}
+	clone := *reason
+	clone.Responses = append([]string(nil), reason.Responses...)
+	clone.Markers = append([]string(nil), reason.Markers...)
+	return &clone
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func mtrProbeResponseFromProbe(response probeResponse) *MTRProbeResponse {
+	result := &MTRProbeResponse{
+		Description: response.detail,
+		Marker:      response.marker,
+		responderIP: response.responderIP,
+	}
+	switch response.kind {
+	case probeResponseTransit:
+		result.Kind = MTRResponseTransit
+	case probeResponseDestination:
+		result.Kind = MTRResponseDestination
+	case probeResponseUnreachable:
+		result.Kind = MTRResponseUnreachable
+	default:
+		return nil
+	}
+	return result
+}
+
+func probeResponseFromMTR(response *MTRProbeResponse) probeResponse {
+	if response == nil {
+		return probeResponse{}
+	}
+	result := probeResponse{
+		detail:      response.Description,
+		marker:      response.Marker,
+		responderIP: response.responderIP,
+	}
+	switch response.Kind {
+	case MTRResponseTransit:
+		result.kind = probeResponseTransit
+	case MTRResponseDestination:
+		result.kind = probeResponseDestination
+	case MTRResponseUnreachable:
+		result.kind = probeResponseUnreachable
+	}
+	return result
+}
+
+func bestMTRProbeResponse(res *Result, ttl int) *MTRProbeResponse {
+	if res == nil || ttl <= 0 {
+		return nil
+	}
+	res.lock.RLock()
+	responses := append([]probeResponse(nil), res.responses[ttl]...)
+	stopReason := cloneStopReason(res.StopReason)
+	res.lock.RUnlock()
+	best := probeResponse{}
+	for _, response := range responses {
+		if probeResponsePriority(response.kind) > probeResponsePriority(best.kind) {
+			best = response
+		}
+	}
+	if response := mtrProbeResponseFromProbe(best); response != nil {
+		return mtrProbeResponseWithResultPeer(response, res, ttl)
+	}
+	if stopReason != nil && stopReason.Hop == ttl {
+		tracker := newMTRPathTracker(true, ttl, nil)
+		tracker.observeStopReason(stopReason)
+		return mtrProbeResponseWithResultPeer(tracker.responseAt(ttl), res, ttl)
+	}
+	return nil
+}
+
+func mtrProbeResponseWithResultPeer(response *MTRProbeResponse, res *Result, ttl int) *MTRProbeResponse {
+	if response == nil || res == nil || ttl <= 0 {
+		return response
+	}
+	if response.responderIP != "" {
+		return response
+	}
+	res.lock.RLock()
+	defer res.lock.RUnlock()
+	if ttl > len(res.Hops) {
+		return response
+	}
+	for _, hop := range res.Hops[ttl-1] {
+		if hop.Success && hop.Address != nil {
+			return mtrProbeResponseWithPeer(response, hop.Address)
+		}
+	}
+	return response
+}
+
+func probeResponsePriority(kind probeResponseKind) int {
+	switch kind {
+	case probeResponseDestination:
+		return 3
+	case probeResponseTransit:
+		return 2
+	case probeResponseUnreachable:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/trace/mtr_response_test.go
+++ b/trace/mtr_response_test.go
@@ -35,20 +35,85 @@ func TestMTRPathTrackerBoundedEvidencePriority(t *testing.T) {
 	}
 }
 
+func TestMTRPathTrackerDestinationIsStickyAcrossTTLs(t *testing.T) {
+	for _, bounded := range []bool{false, true} {
+		name := "unbounded"
+		if bounded {
+			name = "bounded"
+		}
+		t.Run(name, func(t *testing.T) {
+			tracker := newMTRPathTracker(bounded, 30, nil)
+			tracker.observe(5, &MTRProbeResponse{Kind: MTRResponseDestination, Description: "destination at 5"})
+			tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "unreachable at 3", Marker: "!H"})
+			want := &StopReason{Hop: 5, Reason: StopReasonDestination, Responses: []string{"destination at 5"}}
+			if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+				t.Fatalf("pathEnd() after lower unreachable = %#v, want sticky destination %#v", got, want)
+			}
+
+			tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseDestination, Description: "destination at 4"})
+			want = &StopReason{Hop: 4, Reason: StopReasonDestination, Responses: []string{"destination at 4"}}
+			if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+				t.Fatalf("pathEnd() after lower destination = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestMTRPathTrackerBoundedAccumulatesWinningEvidence(t *testing.T) {
+	var changes []*StopReason
+	tracker := newMTRPathTracker(true, 30, func(reason *StopReason) {
+		changes = append(changes, reason)
+	})
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "network unreachable", Marker: "!N"})
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "host unreachable", Marker: "!H"})
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "network unreachable", Marker: "!N"})
+
+	want := &StopReason{
+		Hop:       4,
+		Reason:    StopReasonUnreachable,
+		Responses: []string{"host unreachable", "network unreachable"},
+		Markers:   []string{"!H", "!N"},
+	}
+	if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("pathEnd() = %#v, want %#v", got, want)
+	}
+	if got := len(changes); got != 2 {
+		t.Fatalf("path-end changes = %d, want two distinct evidence states", got)
+	}
+
+	tracker = newMTRPathTracker(true, 30, nil)
+	tracker.observeStopReason(&StopReason{
+		Hop:       5,
+		Reason:    StopReasonDestination,
+		Responses: []string{"TCP RST from 192.0.2.2", "TCP SYN/ACK from 192.0.2.1", "TCP RST from 192.0.2.2"},
+	})
+	want = &StopReason{
+		Hop:       5,
+		Reason:    StopReasonDestination,
+		Responses: []string{"TCP RST from 192.0.2.2", "TCP SYN/ACK from 192.0.2.1"},
+	}
+	if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("pathEnd() from StopReason = %#v, want %#v", got, want)
+	}
+}
+
 func TestMTRPathTrackerUnboundedReopensProvisionalEdge(t *testing.T) {
 	var changes []*StopReason
 	tracker := newMTRPathTracker(false, 30, func(reason *StopReason) {
 		changes = append(changes, reason)
 	})
 
-	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Marker: "!H"})
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "host unreachable", Marker: "!H"})
 	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonUnreachable)
 	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseTransit})
 	if got := tracker.pathEnd(); got != nil {
 		t.Fatalf("path end after transit = %#v, want nil", got)
 	}
-	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Marker: "!N"})
-	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonUnreachable)
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "network unreachable", Marker: "!N"})
+	want := &StopReason{Hop: 3, Reason: StopReasonUnreachable, Responses: []string{"network unreachable"}, Markers: []string{"!N"}}
+	if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("reopened path end = %#v, want latest live evidence %#v", got, want)
+	}
 	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseDestination})
 	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonDestination)
 	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseTransit})
@@ -60,6 +125,9 @@ func TestMTRPathTrackerUnboundedReopensProvisionalEdge(t *testing.T) {
 	}
 	if changes[len(changes)-1] != nil {
 		t.Fatalf("last reset callback = %#v, want nil", changes[len(changes)-1])
+	}
+	if got := len(changes); got != 5 {
+		t.Fatalf("path-end changes = %d, want unreachable, reopen, unreachable, destination, reset", got)
 	}
 }
 
@@ -90,6 +158,21 @@ func TestMTRPathTrackerCopiesCallbackState(t *testing.T) {
 	want := &StopReason{Hop: 2, Reason: StopReasonUnreachable, Responses: []string{"blocked"}, Markers: []string{"!X"}}
 	if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("pathEnd() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMTRPathTrackerPathEndReturnsCopy(t *testing.T) {
+	tracker := newMTRPathTracker(false, 30, nil)
+	tracker.observe(2, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "blocked", Marker: "!X"})
+
+	read := tracker.pathEnd()
+	read.Hop = 99
+	read.Responses[0] = "mutated"
+	read.Markers[0] = "mutated"
+
+	want := &StopReason{Hop: 2, Reason: StopReasonUnreachable, Responses: []string{"blocked"}, Markers: []string{"!X"}}
+	if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("pathEnd() after caller mutation = %#v, want %#v", got, want)
 	}
 }
 

--- a/trace/mtr_response_test.go
+++ b/trace/mtr_response_test.go
@@ -1,0 +1,134 @@
+package trace
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestMTRPathTrackerBoundedEvidencePriority(t *testing.T) {
+	var changes []*StopReason
+	tracker := newMTRPathTracker(true, 30, func(reason *StopReason) {
+		changes = append(changes, reason)
+	})
+
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "host unreachable", Marker: "!H"})
+	assertMTRPathEnd(t, tracker.pathEnd(), 4, StopReasonUnreachable)
+
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseTransit, Description: "time exceeded"})
+	if got := tracker.pathEnd(); got != nil {
+		t.Fatalf("path end after transit = %#v, want nil", got)
+	}
+
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "network unreachable", Marker: "!N"})
+	if got := tracker.pathEnd(); got != nil {
+		t.Fatalf("bounded transit evidence must remain authoritative, got %#v", got)
+	}
+
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseDestination, Description: "echo reply"})
+	assertMTRPathEnd(t, tracker.pathEnd(), 4, StopReasonDestination)
+	tracker.observe(4, &MTRProbeResponse{Kind: MTRResponseTransit})
+	assertMTRPathEnd(t, tracker.pathEnd(), 4, StopReasonDestination)
+
+	if got, want := len(changes), 3; got != want {
+		t.Fatalf("path-end changes = %d, want %d (%#v)", got, want, changes)
+	}
+}
+
+func TestMTRPathTrackerUnboundedReopensProvisionalEdge(t *testing.T) {
+	var changes []*StopReason
+	tracker := newMTRPathTracker(false, 30, func(reason *StopReason) {
+		changes = append(changes, reason)
+	})
+
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Marker: "!H"})
+	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonUnreachable)
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseTransit})
+	if got := tracker.pathEnd(); got != nil {
+		t.Fatalf("path end after transit = %#v, want nil", got)
+	}
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseUnreachable, Marker: "!N"})
+	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonUnreachable)
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseDestination})
+	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonDestination)
+	tracker.observe(3, &MTRProbeResponse{Kind: MTRResponseTransit})
+	assertMTRPathEnd(t, tracker.pathEnd(), 3, StopReasonDestination)
+
+	tracker.reset()
+	if got := tracker.pathEnd(); got != nil {
+		t.Fatalf("path end after reset = %#v, want nil", got)
+	}
+	if changes[len(changes)-1] != nil {
+		t.Fatalf("last reset callback = %#v, want nil", changes[len(changes)-1])
+	}
+}
+
+func TestMTRPathTrackerMaxHopsOnlyWithoutSemanticEdge(t *testing.T) {
+	tracker := newMTRPathTracker(true, 12, nil)
+	if !tracker.completeAtMaxHops() {
+		t.Fatal("completeAtMaxHops() = false, want true")
+	}
+	assertMTRPathEnd(t, tracker.pathEnd(), 12, StopReasonMaxHops)
+
+	tracker = newMTRPathTracker(true, 12, nil)
+	tracker.observe(7, &MTRProbeResponse{Kind: MTRResponseUnreachable})
+	if tracker.completeAtMaxHops() {
+		t.Fatal("completeAtMaxHops() replaced semantic path edge")
+	}
+	assertMTRPathEnd(t, tracker.pathEnd(), 7, StopReasonUnreachable)
+}
+
+func TestMTRPathTrackerCopiesCallbackState(t *testing.T) {
+	var callback *StopReason
+	tracker := newMTRPathTracker(false, 30, func(reason *StopReason) {
+		callback = reason
+	})
+	tracker.observe(2, &MTRProbeResponse{Kind: MTRResponseUnreachable, Description: "blocked", Marker: "!X"})
+	callback.Responses[0] = "mutated"
+	callback.Markers[0] = "mutated"
+
+	want := &StopReason{Hop: 2, Reason: StopReasonUnreachable, Responses: []string{"blocked"}, Markers: []string{"!X"}}
+	if got := tracker.pathEnd(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("pathEnd() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMTRProbeResponseMarkerOnlyDecoratesRespondingMultipathRow(t *testing.T) {
+	tracker := newMTRPathTracker(false, 30, nil)
+	transitPeer := &net.IPAddr{IP: net.ParseIP("192.0.2.21")}
+	unreachablePeer := &net.IPAddr{IP: net.ParseIP("192.0.2.22")}
+	tracker.observe(2, mtrProbeResponseFromProbe(responseWithPeer(probeResponse{
+		kind: probeResponseTransit,
+	}, transitPeer)))
+
+	res := &Result{
+		Hops: make([][]Hop, 2),
+		responses: map[int][]probeResponse{
+			2: {responseWithPeer(probeResponse{
+				kind:   probeResponseUnreachable,
+				marker: "!H",
+			}, unreachablePeer)},
+		},
+	}
+	res.Hops[1] = []Hop{
+		{TTL: 2, Success: true, Address: transitPeer},
+		{TTL: 2, Success: true, Address: unreachablePeer},
+	}
+	tracker.observe(2, bestMTRProbeResponse(res, 2))
+
+	transit := mtrProbeResponseForStat(tracker, MTRHopStat{TTL: 2, IP: transitPeer.IP.String()})
+	if transit != nil {
+		t.Fatalf("transit multipath row response = %#v, want nil", transit)
+	}
+	matched := mtrProbeResponseForStat(tracker, MTRHopStat{TTL: 2, IP: unreachablePeer.IP.String()})
+	if matched == nil || matched.Kind != MTRResponseUnreachable || matched.Marker != "!H" {
+		t.Fatalf("responding multipath row response = %#v, want unreachable !H", matched)
+	}
+}
+
+func assertMTRPathEnd(t *testing.T, reason *StopReason, hop int, kind string) {
+	t.Helper()
+	if reason == nil || reason.Hop != hop || reason.Reason != kind {
+		t.Fatalf("path end = %#v, want hop=%d reason=%s", reason, hop, kind)
+	}
+}

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -45,6 +45,9 @@ type MTROptions struct {
 	// OnProbe is called for each per-hop probe that is counted into Snt.
 	// It is only used by per-hop MTR; discarded probes are not emitted.
 	OnProbe func(MTRProbeEvent)
+	// OnPathEnd is called whenever the semantic path edge changes. A nil value
+	// means that a provisional unreachable edge was reopened or reset.
+	OnPathEnd func(*StopReason)
 }
 
 // MTROnSnapshot 每轮完成后的回调，用于刷新 CLI 表格。
@@ -57,6 +60,7 @@ type MTRProbeEvent struct {
 	Success   bool
 	RTT       time.Duration
 	Timestamp time.Time
+	Response  *MTRProbeResponse
 }
 
 // mtrBackoffCfg 控制连续错误时的指数退避行为。
@@ -157,6 +161,7 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		DstIP:            baseConfig.DstIP,
 		IsPaused:         opts.IsPaused,
 		IsResetRequested: opts.IsResetRequested,
+		OnPathEnd:        opts.OnPathEnd,
 	}, onSnapshot, mtrProbeCallbackFromOptions(opts))
 }
 
@@ -304,9 +309,10 @@ type mtrProbeMeta struct {
 }
 
 type mtrProbeReply struct {
-	peer net.Addr
-	rtt  time.Duration
-	mpls []string
+	peer     net.Addr
+	rtt      time.Duration
+	mpls     []string
+	response *MTRProbeResponse
 }
 
 func newMTRICMPEngine(config Config) (*mtrICMPEngine, error) {
@@ -495,7 +501,7 @@ func (e *mtrICMPEngine) onICMP(msg internal.ReceivedMessage, finish time.Time, s
 
 	rtt := finish.Sub(start.start)
 	e.storeProbeReplyLocked(seq, msg, rtt)
-	finalTTL := e.detectRoundFinalTTLCandidate(msg.Peer, start.ttl)
+	finalTTL := e.detectRoundFinalTTLCandidate(e.replied[seq].response, start.ttl)
 	e.mu.Unlock()
 
 	e.updateRoundFinalTTL(finalTTL)
@@ -529,9 +535,10 @@ func (e *mtrICMPEngine) discardProbeLocked(seq int) {
 
 func (e *mtrICMPEngine) storeProbeReplyLocked(seq int, msg internal.ReceivedMessage, rtt time.Duration) {
 	e.replied[seq] = &mtrProbeReply{
-		peer: msg.Peer,
-		rtt:  rtt,
-		mpls: extractMPLS(msg, e.config.DisableMPLS),
+		peer:     msg.Peer,
+		rtt:      rtt,
+		mpls:     extractMPLS(msg, e.config.DisableMPLS),
+		response: mtrProbeResponseFromProbe(probeResponseFromICMPForMethod(msg.ICMP, ICMPTrace)),
 	}
 	delete(e.sentAt, seq)
 	e.closeProbeNotifyLocked(seq)
@@ -544,9 +551,11 @@ func (e *mtrICMPEngine) closeProbeNotifyLocked(seq int) {
 	}
 }
 
-func (e *mtrICMPEngine) detectRoundFinalTTLCandidate(peer net.Addr, ttl int) int32 {
-	peerIP := mtrPeerIP(peer)
-	if peerIP == nil || !peerIP.Equal(e.config.DstIP) {
+func (e *mtrICMPEngine) detectRoundFinalTTLCandidate(response *MTRProbeResponse, ttl int) int32 {
+	// Only destination evidence is sticky inside the round engine. Unreachable
+	// evidence is provisional and is maintained by the outer path tracker so a
+	// later transit reply can reopen the scan without losing higher-TTL data.
+	if response == nil || response.Kind != MTRResponseDestination {
 		return -1
 	}
 	return int32(ttl)
@@ -838,11 +847,27 @@ func (e *mtrICMPEngine) roundFinalMax(effectiveMax int) int {
 }
 
 func (e *mtrICMPEngine) buildProbeRoundResult(beginHop, finalMax int) *Result {
-	res := &Result{Hops: make([][]Hop, finalMax)}
+	res := &Result{Hops: make([][]Hop, finalMax), responses: make(map[int][]probeResponse)}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	for ttl := beginHop; ttl <= finalMax; ttl++ {
 		res.Hops[ttl-1] = []Hop{e.probeRoundHop(ttl)}
+		seq, sent := e.curTtlSeq[ttl]
+		if !sent {
+			continue
+		}
+		reply := e.replied[seq]
+		if reply == nil || reply.response == nil {
+			continue
+		}
+		res.responses[ttl] = []probeResponse{probeResponseFromMTR(reply.response)}
+		if res.StopReason == nil && (reply.response.Kind == MTRResponseDestination || reply.response.Kind == MTRResponseUnreachable) {
+			reason := StopReasonDestination
+			if reply.response.Kind == MTRResponseUnreachable {
+				reason = StopReasonUnreachable
+			}
+			res.StopReason = stopReasonFromMTRResponse(ttl, reason, reply.response)
+		}
 	}
 	return res
 }
@@ -951,11 +976,12 @@ func (e *mtrICMPEngine) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, 
 
 		if ok && reply != nil {
 			return mtrProbeResult{
-				TTL:     ttl,
-				Success: true,
-				Addr:    reply.peer,
-				RTT:     reply.rtt,
-				MPLS:    reply.mpls,
+				TTL:      ttl,
+				Success:  true,
+				Addr:     reply.peer,
+				RTT:      reply.rtt,
+				MPLS:     reply.mpls,
+				Response: cloneMTRProbeResponse(reply.response),
 			}, nil
 		}
 		// Notified but no reply → was discarded (stale/bad RTT)
@@ -1046,6 +1072,7 @@ func (p *mtrFallbackTTLProber) ProbeTTL(ctx context.Context, ttl int) (mtrProbeR
 		MPLS:     h.MPLS,
 		Hostname: h.Hostname,
 		Geo:      h.Geo,
+		Response: bestMTRProbeResponse(res, ttl),
 	}, nil
 }
 

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -158,7 +158,6 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		FillGeo:          true,
 		AsyncMetadata:    opts.AsyncMetadata,
 		BaseConfig:       baseConfig,
-		DstIP:            baseConfig.DstIP,
 		IsPaused:         opts.IsPaused,
 		IsResetRequested: opts.IsResetRequested,
 		OnPathEnd:        opts.OnPathEnd,

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -760,7 +760,7 @@ func TestResetClearsKnownFinalTTL(t *testing.T) {
 // 目的地停止测试
 // ---------------------------------------------------------------------------
 
-// TestOnICMP_DetectsDestination 验证 onICMP 在 peer==DstIP 时设置 roundFinalTTL。
+// TestOnICMP_DetectsDestination verifies protocol semantics, not peer-IP equality.
 func TestOnICMP_DetectsDestination(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
 	e.config.DstIP = net.ParseIP("8.8.8.8")
@@ -772,8 +772,11 @@ func TestOnICMP_DetectsDestination(t *testing.T) {
 	seq := 42
 	e.sentAt[seq] = mtrProbeMeta{ttl: 5, start: now, roundID: 1}
 
-	peer := &net.IPAddr{IP: net.ParseIP("8.8.8.8")}
-	e.onICMP(internal.ReceivedMessage{Peer: peer}, now.Add(15*time.Millisecond), seq)
+	peer := &net.IPAddr{IP: net.ParseIP("192.0.2.55")}
+	e.onICMP(internal.ReceivedMessage{
+		Peer: peer,
+		ICMP: internal.ICMPResponse{Kind: internal.ICMPResponseEchoReply, Description: "ICMP Echo Reply"},
+	}, now.Add(15*time.Millisecond), seq)
 
 	if got := atomic.LoadInt32(&e.roundFinalTTL); got != 5 {
 		t.Errorf("expected roundFinalTTL=5, got %d", got)
@@ -992,5 +995,130 @@ func TestMTRLoop_NonPeekerNoStreaming(t *testing.T) {
 	// 非 peeker 模式：每轮仅 1 次快照，共 3 次
 	if got := atomic.LoadInt32(&snapshotCount); got != 3 {
 		t.Errorf("expected exactly 3 snapshots, got %d", got)
+	}
+}
+
+func TestMTRLoopPreviewFiltersProvisionalPathWithoutClearingHigherStats(t *testing.T) {
+	full := mkResult(
+		[]Hop{mkHop(1, "192.0.2.1", time.Millisecond)},
+		[]Hop{mkHop(2, "192.0.2.2", 2*time.Millisecond)},
+		[]Hop{mkHop(3, "192.0.2.3", 3*time.Millisecond)},
+	)
+	agg := NewMTRAggregator()
+	agg.Update(full, 1)
+
+	var snapshots [][]MTRHopStat
+	peeker := &mockPeekerProber{peekFn: func() *Result { return full }}
+	rt := newMTRLoopRuntime(context.Background(), peeker, Config{MaxHops: 3}, MTROptions{}, agg, func(_ int, stats []MTRHopStat) {
+		snapshots = append(snapshots, stats)
+	}, false, fastBackoff)
+
+	rt.pathTracker.observe(2, &MTRProbeResponse{Kind: MTRResponseUnreachable, Marker: "!H"})
+	rt.emitPreview(peeker)
+	if got := snapshots[len(snapshots)-1]; len(got) != 2 || got[1].TTL != 2 || got[1].Response == nil || got[1].Response.Marker != "!H" {
+		t.Fatalf("provisional preview = %#v, want TTL 1..2 with unreachable marker", got)
+	}
+	if got := agg.Snapshot(); len(got) != 3 {
+		t.Fatalf("provisional filtering cleared aggregate stats: %#v", got)
+	}
+
+	rt.pathTracker.observe(2, &MTRProbeResponse{Kind: MTRResponseTransit})
+	rt.emitPreview(peeker)
+	if got := snapshots[len(snapshots)-1]; len(got) != 3 || got[2].TTL != 3 {
+		t.Fatalf("reopened preview = %#v, want preserved TTL 1..3", got)
+	}
+}
+
+func TestMTRLoopRoundPathReopensProvisionalEdgeAndKeepsHigherStats(t *testing.T) {
+	var round int32
+	prober := &mockProber{roundFn: func(_ context.Context) (*Result, error) {
+		res := mkResult(
+			[]Hop{mkHop(1, "192.0.2.1", time.Millisecond)},
+			[]Hop{mkHop(2, "192.0.2.2", 2*time.Millisecond)},
+			[]Hop{mkHop(3, "192.0.2.3", 3*time.Millisecond)},
+			[]Hop{mkHop(4, "192.0.2.4", 4*time.Millisecond)},
+		)
+		res.responses = make(map[int][]probeResponse)
+		if atomic.AddInt32(&round, 1) == 1 {
+			res.responses[2] = []probeResponse{{kind: probeResponseUnreachable, detail: "ICMP Host Unreachable", marker: "!H"}}
+		} else {
+			res.responses[2] = []probeResponse{{kind: probeResponseTransit, detail: "ICMP Time Exceeded"}}
+		}
+		return res, nil
+	}}
+
+	var changes []*StopReason
+	var snapshots [][]MTRHopStat
+	agg := NewMTRAggregator()
+	err := mtrLoop(context.Background(), prober, Config{MaxHops: 4}, MTROptions{
+		MaxRounds: 2,
+		Interval:  time.Millisecond,
+		OnPathEnd: func(reason *StopReason) {
+			changes = append(changes, reason)
+		},
+	}, agg, func(_ int, stats []MTRHopStat) {
+		snapshots = append(snapshots, stats)
+	}, false, fastBackoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) != 2 || len(snapshots[0]) != 2 || len(snapshots[1]) != 4 {
+		t.Fatalf("round snapshots = %#v, want provisional TTL 1..2 then reopened TTL 1..4", snapshots)
+	}
+	if got := snapshots[0][1].Response; got == nil || got.Kind != MTRResponseUnreachable || got.Marker != "!H" {
+		t.Fatalf("provisional response = %#v, want unreachable !H", got)
+	}
+	if got := snapshots[1][1].Response; got == nil || got.Kind != MTRResponseTransit {
+		t.Fatalf("reopened response = %#v, want sticky transit", got)
+	}
+	if got := agg.Snapshot(); len(got) != 4 || got[3].Snt != 2 {
+		t.Fatalf("higher aggregate stats were lost across provisional edge: %#v", got)
+	}
+	if len(changes) != 3 || changes[0] == nil || changes[0].Reason != StopReasonUnreachable || changes[1] != nil {
+		t.Fatalf("path changes = %#v, want unreachable, nil, max_hops", changes)
+	}
+	assertMTRPathEnd(t, changes[2], 4, StopReasonMaxHops)
+}
+
+func TestMTRICMPEngineCarriesTransitAndUnreachableResponses(t *testing.T) {
+	e := newTestICMPEngine(2 * time.Second)
+	e.config.DstIP = net.ParseIP("203.0.113.10")
+	atomic.StoreUint32(&e.roundID, 1)
+	atomic.StoreInt32(&e.roundFinalTTL, -1)
+	e.curBeginHop = 1
+	e.curEffectiveMax = 3
+	e.curTtlSeq = map[int]int{2: 20, 3: 30}
+
+	now := time.Now()
+	e.sentAt[20] = mtrProbeMeta{ttl: 2, start: now, roundID: 1}
+	e.onICMP(internal.ReceivedMessage{
+		Peer: &net.IPAddr{IP: e.config.DstIP},
+		ICMP: internal.ICMPResponse{Kind: internal.ICMPResponseTransit, Description: "ICMP Time Exceeded"},
+	}, now.Add(time.Millisecond), 20)
+	if got := e.replied[20].response; got == nil || got.Kind != MTRResponseTransit {
+		t.Fatalf("target-IP Time Exceeded response = %#v, want transit", got)
+	}
+	if got := atomic.LoadInt32(&e.roundFinalTTL); got != -1 {
+		t.Fatalf("target-IP transit set round final TTL to %d", got)
+	}
+
+	e.sentAt[30] = mtrProbeMeta{ttl: 3, start: now, roundID: 1}
+	e.onICMP(internal.ReceivedMessage{
+		Peer: &net.IPAddr{IP: net.ParseIP("198.51.100.30")},
+		ICMP: internal.ICMPResponse{Kind: internal.ICMPResponseUnreachable, Description: "ICMP Host Unreachable", Marker: "!H"},
+	}, now.Add(2*time.Millisecond), 30)
+	if got := e.replied[30].response; got == nil || got.Kind != MTRResponseUnreachable || got.Marker != "!H" {
+		t.Fatalf("unreachable response = %#v, want unreachable !H", got)
+	}
+	if got := atomic.LoadInt32(&e.roundFinalTTL); got != -1 {
+		t.Fatalf("provisional unreachable set sticky round final TTL to %d", got)
+	}
+
+	res := e.buildProbeRoundResult(1, 3)
+	if got := bestMTRProbeResponse(res, 2); got == nil || got.Kind != MTRResponseTransit {
+		t.Fatalf("round transit response = %#v", got)
+	}
+	if got := bestMTRProbeResponse(res, 3); got == nil || got.Kind != MTRResponseUnreachable || got.Marker != "!H" {
+		t.Fatalf("round unreachable response = %#v", got)
 	}
 }

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -1085,6 +1085,7 @@ func TestMTRICMPEngineCarriesTransitAndUnreachableResponses(t *testing.T) {
 	e.config.DstIP = net.ParseIP("203.0.113.10")
 	atomic.StoreUint32(&e.roundID, 1)
 	atomic.StoreInt32(&e.roundFinalTTL, -1)
+	atomic.StoreInt32(&e.knownFinalTTL, -1)
 	e.curBeginHop = 1
 	e.curEffectiveMax = 3
 	e.curTtlSeq = map[int]int{2: 20, 3: 30}

--- a/trace/mtr_scheduler.go
+++ b/trace/mtr_scheduler.go
@@ -19,6 +19,7 @@ type mtrProbeResult struct {
 	Addr     net.Addr
 	RTT      time.Duration
 	MPLS     []string
+	Response *MTRProbeResponse
 	Hostname string           // pre-resolved PTR (fallback prober)
 	Geo      *ipgeo.IPGeoData // pre-resolved geo  (fallback prober)
 }
@@ -48,6 +49,7 @@ type mtrSchedulerConfig struct {
 	AsyncMetadata     bool
 	BaseConfig        Config // used for geo/RDNS lookup
 	DstIP             net.IP
+	OnPathEnd         func(*StopReason)
 
 	IsPaused         func() bool
 	IsResetRequested func() bool
@@ -102,6 +104,7 @@ func mtrProbeEventFromResult(result mtrProbeResult, at time.Time) MTRProbeEvent 
 		Success:   result.Success && result.Addr != nil,
 		RTT:       result.RTT,
 		Timestamp: at,
+		Response:  cloneMTRProbeResponse(result.Response),
 	}
 }
 

--- a/trace/mtr_scheduler.go
+++ b/trace/mtr_scheduler.go
@@ -48,7 +48,6 @@ type mtrSchedulerConfig struct {
 	FillGeo           bool
 	AsyncMetadata     bool
 	BaseConfig        Config // used for geo/RDNS lookup
-	DstIP             net.IP
 	OnPathEnd         func(*StopReason)
 
 	IsPaused         func() bool

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -184,21 +184,21 @@ func (rt *mtrSchedulerRuntime) run() error {
 		case cp := <-rt.resultCh:
 			rt.processResult(cp)
 			if rt.isDone() {
-				rt.maybeSnapshot(true)
+				rt.finishRun()
 				return nil
 			}
 			rt.scheduleReady()
 		case mr := <-rt.metadataCh:
 			rt.processMetadataResult(mr)
 			if rt.isDone() {
-				rt.maybeSnapshot(true)
+				rt.finishRun()
 				return nil
 			}
 		case <-tick.C:
 			rt.handleReset()
 			rt.scheduleReady()
 			if rt.isDone() {
-				rt.maybeSnapshot(true)
+				rt.finishRun()
 				return nil
 			}
 		}
@@ -350,7 +350,6 @@ func (rt *mtrSchedulerRuntime) timeoutProbeResult(ttl int) *Result {
 }
 
 func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResult, doneAt time.Time) {
-	result = rt.normalizeProbeResponse(result)
 	result.Response = mtrProbeResponseWithPeer(result.Response, result.Addr)
 	if rt.probeBudgetReached(ttl) {
 		rt.states[ttl].consecutiveErrs = 0
@@ -372,19 +371,6 @@ func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResul
 		rt.onProbe(result, rt.computeIteration(), doneAt)
 	}
 	rt.maybeSnapshot(false)
-}
-
-func (rt *mtrSchedulerRuntime) normalizeProbeResponse(result mtrProbeResult) mtrProbeResult {
-	if result.Response != nil || !result.Success || result.Addr == nil || rt.cfg.DstIP == nil {
-		return result
-	}
-	peerIP := mtrAddrToIP(result.Addr)
-	if peerIP != nil && peerIP.Equal(rt.cfg.DstIP) {
-		// Compatibility for custom mtrTTLProber implementations. Built-in
-		// probers always provide protocol-derived response semantics.
-		result.Response = &MTRProbeResponse{Kind: MTRResponseDestination}
-	}
-	return result
 }
 
 func (rt *mtrSchedulerRuntime) applyMetadataCache(result mtrProbeResult) mtrProbeResult {
@@ -809,11 +795,12 @@ func (rt *mtrSchedulerRuntime) isDone() bool {
 	if rt.inFlight != 0 {
 		return false
 	}
-	done := len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0
-	if done {
-		rt.pathTracker.completeAtMaxHops()
-	}
-	return done
+	return len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0
+}
+
+func (rt *mtrSchedulerRuntime) finishRun() {
+	rt.pathTracker.completeAtMaxHops()
+	rt.maybeSnapshot(true)
 }
 
 func (rt *mtrSchedulerRuntime) handleReset() {

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -53,6 +53,7 @@ type mtrSchedulerRuntime struct {
 	states               []mtrHopState
 	generation           uint64
 	knownFinalTTL        int32
+	pathTracker          *mtrPathTracker
 	inFlight             int
 	resultCh             chan mtrCompletedProbe
 	metadataCh           chan mtrMetadataResult
@@ -132,7 +133,7 @@ func newMTRSchedulerRuntime(
 
 	metadataCtx, metadataCancel := context.WithCancel(ctx)
 
-	return &mtrSchedulerRuntime{
+	rt := &mtrSchedulerRuntime{
 		ctx:                  ctx,
 		metadataCtx:          metadataCtx,
 		metadataCancel:       metadataCancel,
@@ -162,7 +163,9 @@ func newMTRSchedulerRuntime(
 		metadataHostAttempts: make(map[string]int),
 		metadataGeoRetryAt:   make(map[string]time.Time),
 		metadataHostRetryAt:  make(map[string]time.Time),
-	}, nil
+	}
+	rt.pathTracker = newMTRPathTracker(cfg.MaxPerHop > 0, maxHops, cfg.OnPathEnd)
+	return rt, nil
 }
 
 func (rt *mtrSchedulerRuntime) run() error {
@@ -237,7 +240,18 @@ func (rt *mtrSchedulerRuntime) maybeSnapshot(force bool) {
 		return
 	}
 	rt.lastSnapshot = now
-	rt.onSnapshot(rt.computeIteration(), rt.agg.Snapshot())
+	rt.onSnapshot(rt.computeIteration(), rt.snapshotStats())
+}
+
+func (rt *mtrSchedulerRuntime) snapshotStats() []MTRHopStat {
+	stats := rt.agg.Snapshot()
+	if pathEnd := rt.pathTracker.pathEnd(); pathEnd != nil && pathEnd.Hop > 0 {
+		stats = filterMTRStatsAtPathEnd(stats, pathEnd.Hop)
+	}
+	for i := range stats {
+		stats[i].Response = mtrProbeResponseForStat(rt.pathTracker, stats[i])
+	}
+	return stats
 }
 
 func (rt *mtrSchedulerRuntime) launchProbe(ttl int) {
@@ -336,11 +350,13 @@ func (rt *mtrSchedulerRuntime) timeoutProbeResult(ttl int) *Result {
 }
 
 func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResult, doneAt time.Time) {
-	rt.detectDestination(ttl, result)
+	result = rt.normalizeProbeResponse(result)
+	result.Response = mtrProbeResponseWithPeer(result.Response, result.Addr)
 	if rt.probeBudgetReached(ttl) {
 		rt.states[ttl].consecutiveErrs = 0
 		return
 	}
+	rt.observeProbeResponse(ttl, result.Response)
 
 	rt.markProbeCompleted(ttl)
 	result = rt.applyMetadataCache(result)
@@ -356,6 +372,19 @@ func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResul
 		rt.onProbe(result, rt.computeIteration(), doneAt)
 	}
 	rt.maybeSnapshot(false)
+}
+
+func (rt *mtrSchedulerRuntime) normalizeProbeResponse(result mtrProbeResult) mtrProbeResult {
+	if result.Response != nil || !result.Success || result.Addr == nil || rt.cfg.DstIP == nil {
+		return result
+	}
+	peerIP := mtrAddrToIP(result.Addr)
+	if peerIP != nil && peerIP.Equal(rt.cfg.DstIP) {
+		// Compatibility for custom mtrTTLProber implementations. Built-in
+		// probers always provide protocol-derived response semantics.
+		result.Response = &MTRProbeResponse{Kind: MTRResponseDestination}
+	}
+	return result
 }
 
 func (rt *mtrSchedulerRuntime) applyMetadataCache(result mtrProbeResult) mtrProbeResult {
@@ -681,34 +710,21 @@ func (rt *mtrSchedulerRuntime) metadataRetriesExhausted(attempts map[string]int,
 	return true
 }
 
-func (rt *mtrSchedulerRuntime) detectDestination(ttl int, result mtrProbeResult) {
-	if !result.Success || result.Addr == nil {
+func (rt *mtrSchedulerRuntime) observeProbeResponse(ttl int, response *MTRProbeResponse) {
+	if !rt.pathTracker.observe(ttl, response) {
 		return
 	}
-
-	peerIP := mtrAddrToIP(result.Addr)
-	if peerIP == nil || !peerIP.Equal(rt.cfg.DstIP) {
-		return
+	pathEnd := rt.pathTracker.pathEnd()
+	boundary := -1
+	if pathEnd != nil {
+		boundary = pathEnd.Hop
 	}
-
-	curFinal := atomic.LoadInt32(&rt.knownFinalTTL)
-	if curFinal < 0 {
-		atomic.StoreInt32(&rt.knownFinalTTL, int32(ttl))
-		rt.disableHigherTTLs(ttl + 1)
-		return
+	atomic.StoreInt32(&rt.knownFinalTTL, int32(boundary))
+	for hop := rt.beginHop; hop <= rt.maxHops; hop++ {
+		rt.states[hop].disabled = boundary > 0 && hop > boundary
 	}
-
-	if int32(ttl) < curFinal {
-		oldFinal := int(curFinal)
-		atomic.StoreInt32(&rt.knownFinalTTL, int32(ttl))
-		rt.disableHigherTTLs(ttl + 1)
-		rt.agg.ClearHop(oldFinal)
-	}
-}
-
-func (rt *mtrSchedulerRuntime) disableHigherTTLs(fromTTL int) {
-	for ttl := fromTTL; ttl <= rt.maxHops; ttl++ {
-		rt.states[ttl].disabled = true
+	if pathEnd != nil && pathEnd.Reason == StopReasonDestination {
+		rt.agg.ClearAbove(pathEnd.Hop)
 	}
 }
 
@@ -793,7 +809,11 @@ func (rt *mtrSchedulerRuntime) isDone() bool {
 	if rt.inFlight != 0 {
 		return false
 	}
-	return len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0
+	done := len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0
+	if done {
+		rt.pathTracker.completeAtMaxHops()
+	}
+	return done
 }
 
 func (rt *mtrSchedulerRuntime) handleReset() {
@@ -814,6 +834,7 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	clear(rt.metadataGeoRetryAt)
 	clear(rt.metadataHostRetryAt)
 	atomic.StoreInt32(&rt.knownFinalTTL, -1)
+	rt.pathTracker.reset()
 	rt.agg.Reset()
 	_ = rt.prober.Reset()
 }

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -2563,6 +2563,7 @@ func TestScheduler_LateHigherTTLDestinationReply_Discarded_NoSntBump(t *testing.
 
 	var mu sync.Mutex
 	var callbackCount int
+	callbackByTTL := make(map[int]int)
 
 	err := runMTRScheduler(context.Background(), prober, agg, mtrSchedulerConfig{
 		BeginHop:         1,
@@ -2575,6 +2576,7 @@ func TestScheduler_LateHigherTTLDestinationReply_Discarded_NoSntBump(t *testing.
 	}, nil, func(result mtrProbeResult, _ int, _ time.Time) {
 		mu.Lock()
 		callbackCount++
+		callbackByTTL[result.TTL]++
 		mu.Unlock()
 	})
 
@@ -2598,14 +2600,16 @@ func TestScheduler_LateHigherTTLDestinationReply_Discarded_NoSntBump(t *testing.
 		t.Errorf("TTL 5: expected Snt=0 (discarded late dst reply), got %d", sntByTTL[5])
 	}
 
-	// Callback count should equal sum of Snt across active TTLs only
+	// The delayed over-boundary result must not emit a callback. Other higher
+	// TTL callbacks may have been emitted before the destination edge became
+	// known; the subsequent path_end update tells streaming consumers to filter
+	// them and the sticky destination clears them from the final snapshot.
 	mu.Lock()
-	totalSnt := 0
-	for _, s := range stats {
-		totalSnt += s.Snt
+	if callbackByTTL[5] != 0 {
+		t.Errorf("TTL 5 emitted %d callbacks after the path edge was known", callbackByTTL[5])
 	}
-	if callbackCount != totalSnt {
-		t.Errorf("callback count (%d) != total Snt (%d); discarded results may have leaked", callbackCount, totalSnt)
+	if callbackCount < sntByTTL[1]+sntByTTL[2]+sntByTTL[3] {
+		t.Errorf("callback count (%d) is below retained Snt", callbackCount)
 	}
 	mu.Unlock()
 }
@@ -3353,5 +3357,173 @@ func TestScheduler_DynamicMaxInFlightPerHop_SmallTimeout(t *testing.T) {
 		if s.TTL >= 1 && s.TTL <= 2 && s.Snt != 3 {
 			t.Errorf("TTL %d: Snt=%d, expected 3", s.TTL, s.Snt)
 		}
+	}
+}
+
+func TestSchedulerUsesExplicitResponseSemanticsForPathEnd(t *testing.T) {
+	dstIP := net.ParseIP("203.0.113.10")
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:  1,
+		MaxHops:   4,
+		MaxPerHop: 2,
+		DstIP:     dstIP,
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A Time Exceeded response from the target address is still transit.
+	rt.processProbeSuccess(2, mtrProbeResult{
+		TTL:      2,
+		Success:  true,
+		Addr:     &net.IPAddr{IP: dstIP},
+		RTT:      time.Millisecond,
+		Response: &MTRProbeResponse{Kind: MTRResponseTransit, Description: "ICMP Time Exceeded"},
+	}, time.Now())
+	if got := rt.pathTracker.pathEnd(); got != nil {
+		t.Fatalf("target-IP transit path end = %#v, want nil", got)
+	}
+	if rt.states[3].disabled || rt.states[4].disabled {
+		t.Fatal("target-IP transit disabled higher TTLs")
+	}
+
+	// TCP/UDP destination evidence may legitimately come from another address.
+	rt.processProbeSuccess(3, mtrProbeResult{
+		TTL:      3,
+		Success:  true,
+		Addr:     &net.TCPAddr{IP: net.ParseIP("198.51.100.44"), Port: 443},
+		RTT:      2 * time.Millisecond,
+		Response: &MTRProbeResponse{Kind: MTRResponseDestination, Description: "TCP RST"},
+	}, time.Now())
+	assertMTRPathEnd(t, rt.pathTracker.pathEnd(), 3, StopReasonDestination)
+	if !rt.states[4].disabled {
+		t.Fatal("different-source destination did not disable higher TTLs")
+	}
+}
+
+func TestSchedulerProvisionalEdgeDropsDisabledInFlightWithoutSpendingBudget(t *testing.T) {
+	var changes []*StopReason
+	agg := NewMTRAggregator()
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, agg, mtrSchedulerConfig{
+		BeginHop:  1,
+		MaxHops:   4,
+		MaxPerHop: 2,
+		OnPathEnd: func(reason *StopReason) {
+			changes = append(changes, reason)
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Preserve one already-counted high-TTL sample, then model another probe
+	// that was in flight when a lower provisional edge was observed.
+	rt.processProbeSuccess(4, mtrProbeResult{
+		TTL:      4,
+		Success:  true,
+		Addr:     &net.IPAddr{IP: net.ParseIP("192.0.2.4")},
+		RTT:      4 * time.Millisecond,
+		Response: &MTRProbeResponse{Kind: MTRResponseTransit},
+	}, time.Now())
+	rt.states[4].inFlightCount = 1
+	rt.inFlight = 1
+
+	rt.processProbeSuccess(2, mtrProbeResult{
+		TTL:      2,
+		Success:  true,
+		Addr:     &net.IPAddr{IP: net.ParseIP("192.0.2.2")},
+		RTT:      2 * time.Millisecond,
+		Response: &MTRProbeResponse{Kind: MTRResponseUnreachable, Marker: "!H"},
+	}, time.Now())
+	assertMTRPathEnd(t, rt.pathTracker.pathEnd(), 2, StopReasonUnreachable)
+	if got := rt.snapshotStats(); len(got) == 0 || got[len(got)-1].TTL > 2 {
+		t.Fatalf("provisional snapshot leaked higher TTLs: %#v", got)
+	}
+	if got := agg.Snapshot(); got[len(got)-1].TTL != 4 {
+		t.Fatalf("provisional filtering destroyed higher stats: %#v", got)
+	}
+
+	rt.processResult(mtrCompletedProbe{
+		ttl: 4,
+		result: mtrProbeResult{
+			TTL:      4,
+			Success:  true,
+			Addr:     &net.IPAddr{IP: net.ParseIP("192.0.2.40")},
+			Response: &MTRProbeResponse{Kind: MTRResponseDestination},
+		},
+		gen:    rt.generation,
+		doneAt: time.Now(),
+	})
+	if got := rt.states[4].completed; got != 1 {
+		t.Fatalf("disabled in-flight result spent budget: completed=%d, want 1", got)
+	}
+
+	rt.processProbeSuccess(2, mtrProbeResult{
+		TTL:      2,
+		Success:  true,
+		Addr:     &net.IPAddr{IP: net.ParseIP("192.0.2.2")},
+		RTT:      2 * time.Millisecond,
+		Response: &MTRProbeResponse{Kind: MTRResponseTransit},
+	}, time.Now())
+	if got := rt.pathTracker.pathEnd(); got != nil {
+		t.Fatalf("transit did not reopen provisional edge: %#v", got)
+	}
+	if rt.states[4].disabled {
+		t.Fatal("reopened TTL remained disabled")
+	}
+	if !rt.canLaunchProbe(4, time.Now()) {
+		t.Fatal("discarded high-TTL probe was not eligible for refill")
+	}
+	if got := rt.snapshotStats(); len(got) == 0 || got[len(got)-1].TTL != 4 {
+		t.Fatalf("reopened snapshot did not restore preserved high TTL: %#v", got)
+	}
+	if len(changes) != 2 || changes[0] == nil || changes[0].Reason != StopReasonUnreachable || changes[1] != nil {
+		t.Fatalf("path changes = %#v, want unreachable then nil", changes)
+	}
+}
+
+func TestSchedulerOnlyNaturalBoundedCompletionReportsMaxHops(t *testing.T) {
+	var natural []*StopReason
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:  1,
+		MaxHops:   3,
+		MaxPerHop: 1,
+		OnPathEnd: func(reason *StopReason) {
+			natural = append(natural, reason)
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for ttl := 1; ttl <= 3; ttl++ {
+		rt.states[ttl].completed = 1
+	}
+	if !rt.isDone() {
+		t.Fatal("fully-budgeted scheduler did not complete")
+	}
+	if len(natural) != 1 {
+		t.Fatalf("natural path changes = %#v, want one max_hops", natural)
+	}
+	assertMTRPathEnd(t, natural[0], 3, StopReasonMaxHops)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var canceled []*StopReason
+	cancelRT, err := newMTRSchedulerRuntime(ctx, &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:  1,
+		MaxHops:   3,
+		MaxPerHop: 1,
+		OnPathEnd: func(reason *StopReason) {
+			canceled = append(canceled, reason)
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cancelRT.handleCancel(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("handleCancel() = %v, want context.Canceled", err)
+	}
+	if len(canceled) != 0 || cancelRT.pathTracker.pathEnd() != nil {
+		t.Fatalf("cancel fabricated path end: callbacks=%#v state=%#v", canceled, cancelRT.pathTracker.pathEnd())
 	}
 }

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -117,10 +117,11 @@ func TestScheduler_MaxPerHopCompletion(t *testing.T) {
 			// Simulate: TTL 3 is the destination
 			if ttl == 3 {
 				return mtrProbeResult{
-					TTL:     ttl,
-					Success: true,
-					Addr:    &net.IPAddr{IP: dstIP},
-					RTT:     10 * time.Millisecond,
+					TTL:      ttl,
+					Success:  true,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      10 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -143,7 +144,6 @@ func TestScheduler_MaxPerHopCompletion(t *testing.T) {
 		MaxPerHop:        3,
 		ParallelRequests: 5,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, func(iter int, stats []MTRHopStat) {
 		atomic.AddInt32(&snapshotCount, 1)
 		lastIter = iter
@@ -219,10 +219,11 @@ func TestScheduler_DestinationDetection(t *testing.T) {
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			if ttl >= 5 {
 				return mtrProbeResult{
-					TTL:     ttl,
-					Success: true,
-					Addr:    &net.IPAddr{IP: dstIP},
-					RTT:     50 * time.Millisecond,
+					TTL:      ttl,
+					Success:  true,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      50 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -243,7 +244,6 @@ func TestScheduler_DestinationDetection(t *testing.T) {
 		MaxPerHop:        2,
 		ParallelRequests: 1, // serialize to ensure dest detection before higher TTLs
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -435,8 +435,9 @@ func TestScheduler_OnProbeCallback(t *testing.T) {
 			if ttl == 3 {
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  5 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -459,7 +460,6 @@ func TestScheduler_OnProbeCallback(t *testing.T) {
 		MaxPerHop:        1,
 		ParallelRequests: 5,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, func(result mtrProbeResult, _ int, _ time.Time) {
 		mu.Lock()
 		callbackResults = append(callbackResults, result)
@@ -2142,18 +2142,20 @@ func TestScheduler_HigherTTLDestinationRepliesDiscarded(t *testing.T) {
 				// so TTL 3's result is processed first.
 				time.Sleep(30 * time.Millisecond)
 				return mtrProbeResult{
-					TTL:     ttl,
-					Success: true,
-					Addr:    &net.IPAddr{IP: dstIP},
-					RTT:     time.Duration(ttl) * time.Millisecond,
+					TTL:      ttl,
+					Success:  true,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      time.Duration(ttl) * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 3 {
 				return mtrProbeResult{
-					TTL:     ttl,
-					Success: true,
-					Addr:    &net.IPAddr{IP: dstIP},
-					RTT:     time.Duration(ttl) * time.Millisecond,
+					TTL:      ttl,
+					Success:  true,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      time.Duration(ttl) * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2177,7 +2179,6 @@ func TestScheduler_HigherTTLDestinationRepliesDiscarded(t *testing.T) {
 		MaxPerHop:        3,
 		ParallelRequests: 6, // enough to launch TTLs 1-6 simultaneously
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, func(result mtrProbeResult, _ int, _ time.Time) {
 		mu.Lock()
 		probeByTTL[result.TTL]++
@@ -2233,10 +2234,11 @@ func TestScheduler_DiscardedDestinationRepliesCannotExceedMaxPerHop(t *testing.T
 			if ttl >= 2 {
 				// All TTLs >= 2 hit destination
 				return mtrProbeResult{
-					TTL:     ttl,
-					Success: true,
-					Addr:    &net.IPAddr{IP: dstIP},
-					RTT:     5 * time.Millisecond,
+					TTL:      ttl,
+					Success:  true,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2257,7 +2259,6 @@ func TestScheduler_DiscardedDestinationRepliesCannotExceedMaxPerHop(t *testing.T
 		MaxPerHop:        2, // strict cap
 		ParallelRequests: 10,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -2298,10 +2299,11 @@ func TestScheduler_NonDestinationRepliesOnDisabledHigherTTLDiscarded(t *testing.
 			if ttl == 3 {
 				// TTL 3 is destination — returns quickly
 				return mtrProbeResult{
-					TTL:     ttl,
-					Success: true,
-					Addr:    &net.IPAddr{IP: dstIP},
-					RTT:     5 * time.Millisecond,
+					TTL:      ttl,
+					Success:  true,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl > 3 {
@@ -2333,7 +2335,6 @@ func TestScheduler_NonDestinationRepliesOnDisabledHigherTTLDiscarded(t *testing.
 		MaxPerHop:        2,
 		ParallelRequests: 6, // all TTLs may launch before destination detected
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, func(result mtrProbeResult, _ int, _ time.Time) {
 		mu.Lock()
 		probeResults = append(probeResults, result)
@@ -2378,8 +2379,9 @@ func TestScheduler_FinalTTLLowered_MigratesStatsToNewFinal(t *testing.T) {
 				// TTL 12 returns destination quickly
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  3 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      3 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 7 {
@@ -2388,8 +2390,9 @@ func TestScheduler_FinalTTLLowered_MigratesStatsToNewFinal(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  5 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			// Intermediate hops
@@ -2410,7 +2413,6 @@ func TestScheduler_FinalTTLLowered_MigratesStatsToNewFinal(t *testing.T) {
 		MaxPerHop:        3,
 		ParallelRequests: 15,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -2463,24 +2465,27 @@ func TestScheduler_FinalTTLLowered_ChainMigration(t *testing.T) {
 			if ttl == 12 {
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  3 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      3 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 9 {
 				time.Sleep(30 * time.Millisecond)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  4 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      4 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 7 {
 				time.Sleep(60 * time.Millisecond)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  5 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2500,7 +2505,6 @@ func TestScheduler_FinalTTLLowered_ChainMigration(t *testing.T) {
 		MaxPerHop:        2,
 		ParallelRequests: 15,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -2538,8 +2542,9 @@ func TestScheduler_LateHigherTTLDestinationReply_Discarded_NoSntBump(t *testing.
 				// Destination — returns fast
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  3 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      3 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 5 {
@@ -2547,8 +2552,9 @@ func TestScheduler_LateHigherTTLDestinationReply_Discarded_NoSntBump(t *testing.
 				time.Sleep(40 * time.Millisecond)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  8 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      8 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2572,7 +2578,6 @@ func TestScheduler_LateHigherTTLDestinationReply_Discarded_NoSntBump(t *testing.
 		MaxPerHop:        2,
 		ParallelRequests: 6,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, func(result mtrProbeResult, _ int, _ time.Time) {
 		mu.Lock()
 		callbackCount++
@@ -2625,16 +2630,18 @@ func TestScheduler_DiscardedOverFinal_DoesNotEmitOnProbe(t *testing.T) {
 			if ttl == 2 {
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  5 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl > 2 {
 				time.Sleep(30 * time.Millisecond)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  10 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      10 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2664,7 +2671,6 @@ func TestScheduler_DiscardedOverFinal_DoesNotEmitOnProbe(t *testing.T) {
 		MaxPerHop:        2,
 		ParallelRequests: 5,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, onProbe)
 
 	if err != nil {
@@ -2722,8 +2728,9 @@ func TestScheduler_FinalTTLLowering_Chain_WithMaxPerHop_NoGhostRow_StableStats(t
 				}
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  rtt,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      rtt,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 9 {
@@ -2734,8 +2741,9 @@ func TestScheduler_FinalTTLLowering_Chain_WithMaxPerHop_NoGhostRow_StableStats(t
 				}
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  rtt,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      rtt,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 7 {
@@ -2746,8 +2754,9 @@ func TestScheduler_FinalTTLLowering_Chain_WithMaxPerHop_NoGhostRow_StableStats(t
 				}
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  rtt,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      rtt,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2767,7 +2776,6 @@ func TestScheduler_FinalTTLLowering_Chain_WithMaxPerHop_NoGhostRow_StableStats(t
 		MaxPerHop:        3,
 		ParallelRequests: 15,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -2847,8 +2855,9 @@ func TestScheduler_FinalHopSntNotInflated_NoLowering(t *testing.T) {
 			if ttl == 5 {
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  5 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2868,7 +2877,6 @@ func TestScheduler_FinalHopSntNotInflated_NoLowering(t *testing.T) {
 		MaxPerHop:        5,
 		ParallelRequests: 30,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -2901,8 +2909,9 @@ func TestScheduler_FinalHopSntNotInflated_WithLowering(t *testing.T) {
 				// Returns destination quickly (discovered first as provisional final)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  3 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      3 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			if ttl == 5 {
@@ -2910,8 +2919,9 @@ func TestScheduler_FinalHopSntNotInflated_WithLowering(t *testing.T) {
 				time.Sleep(30 * time.Millisecond)
 				return mtrProbeResult{
 					TTL: ttl, Success: true,
-					Addr: &net.IPAddr{IP: dstIP},
-					RTT:  5 * time.Millisecond,
+					Addr:     &net.IPAddr{IP: dstIP},
+					RTT:      5 * time.Millisecond,
+					Response: &MTRProbeResponse{Kind: MTRResponseDestination},
 				}, nil
 			}
 			return mtrProbeResult{
@@ -2931,7 +2941,6 @@ func TestScheduler_FinalHopSntNotInflated_WithLowering(t *testing.T) {
 		MaxPerHop:        4,
 		ParallelRequests: 15,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -2977,8 +2986,10 @@ func TestScheduler_MultiInFlightPerHop_HighLossEqualSnt(t *testing.T) {
 			// TTL 2: 80% loss (simulated as 80% of probes sleeping 200ms = "timeout")
 			// TTL 3: destination, fast
 			ip := net.ParseIP(fmt.Sprintf("10.0.0.%d", ttl))
+			var response *MTRProbeResponse
 			if ttl == 3 {
 				ip = dstIP
+				response = &MTRProbeResponse{Kind: MTRResponseDestination}
 			}
 
 			if ttl == 2 {
@@ -2988,10 +2999,11 @@ func TestScheduler_MultiInFlightPerHop_HighLossEqualSnt(t *testing.T) {
 			}
 
 			return mtrProbeResult{
-				TTL:     ttl,
-				Success: true,
-				Addr:    &net.IPAddr{IP: ip},
-				RTT:     5 * time.Millisecond,
+				TTL:      ttl,
+				Success:  true,
+				Addr:     &net.IPAddr{IP: ip},
+				RTT:      5 * time.Millisecond,
+				Response: response,
 			}, nil
 		},
 	}
@@ -3006,7 +3018,6 @@ func TestScheduler_MultiInFlightPerHop_HighLossEqualSnt(t *testing.T) {
 		MaxInFlightPerHop: 3,
 		ParallelRequests:  30,
 		ProgressThrottle:  time.Millisecond,
-		DstIP:             dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -3039,8 +3050,10 @@ func TestScheduler_MultiInFlightPerHop_TimeoutHopsKeepUp(t *testing.T) {
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			ip := net.ParseIP(fmt.Sprintf("10.0.0.%d", ttl))
+			var response *MTRProbeResponse
 			if ttl == 5 {
 				ip = dstIP
+				response = &MTRProbeResponse{Kind: MTRResponseDestination}
 			}
 
 			if ttl == 3 {
@@ -3054,10 +3067,11 @@ func TestScheduler_MultiInFlightPerHop_TimeoutHopsKeepUp(t *testing.T) {
 			}
 
 			return mtrProbeResult{
-				TTL:     ttl,
-				Success: true,
-				Addr:    &net.IPAddr{IP: ip},
-				RTT:     2 * time.Millisecond,
+				TTL:      ttl,
+				Success:  true,
+				Addr:     &net.IPAddr{IP: ip},
+				RTT:      2 * time.Millisecond,
+				Response: response,
 			}, nil
 		},
 	}
@@ -3072,7 +3086,6 @@ func TestScheduler_MultiInFlightPerHop_TimeoutHopsKeepUp(t *testing.T) {
 		MaxInFlightPerHop: 3,
 		ParallelRequests:  30,
 		ProgressThrottle:  time.Millisecond,
-		DstIP:             dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -3166,14 +3179,17 @@ func TestScheduler_MaxPerHopRespectedWithMultiInFlight(t *testing.T) {
 			time.Sleep(30 * time.Millisecond)
 
 			ip := net.ParseIP(fmt.Sprintf("10.0.0.%d", ttl))
+			var response *MTRProbeResponse
 			if ttl == 3 {
 				ip = dstIP
+				response = &MTRProbeResponse{Kind: MTRResponseDestination}
 			}
 			return mtrProbeResult{
-				TTL:     ttl,
-				Success: true,
-				Addr:    &net.IPAddr{IP: ip},
-				RTT:     5 * time.Millisecond,
+				TTL:      ttl,
+				Success:  true,
+				Addr:     &net.IPAddr{IP: ip},
+				RTT:      5 * time.Millisecond,
+				Response: response,
 			}, nil
 		},
 	}
@@ -3188,7 +3204,6 @@ func TestScheduler_MaxPerHopRespectedWithMultiInFlight(t *testing.T) {
 		MaxInFlightPerHop: 5, // higher than MaxPerHop to test the guard
 		ParallelRequests:  30,
 		ProgressThrottle:  time.Millisecond,
-		DstIP:             dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -3217,14 +3232,17 @@ func TestScheduler_SingleInFlightPerHopConfig(t *testing.T) {
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			ip := net.ParseIP(fmt.Sprintf("10.0.0.%d", ttl))
+			var response *MTRProbeResponse
 			if ttl == 3 {
 				ip = dstIP
+				response = &MTRProbeResponse{Kind: MTRResponseDestination}
 			}
 			return mtrProbeResult{
-				TTL:     ttl,
-				Success: true,
-				Addr:    &net.IPAddr{IP: ip},
-				RTT:     1 * time.Millisecond,
+				TTL:      ttl,
+				Success:  true,
+				Addr:     &net.IPAddr{IP: ip},
+				RTT:      1 * time.Millisecond,
+				Response: response,
 			}, nil
 		},
 	}
@@ -3239,7 +3257,6 @@ func TestScheduler_SingleInFlightPerHopConfig(t *testing.T) {
 		MaxInFlightPerHop: 1, // explicit single in-flight
 		ParallelRequests:  5,
 		ProgressThrottle:  time.Millisecond,
-		DstIP:             dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -3270,17 +3287,20 @@ func TestScheduler_DynamicMaxInFlightPerHop(t *testing.T) {
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			ip := net.ParseIP(fmt.Sprintf("10.0.0.%d", ttl))
+			var response *MTRProbeResponse
 			if ttl == 3 {
 				ip = dstIP
+				response = &MTRProbeResponse{Kind: MTRResponseDestination}
 			}
 			if ttl == 2 {
 				time.Sleep(500 * time.Millisecond) // full "timeout"
 			}
 			return mtrProbeResult{
-				TTL:     ttl,
-				Success: true,
-				Addr:    &net.IPAddr{IP: ip},
-				RTT:     2 * time.Millisecond,
+				TTL:      ttl,
+				Success:  true,
+				Addr:     &net.IPAddr{IP: ip},
+				RTT:      2 * time.Millisecond,
+				Response: response,
 			}, nil
 		},
 	}
@@ -3295,7 +3315,6 @@ func TestScheduler_DynamicMaxInFlightPerHop(t *testing.T) {
 		MaxPerHop:        8,
 		ParallelRequests: 30,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 		// MaxInFlightPerHop intentionally 0 → dynamic
 	}, nil, nil)
 
@@ -3324,13 +3343,16 @@ func TestScheduler_DynamicMaxInFlightPerHop_SmallTimeout(t *testing.T) {
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			ip := net.ParseIP(fmt.Sprintf("10.0.0.%d", ttl))
+			var response *MTRProbeResponse
 			if ttl == 2 {
 				ip = dstIP
+				response = &MTRProbeResponse{Kind: MTRResponseDestination}
 			}
 			return mtrProbeResult{
 				TTL: ttl, Success: true,
-				Addr: &net.IPAddr{IP: ip},
-				RTT:  1 * time.Millisecond,
+				Addr:     &net.IPAddr{IP: ip},
+				RTT:      1 * time.Millisecond,
+				Response: response,
 			}, nil
 		},
 	}
@@ -3345,7 +3367,6 @@ func TestScheduler_DynamicMaxInFlightPerHop_SmallTimeout(t *testing.T) {
 		MaxPerHop:        3,
 		ParallelRequests: 10,
 		ProgressThrottle: time.Millisecond,
-		DstIP:            dstIP,
 	}, nil, nil)
 
 	if err != nil {
@@ -3366,10 +3387,20 @@ func TestSchedulerUsesExplicitResponseSemanticsForPathEnd(t *testing.T) {
 		BeginHop:  1,
 		MaxHops:   4,
 		MaxPerHop: 2,
-		DstIP:     dstIP,
 	}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// A matching responder address without protocol evidence is not a path end.
+	rt.processProbeSuccess(1, mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: dstIP},
+		RTT:     time.Millisecond,
+	}, time.Now())
+	if got := rt.pathTracker.pathEnd(); got != nil {
+		t.Fatalf("target-IP response without semantics path end = %#v, want nil", got)
 	}
 
 	// A Time Exceeded response from the target address is still transit.
@@ -3501,6 +3532,10 @@ func TestSchedulerOnlyNaturalBoundedCompletionReportsMaxHops(t *testing.T) {
 	if !rt.isDone() {
 		t.Fatal("fully-budgeted scheduler did not complete")
 	}
+	if len(natural) != 0 || rt.pathTracker.pathEnd() != nil {
+		t.Fatalf("isDone mutated path end: callbacks=%#v state=%#v", natural, rt.pathTracker.pathEnd())
+	}
+	rt.finishRun()
 	if len(natural) != 1 {
 		t.Fatalf("natural path changes = %#v, want one max_hops", natural)
 	}

--- a/trace/mtr_stats.go
+++ b/trace/mtr_stats.go
@@ -14,19 +14,20 @@ import (
 
 // MTRHopStat 表示 MTR 输出中一行统计数据。
 type MTRHopStat struct {
-	TTL      int              `json:"ttl"`
-	Host     string           `json:"host,omitempty"`
-	IP       string           `json:"ip,omitempty"`
-	Loss     float64          `json:"loss_percent"`
-	Snt      int              `json:"snt"`
-	Last     float64          `json:"last_ms"`
-	Avg      float64          `json:"avg_ms"`
-	Best     float64          `json:"best_ms"`
-	Wrst     float64          `json:"wrst_ms"`
-	StDev    float64          `json:"stdev_ms"`
-	Geo      *ipgeo.IPGeoData `json:"geo,omitempty"`
-	MPLS     []string         `json:"mpls,omitempty"`
-	Received int              `json:"received"`
+	TTL      int               `json:"ttl"`
+	Host     string            `json:"host,omitempty"`
+	IP       string            `json:"ip,omitempty"`
+	Loss     float64           `json:"loss_percent"`
+	Snt      int               `json:"snt"`
+	Last     float64           `json:"last_ms"`
+	Avg      float64           `json:"avg_ms"`
+	Best     float64           `json:"best_ms"`
+	Wrst     float64           `json:"wrst_ms"`
+	StDev    float64           `json:"stdev_ms"`
+	Geo      *ipgeo.IPGeoData  `json:"geo,omitempty"`
+	MPLS     []string          `json:"mpls,omitempty"`
+	Received int               `json:"received"`
+	Response *MTRProbeResponse `json:"response,omitempty"`
 }
 
 // MTRSnapshot 是某一时刻的完整快照。
@@ -111,6 +112,27 @@ func (agg *MTRAggregator) ClearHop(ttl int) {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
 	delete(agg.stats, ttl)
+}
+
+// ClearAbove removes statistics beyond a confirmed sticky destination edge.
+func (agg *MTRAggregator) ClearAbove(ttl int) {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
+	for hop := range agg.stats {
+		if hop > ttl {
+			delete(agg.stats, hop)
+		}
+	}
+}
+
+func filterMTRStatsAtPathEnd(stats []MTRHopStat, ttl int) []MTRHopStat {
+	filtered := stats[:0]
+	for _, stat := range stats {
+		if stat.TTL <= ttl {
+			filtered = append(filtered, stat)
+		}
+	}
+	return filtered
 }
 
 // MigrateStats 将 fromTTL 上所有累加器迁移合并到 toTTL，然后删除 fromTTL。

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -80,7 +80,8 @@ func (t *TCPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFun
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
-			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+			if t.res.stopAfterTTL(ttl, t.MaxHops) {
+				t.final.Store(int32(ttl))
 				cancel(errNaturalDone) // 标记为“自然完成”
 				return
 			}
@@ -164,23 +165,10 @@ func (t *TCPTracer) dropSent(seq int) {
 	delete(t.sentAt, seq)
 }
 
-func (t *TCPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string) {
+func (t *TCPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		return
 	}
-
-	if ip := util.AddrIP(peer); ip != nil && ip.Equal(t.DstIP) {
-		for {
-			old := t.final.Load()
-			if old != -1 && ttl >= int(old) {
-				break
-			}
-			if t.final.CompareAndSwap(old, int32(ttl)) {
-				break
-			}
-		}
-	}
-
 	h := Hop{
 		Success: true,
 		Address: peer,
@@ -188,7 +176,7 @@ func (t *TCPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration
 		RTT:     rtt,
 		MPLS:    mpls,
 	}
-	t.res.addWithGeoAsync(h, i, t.NumMeasurements, t.MaxAttempts, t.Config)
+	t.res.addMatchedHop(h, response, &t.final, i, t.NumMeasurements, t.MaxAttempts, t.Config)
 }
 
 func (t *TCPTracer) matchWorker(ctx context.Context) {
@@ -240,7 +228,7 @@ func (t *TCPTracer) matchWorker(ctx context.Context) {
 
 			if t.clearPending(task.seq) {
 				rtt := task.finish.Sub(start)
-				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls)
+				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls, task.response)
 			}
 			t.dropSent(task.seq)
 		}
@@ -319,6 +307,7 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 			select {
 			case t.matchQ <- matchTask{
 				srcPort: srcPort, seq: seq, ack: ack, peer: peer, finish: finish, mpls: nil,
+				response: probeResponse{kind: probeResponseDestination},
 			}:
 			default:
 				// 丢弃以避免阻塞抓包循环
@@ -394,7 +383,7 @@ func (t *TCPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time.
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls,
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -307,7 +307,7 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 			select {
 			case t.matchQ <- matchTask{
 				srcPort: srcPort, seq: seq, ack: ack, peer: peer, finish: finish, mpls: nil,
-				response: probeResponse{kind: probeResponseDestination},
+				response: probeResponse{kind: probeResponseDestination, detail: "TCP Response"},
 			}:
 			default:
 				// 丢弃以避免阻塞抓包循环

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -55,10 +55,7 @@ func (t *TCPTracer) waitAllReady(ctx context.Context) {
 }
 
 func (t *TCPTracer) ttlComp(ttl int) bool {
-	idx := ttl - 1
-	t.res.lock.RLock()
-	defer t.res.lock.RUnlock()
-	return idx < len(t.res.Hops) && len(t.res.Hops[idx]) >= t.NumMeasurements
+	return t.res.ttlDisplayComplete(ttl, t.NumMeasurements)
 }
 
 func (t *TCPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
@@ -69,22 +66,14 @@ func (t *TCPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFun
 	defer ticker.Stop()
 
 	for {
-		if t.AsyncPrinter != nil {
-			t.AsyncPrinter(&t.res)
-		}
-
-		// 接收的时候检查一下是不是 3 跳都齐了
-		if t.ttlComp(ttl + 1) {
-			if t.RealtimePrinter != nil {
-				t.res.waitGeo(ctx, ttl)
-				t.RealtimePrinter(&t.res, ttl)
-			}
-			ttl++
-			if t.res.stopAfterTTL(ttl, t.MaxHops) {
-				t.final.Store(int32(ttl))
-				cancel(errNaturalDone) // 标记为“自然完成”
-				return
-			}
+		nextTTL, stop := advanceStableTracePrint(
+			ctx, &t.res, ttl, t.MaxHops, t.NumMeasurements, &t.final,
+			t.AsyncPrinter, t.RealtimePrinter,
+		)
+		ttl = nextTTL
+		if stop {
+			cancel(errNaturalDone)
+			return
 		}
 
 		select {
@@ -96,20 +85,35 @@ func (t *TCPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFun
 }
 
 func (t *TCPTracer) launchTTL(ctx context.Context, s *internal.TCPSpec, ttl int) {
+	t.wg.Add(1)
 	go func(ttl int) {
+		defer t.wg.Done()
+		defer t.res.markTTLLaunchDone(ttl)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
 
+			if !t.res.markAttemptLaunched(ttl, i, &t.final) {
+				return
+			}
 			t.wg.Add(1)
 			go func(ttl, i int) {
-				if err := t.send(ctx, s, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
+				defer t.wg.Done()
+				err := t.send(ctx, s, ttl, i)
+				if err != nil && !errors.Is(err, context.Canceled) {
 					if util.EnvDevMode {
 						panic(err)
 					}
 					fmt.Fprintf(os.Stderr, "send error (ttl=%d, attempt=%d): %v\n", ttl, i, err)
+				}
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+						t.res.addFailedAttempt(Hop{TTL: ttl, Error: err}, &t.final, i, t.NumMeasurements, t.MaxAttempts)
+					} else {
+						t.res.settleAttempt(ttl, i)
+					}
 				}
 			}(ttl, i)
 
@@ -167,6 +171,7 @@ func (t *TCPTracer) dropSent(seq int) {
 
 func (t *TCPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return
 	}
 	h := Hop{
@@ -307,7 +312,7 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 			select {
 			case t.matchQ <- matchTask{
 				srcPort: srcPort, seq: seq, ack: ack, peer: peer, finish: finish, mpls: nil,
-				response: probeResponse{kind: probeResponseDestination, detail: "TCP Response"},
+				response: probeResponseFromTCPAck(ack),
 			}:
 			default:
 				// 丢弃以避免阻塞抓包循环
@@ -334,6 +339,7 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
+				t.res.markTTLLaunchDone(ttl)
 				return
 			}
 
@@ -383,7 +389,7 @@ func (t *TCPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time.
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMPForMethod(msg.ICMP, TCPTrace),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环
@@ -391,10 +397,9 @@ func (t *TCPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time.
 }
 
 func (t *TCPTracer) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) error {
-	defer t.wg.Done()
-
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -404,11 +409,13 @@ func (t *TCPTracer) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) e
 	defer t.sem.Release(1)
 
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -453,18 +460,15 @@ func (t *TCPTracer) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) e
 
 	// 登记 pending，并启动超时守护
 	t.markPending(seq)
+	t.wg.Add(1)
 	go func(seq, ttl, i int) {
+		defer t.wg.Done()
 		if !waitForTraceDelay(ctx, t.Timeout) {
 			_ = t.clearPending(seq)
+			t.res.settleAttempt(ttl, i)
 			return
 		}
 		if !t.clearPending(seq) {
-			return
-		}
-		if f := t.final.Load(); f != -1 && ttl > int(f) {
-			return
-		}
-		if t.ttlComp(ttl) {
 			return
 		}
 
@@ -476,7 +480,7 @@ func (t *TCPTracer) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) e
 			Error:   errHopLimitTimeout,
 		}
 
-		_, _ = t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
+		t.res.addTimeout(h, &t.final, i, t.NumMeasurements, t.MaxAttempts)
 		t.dropSent(seq)
 	}(seq, ttl, i)
 

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -307,7 +307,7 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 			select {
 			case t.matchQ <- matchTask{
 				srcPort: srcPort, seq: seq, ack: ack, peer: peer, finish: finish, mpls: nil,
-				response: probeResponse{kind: probeResponseDestination},
+				response: probeResponse{kind: probeResponseDestination, detail: "TCP Response"},
 			}:
 			default:
 				// 丢弃以避免阻塞抓包循环

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -55,10 +55,7 @@ func (t *TCPTracerIPv6) waitAllReady(ctx context.Context) {
 }
 
 func (t *TCPTracerIPv6) ttlComp(ttl int) bool {
-	idx := ttl - 1
-	t.res.lock.RLock()
-	defer t.res.lock.RUnlock()
-	return idx < len(t.res.Hops) && len(t.res.Hops[idx]) >= t.NumMeasurements
+	return t.res.ttlDisplayComplete(ttl, t.NumMeasurements)
 }
 
 func (t *TCPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
@@ -69,22 +66,14 @@ func (t *TCPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCaus
 	defer ticker.Stop()
 
 	for {
-		if t.AsyncPrinter != nil {
-			t.AsyncPrinter(&t.res)
-		}
-
-		// 接收的时候检查一下是不是 3 跳都齐了
-		if t.ttlComp(ttl + 1) {
-			if t.RealtimePrinter != nil {
-				t.res.waitGeo(ctx, ttl)
-				t.RealtimePrinter(&t.res, ttl)
-			}
-			ttl++
-			if t.res.stopAfterTTL(ttl, t.MaxHops) {
-				t.final.Store(int32(ttl))
-				cancel(errNaturalDone) // 标记为“自然完成”
-				return
-			}
+		nextTTL, stop := advanceStableTracePrint(
+			ctx, &t.res, ttl, t.MaxHops, t.NumMeasurements, &t.final,
+			t.AsyncPrinter, t.RealtimePrinter,
+		)
+		ttl = nextTTL
+		if stop {
+			cancel(errNaturalDone)
+			return
 		}
 
 		select {
@@ -96,20 +85,35 @@ func (t *TCPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCaus
 }
 
 func (t *TCPTracerIPv6) launchTTL(ctx context.Context, s *internal.TCPSpec, ttl int) {
+	t.wg.Add(1)
 	go func(ttl int) {
+		defer t.wg.Done()
+		defer t.res.markTTLLaunchDone(ttl)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
 
+			if !t.res.markAttemptLaunched(ttl, i, &t.final) {
+				return
+			}
 			t.wg.Add(1)
 			go func(ttl, i int) {
-				if err := t.send(ctx, s, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
+				defer t.wg.Done()
+				err := t.send(ctx, s, ttl, i)
+				if err != nil && !errors.Is(err, context.Canceled) {
 					if util.EnvDevMode {
 						panic(err)
 					}
 					fmt.Fprintf(os.Stderr, "send error (ttl=%d, attempt=%d): %v\n", ttl, i, err)
+				}
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+						t.res.addFailedAttempt(Hop{TTL: ttl, Error: err}, &t.final, i, t.NumMeasurements, t.MaxAttempts)
+					} else {
+						t.res.settleAttempt(ttl, i)
+					}
 				}
 			}(ttl, i)
 
@@ -167,6 +171,7 @@ func (t *TCPTracerIPv6) dropSent(seq int) {
 
 func (t *TCPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return
 	}
 	h := Hop{
@@ -307,7 +312,7 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 			select {
 			case t.matchQ <- matchTask{
 				srcPort: srcPort, seq: seq, ack: ack, peer: peer, finish: finish, mpls: nil,
-				response: probeResponse{kind: probeResponseDestination, detail: "TCP Response"},
+				response: probeResponseFromTCPAck(ack),
 			}:
 			default:
 				// 丢弃以避免阻塞抓包循环
@@ -334,6 +339,7 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
+				t.res.markTTLLaunchDone(ttl)
 				return
 			}
 
@@ -383,7 +389,7 @@ func (t *TCPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMPForMethod(msg.ICMP, TCPTrace),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环
@@ -391,10 +397,9 @@ func (t *TCPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 }
 
 func (t *TCPTracerIPv6) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) error {
-	defer t.wg.Done()
-
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -404,11 +409,13 @@ func (t *TCPTracerIPv6) send(ctx context.Context, s *internal.TCPSpec, ttl, i in
 	defer t.sem.Release(1)
 
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -453,18 +460,15 @@ func (t *TCPTracerIPv6) send(ctx context.Context, s *internal.TCPSpec, ttl, i in
 
 	// 登记 pending，并启动超时守护
 	t.markPending(seq)
+	t.wg.Add(1)
 	go func(seq, ttl, i int) {
+		defer t.wg.Done()
 		if !waitForTraceDelay(ctx, t.Timeout) {
 			_ = t.clearPending(seq)
+			t.res.settleAttempt(ttl, i)
 			return
 		}
 		if !t.clearPending(seq) {
-			return
-		}
-		if f := t.final.Load(); f != -1 && ttl > int(f) {
-			return
-		}
-		if t.ttlComp(ttl) {
 			return
 		}
 
@@ -476,7 +480,7 @@ func (t *TCPTracerIPv6) send(ctx context.Context, s *internal.TCPSpec, ttl, i in
 			Error:   errHopLimitTimeout,
 		}
 
-		_, _ = t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
+		t.res.addTimeout(h, &t.final, i, t.NumMeasurements, t.MaxAttempts)
 		t.dropSent(seq)
 	}(seq, ttl, i)
 

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -80,7 +80,8 @@ func (t *TCPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCaus
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
-			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+			if t.res.stopAfterTTL(ttl, t.MaxHops) {
+				t.final.Store(int32(ttl))
 				cancel(errNaturalDone) // 标记为“自然完成”
 				return
 			}
@@ -164,23 +165,10 @@ func (t *TCPTracerIPv6) dropSent(seq int) {
 	delete(t.sentAt, seq)
 }
 
-func (t *TCPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string) {
+func (t *TCPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		return
 	}
-
-	if ip := util.AddrIP(peer); ip != nil && ip.Equal(t.DstIP) {
-		for {
-			old := t.final.Load()
-			if old != -1 && ttl >= int(old) {
-				break
-			}
-			if t.final.CompareAndSwap(old, int32(ttl)) {
-				break
-			}
-		}
-	}
-
 	h := Hop{
 		Success: true,
 		Address: peer,
@@ -188,7 +176,7 @@ func (t *TCPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Dura
 		RTT:     rtt,
 		MPLS:    mpls,
 	}
-	t.res.addWithGeoAsync(h, i, t.NumMeasurements, t.MaxAttempts, t.Config)
+	t.res.addMatchedHop(h, response, &t.final, i, t.NumMeasurements, t.MaxAttempts, t.Config)
 }
 
 func (t *TCPTracerIPv6) matchWorker(ctx context.Context) {
@@ -240,7 +228,7 @@ func (t *TCPTracerIPv6) matchWorker(ctx context.Context) {
 
 			if t.clearPending(task.seq) {
 				rtt := task.finish.Sub(start)
-				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls)
+				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls, task.response)
 			}
 			t.dropSent(task.seq)
 		}
@@ -319,6 +307,7 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 			select {
 			case t.matchQ <- matchTask{
 				srcPort: srcPort, seq: seq, ack: ack, peer: peer, finish: finish, mpls: nil,
+				response: probeResponse{kind: probeResponseDestination},
 			}:
 			default:
 				// 丢弃以避免阻塞抓包循环
@@ -394,7 +383,7 @@ func (t *TCPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls,
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -110,17 +110,27 @@ const (
 )
 
 type probeResponse struct {
-	kind   probeResponseKind
-	detail string
-	marker string
+	kind        probeResponseKind
+	detail      string
+	marker      string
+	responderIP string
 }
 
 func probeResponseFromICMP(response internal.ICMPResponse) probeResponse {
+	return probeResponseFromICMPForMethod(response, ICMPTrace)
+}
+
+func probeResponseFromICMPForMethod(response internal.ICMPResponse, method Method) probeResponse {
 	switch response.Kind {
 	case internal.ICMPResponseTransit:
 		return probeResponse{kind: probeResponseTransit, detail: response.Description}
-	case internal.ICMPResponseEchoReply, internal.ICMPResponsePortUnreachable:
+	case internal.ICMPResponseEchoReply:
 		return probeResponse{kind: probeResponseDestination, detail: response.Description}
+	case internal.ICMPResponsePortUnreachable:
+		if method == UDPTrace {
+			return probeResponse{kind: probeResponseDestination, detail: response.Description}
+		}
+		return probeResponse{kind: probeResponseUnreachable, detail: response.Description, marker: response.Marker}
 	case internal.ICMPResponseUnreachable:
 		return probeResponse{kind: probeResponseUnreachable, detail: response.Description, marker: response.Marker}
 	default:
@@ -128,8 +138,16 @@ func probeResponseFromICMP(response internal.ICMPResponse) probeResponse {
 	}
 }
 
-func markDestinationFinal(final *atomic.Int32, ttl int, response probeResponse) {
-	if final == nil || response.kind != probeResponseDestination {
+func probeResponseFromTCPAck(ack int) probeResponse {
+	detail := "TCP SYN/ACK"
+	if ack != 0 {
+		detail = "TCP RST"
+	}
+	return probeResponse{kind: probeResponseDestination, detail: detail}
+}
+
+func lowerTraceFinal(final *atomic.Int32, ttl int) {
+	if final == nil || ttl <= 0 {
 		return
 	}
 	for {
@@ -140,6 +158,12 @@ func markDestinationFinal(final *atomic.Int32, ttl int, response probeResponse) 
 		if final.CompareAndSwap(old, int32(ttl)) {
 			return
 		}
+	}
+}
+
+func markDestinationFinal(final *atomic.Int32, ttl int, response probeResponse) {
+	if response.kind == probeResponseDestination {
+		lowerTraceFinal(final, ttl)
 	}
 }
 
@@ -335,17 +359,30 @@ type Result struct {
 	lock        sync.RWMutex
 	tailDone    []bool
 	responses   map[int][]probeResponse
+	attempts    map[int]*traceTTLAttempts
+	provisional map[int]int
 	TraceMapUrl string
 	geoWait     time.Duration
 	geoWG       sync.WaitGroup
 	geoCanceled atomic.Bool
 }
 
+// StopReason describes why a finite traceroute stopped.
 type StopReason struct {
-	Hop       int
-	Reason    string
-	Responses []string `json:",omitempty"`
-	Details   []string `json:",omitempty"`
+	Hop int `json:"hop"`
+	// Reason is one of the StopReason constants.
+	Reason string `json:"reason"`
+	// Responses contains sorted response descriptions, including markers and
+	// responder addresses when available.
+	Responses []string `json:"responses,omitempty"`
+	// Markers contains only the sorted ICMP marker values.
+	Markers []string `json:"markers,omitempty"`
+}
+
+type traceTTLAttempts struct {
+	launched   map[int]struct{}
+	settled    map[int]struct{}
+	launchDone bool
 }
 
 const (
@@ -398,17 +435,16 @@ func isValidHop(h Hop) bool {
 	return h.Success && h.Address != nil
 }
 
-// add 带审计/限容
-// - N = numMeasurements（每个 TTL 组的最小输出条数）
-// - M = maxAttempts（每个 TTL 组的最大尝试条数）
-// 规则：对同一 TTL，attemptIdx < N-1 无条件放行（索引 i 从 0 开始）；第 N 条进行审计（已有有效 / 当次有效 / 达到最后一次尝试 任一成立即放行）；超过 N 条一律忽略
-func (s *Result) add(hop Hop, attemptIdx, numMeasurements, maxAttempts int) (bool, int) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
+func (s *Result) addLocked(hop Hop, attemptIdx, numMeasurements, maxAttempts int) (bool, int) {
 	k := hop.TTL - 1
+	if k < 0 || k >= len(s.Hops) {
+		return false, -1
+	}
 	bucket := s.Hops[k]
 	n := numMeasurements
+	if n <= 0 {
+		n = 1
+	}
 
 	switch {
 	case attemptIdx < n-1:
@@ -447,6 +483,90 @@ func (s *Result) add(hop Hop, attemptIdx, numMeasurements, maxAttempts int) (boo
 	return false, -1
 }
 
+func (s *Result) add(hop Hop, attemptIdx, numMeasurements, maxAttempts int) (bool, int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.addLocked(hop, attemptIdx, numMeasurements, maxAttempts)
+}
+
+func (s *Result) ttlAttemptsLocked(ttl int) *traceTTLAttempts {
+	if s.attempts == nil {
+		s.attempts = make(map[int]*traceTTLAttempts)
+	}
+	state := s.attempts[ttl]
+	if state == nil {
+		state = &traceTTLAttempts{
+			launched: make(map[int]struct{}),
+			settled:  make(map[int]struct{}),
+		}
+		s.attempts[ttl] = state
+	}
+	return state
+}
+
+func (s *Result) markAttemptLaunched(ttl, attemptIdx int, final *atomic.Int32) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if traceTTLAboveFinal(final, ttl) {
+		return false
+	}
+	s.ttlAttemptsLocked(ttl).launched[attemptIdx] = struct{}{}
+	return true
+}
+
+func (s *Result) markTTLLaunchDone(ttl int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.ttlAttemptsLocked(ttl).launchDone = true
+}
+
+func (s *Result) ttlDisplayComplete(ttl, numMeasurements int) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if ttl <= 0 || ttl > len(s.Hops) {
+		return false
+	}
+	if numMeasurements <= 0 {
+		numMeasurements = 1
+	}
+	return len(s.Hops[ttl-1]) >= numMeasurements
+}
+
+func (s *Result) ttlStableLocked(ttl, numMeasurements int) bool {
+	if ttl <= 0 || ttl > len(s.Hops) {
+		return false
+	}
+	state := s.attempts[ttl]
+	if state == nil || !state.launchDone || len(state.launched) != len(state.settled) {
+		return false
+	}
+	if numMeasurements <= 0 {
+		numMeasurements = 1
+	}
+	return len(s.Hops[ttl-1]) >= numMeasurements
+}
+
+func (s *Result) ttlStable(ttl, numMeasurements int) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.ttlStableLocked(ttl, numMeasurements)
+}
+
+func traceTTLAboveFinal(final *atomic.Int32, ttl int) bool {
+	if final == nil {
+		return false
+	}
+	known := final.Load()
+	return known > 0 && ttl > int(known)
+}
+
+func (s *Result) markAttemptSettledLocked(ttl, attemptIdx int) {
+	state := s.ttlAttemptsLocked(ttl)
+	if _, launched := state.launched[attemptIdx]; launched {
+		state.settled[attemptIdx] = struct{}{}
+	}
+}
+
 func (s *Result) setGeoWait(numMeasurements int) {
 	s.geoWait = geoWaitForMeasurements(numMeasurements)
 }
@@ -476,7 +596,10 @@ func (s *Result) recordResponse(ttl int, response probeResponse) {
 func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	return s.stopAfterTTLLocked(ttl, maxHops)
+}
 
+func (s *Result) stopAfterTTLLocked(ttl, maxHops int) bool {
 	if ttl <= 0 || ttl > len(s.Hops) {
 		return false
 	}
@@ -518,7 +641,7 @@ func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
 			Hop:       ttl,
 			Reason:    StopReasonUnreachable,
 			Responses: sortedResponseDetails(unreachableDetails),
-			Details:   sortedResponseDetails(markers),
+			Markers:   sortedResponseDetails(markers),
 		}
 		return true
 	case ttl >= maxHops:
@@ -527,6 +650,107 @@ func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
 	default:
 		return false
 	}
+}
+
+func (s *Result) stopAfterStableTTL(ttl, maxHops, numMeasurements int, final *atomic.Int32) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if final != nil {
+		known := int(final.Load())
+		if known > 0 && known < ttl {
+			ttl = known
+		}
+	}
+	if !s.ttlStableLocked(ttl, numMeasurements) || !s.stopAfterTTLLocked(ttl, maxHops) {
+		return false
+	}
+	lowerTraceFinal(final, ttl)
+	return true
+}
+
+func (s *Result) stableFinalAtOrBefore(cursor, maxHops, numMeasurements int, final *atomic.Int32) bool {
+	if final == nil {
+		return false
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	known := int(final.Load())
+	if known <= 0 || known > cursor || !s.ttlStableLocked(known, numMeasurements) || !s.stopAfterTTLLocked(known, maxHops) {
+		return false
+	}
+	lowerTraceFinal(final, known)
+	return true
+}
+
+func (s *Result) snapshotThroughTTL(ttl int) *Result {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	snapshot := &Result{
+		Hops:        make([][]Hop, len(s.Hops)),
+		TraceMapUrl: s.TraceMapUrl,
+		responses:   make(map[int][]probeResponse),
+	}
+	if ttl > len(s.Hops) {
+		ttl = len(s.Hops)
+	}
+	for ttlIdx := 0; ttlIdx < ttl; ttlIdx++ {
+		snapshot.Hops[ttlIdx] = make([]Hop, len(s.Hops[ttlIdx]))
+		for i, hop := range s.Hops[ttlIdx] {
+			if hop.Geo != nil {
+				geo := *hop.Geo
+				hop.Geo = &geo
+			}
+			hop.MPLS = append([]string(nil), hop.MPLS...)
+			snapshot.Hops[ttlIdx][i] = hop
+		}
+	}
+	for responseTTL, responses := range s.responses {
+		if responseTTL <= ttl {
+			snapshot.responses[responseTTL] = append([]probeResponse(nil), responses...)
+		}
+	}
+	if s.StopReason != nil {
+		reason := *s.StopReason
+		reason.Responses = append([]string(nil), reason.Responses...)
+		reason.Markers = append([]string(nil), reason.Markers...)
+		snapshot.StopReason = &reason
+	}
+	return snapshot
+}
+
+func advanceStableTracePrint(
+	ctx context.Context,
+	res *Result,
+	cursor, maxHops, numMeasurements int,
+	final *atomic.Int32,
+	asyncPrinter func(*Result),
+	realtimePrinter func(*Result, int),
+) (nextCursor int, stop bool) {
+	if res == nil || (ctx != nil && ctx.Err() != nil) {
+		return cursor, false
+	}
+	if res.stableFinalAtOrBefore(cursor, maxHops, numMeasurements, final) {
+		return cursor, true
+	}
+
+	nextTTL := cursor + 1
+	if !res.ttlStable(nextTTL, numMeasurements) {
+		return cursor, false
+	}
+
+	stop = res.stopAfterStableTTL(nextTTL, maxHops, numMeasurements, final)
+	if asyncPrinter != nil {
+		asyncPrinter(res.snapshotThroughTTL(nextTTL))
+	}
+	if realtimePrinter != nil {
+		res.waitGeo(ctx, nextTTL-1)
+		if ctx != nil && ctx.Err() != nil {
+			return cursor, false
+		}
+		realtimePrinter(res.snapshotThroughTTL(nextTTL), nextTTL-1)
+	}
+	return nextTTL, stop
 }
 
 func addResponseDetail(details map[string]struct{}, response probeResponse) {
@@ -613,6 +837,9 @@ func (s *Result) updateHop(ttl, idx int, updated Hop) {
 	}
 
 	h := &s.Hops[k][idx]
+	if h.Address == nil || updated.Address == nil || h.Address.String() != updated.Address.String() {
+		return
+	}
 	if updated.Hostname != "" {
 		h.Hostname = updated.Hostname
 	}
@@ -705,22 +932,45 @@ func (s *Result) markAllPendingGeoTimeout() {
 	}
 }
 
-func (s *Result) addMatchedHop(hop Hop, response probeResponse, final *atomic.Int32, attemptIdx, numMeasurements, maxAttempts int, cfg Config) {
-	s.recordResponse(hop.TTL, response)
+func (s *Result) addMatchedHop(hop Hop, response probeResponse, final *atomic.Int32, attemptIdx, numMeasurements, maxAttempts int, cfg Config) bool {
+	needsMetadata := cfg.IPGeoSource != nil || cfg.RDNS
+	prepareHopMetadata(&hop, cfg)
+
+	s.lock.Lock()
+	if s.attemptSettledLocked(hop.TTL, attemptIdx) {
+		s.lock.Unlock()
+		return false
+	}
+	if traceTTLAboveFinal(final, hop.TTL) {
+		s.markAttemptSettledLocked(hop.TTL, attemptIdx)
+		s.lock.Unlock()
+		return false
+	}
+	if response.kind != probeResponseUnknown {
+		if s.responses == nil {
+			s.responses = make(map[int][]probeResponse)
+		}
+		response = responseWithPeer(response, hop.Address)
+		s.responses[hop.TTL] = append(s.responses[hop.TTL], response)
+	}
 	markDestinationFinal(final, hop.TTL, response)
-	s.addWithGeoAsync(hop, attemptIdx, numMeasurements, maxAttempts, cfg)
+	added, idx := s.addLocked(hop, attemptIdx, numMeasurements, maxAttempts)
+	if !added {
+		idx = s.promoteWinningResponseLocked(hop, response, numMeasurements)
+		added = idx >= 0
+	}
+	s.markAttemptSettledLocked(hop.TTL, attemptIdx)
+	s.lock.Unlock()
+
+	if added && needsMetadata {
+		s.launchHopMetadata(hop, idx, cfg)
+	}
+	return added
 }
 
 func (s *Result) addWithGeoAsync(hop Hop, attemptIdx, numMeasurements, maxAttempts int, cfg Config) {
 	needsMetadata := cfg.IPGeoSource != nil || cfg.RDNS
-	if cfg.IPGeoSource != nil && hop.Geo == nil {
-		hop.Geo = pendingGeo()
-	} else if cfg.IPGeoSource != nil && hop.Geo.Source == "" {
-		hop.Geo.Source = PendingGeoSource
-	}
-	if hop.Lang == "" {
-		hop.Lang = cfg.Lang
-	}
+	prepareHopMetadata(&hop, cfg)
 
 	added, idx := s.add(hop, attemptIdx, numMeasurements, maxAttempts)
 	if !added {
@@ -730,6 +980,21 @@ func (s *Result) addWithGeoAsync(hop Hop, attemptIdx, numMeasurements, maxAttemp
 		return
 	}
 
+	s.launchHopMetadata(hop, idx, cfg)
+}
+
+func prepareHopMetadata(hop *Hop, cfg Config) {
+	if cfg.IPGeoSource != nil && hop.Geo == nil {
+		hop.Geo = pendingGeo()
+	} else if cfg.IPGeoSource != nil && hop.Geo.Source == "" {
+		hop.Geo.Source = PendingGeoSource
+	}
+	if hop.Lang == "" {
+		hop.Lang = cfg.Lang
+	}
+}
+
+func (s *Result) launchHopMetadata(hop Hop, idx int, cfg Config) {
 	s.geoWG.Add(1)
 	go func(ttl, idx int, h Hop) {
 		defer s.geoWG.Done()
@@ -738,6 +1003,125 @@ func (s *Result) addWithGeoAsync(hop Hop, attemptIdx, numMeasurements, maxAttemp
 			s.updateHop(ttl, idx, h)
 		}
 	}(hop.TTL, idx, hop)
+}
+
+func isTerminalResponse(response probeResponse) bool {
+	return response.kind == probeResponseDestination || response.kind == probeResponseUnreachable
+}
+
+func responseWithPeer(response probeResponse, peer net.Addr) probeResponse {
+	if peer == nil {
+		return response
+	}
+	peerIP := util.AddrIP(peer)
+	if peerIP == nil {
+		return response
+	}
+	response.responderIP = peerIP.String()
+	if !isTerminalResponse(response) {
+		return response
+	}
+	if response.detail == "" {
+		response.detail = response.responderIP
+	} else {
+		response.detail += " from " + response.responderIP
+	}
+	return response
+}
+
+func (s *Result) promoteWinningResponseLocked(hop Hop, response probeResponse, numMeasurements int) int {
+	k := hop.TTL - 1
+	if k < 0 || k >= len(s.Hops) || len(s.Hops[k]) == 0 {
+		return -1
+	}
+	if idx, ok := s.provisional[hop.TTL]; ok {
+		switch response.kind {
+		case probeResponseDestination, probeResponseTransit:
+			if idx >= 0 && idx < len(s.Hops[k]) {
+				s.Hops[k][idx] = hop
+				delete(s.provisional, hop.TTL)
+				return idx
+			}
+		case probeResponseUnreachable:
+			return -1
+		}
+	}
+	if response.kind != probeResponseDestination &&
+		(response.kind != probeResponseUnreachable || !s.unreachableWinsLocked(hop.TTL)) {
+		return -1
+	}
+	limit := numMeasurements
+	if limit <= 0 || limit > len(s.Hops[k]) {
+		limit = len(s.Hops[k])
+	}
+	for i := limit - 1; i >= 0; i-- {
+		if !isValidHop(s.Hops[k][i]) {
+			s.Hops[k][i] = hop
+			if response.kind == probeResponseUnreachable {
+				s.rememberProvisionalLocked(hop.TTL, i)
+			}
+			return i
+		}
+	}
+	s.Hops[k][limit-1] = hop
+	if response.kind == probeResponseUnreachable {
+		s.rememberProvisionalLocked(hop.TTL, limit-1)
+	}
+	return limit - 1
+}
+
+func (s *Result) rememberProvisionalLocked(ttl, idx int) {
+	if s.provisional == nil {
+		s.provisional = make(map[int]int)
+	}
+	s.provisional[ttl] = idx
+}
+
+func (s *Result) unreachableWinsLocked(ttl int) bool {
+	hasUnreachable := false
+	for _, response := range s.responses[ttl] {
+		switch response.kind {
+		case probeResponseDestination, probeResponseTransit:
+			return false
+		case probeResponseUnreachable:
+			hasUnreachable = true
+		}
+	}
+	return hasUnreachable
+}
+
+func (s *Result) addTimeout(hop Hop, final *atomic.Int32, attemptIdx, numMeasurements, maxAttempts int) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.attemptSettledLocked(hop.TTL, attemptIdx) {
+		return false
+	}
+	if traceTTLAboveFinal(final, hop.TTL) {
+		s.markAttemptSettledLocked(hop.TTL, attemptIdx)
+		return false
+	}
+	added, _ := s.addLocked(hop, attemptIdx, numMeasurements, maxAttempts)
+	s.markAttemptSettledLocked(hop.TTL, attemptIdx)
+	return added
+}
+
+func (s *Result) addFailedAttempt(hop Hop, final *atomic.Int32, attemptIdx, numMeasurements, maxAttempts int) bool {
+	return s.addTimeout(hop, final, attemptIdx, numMeasurements, maxAttempts)
+}
+
+func (s *Result) attemptSettledLocked(ttl, attemptIdx int) bool {
+	state := s.attempts[ttl]
+	if state == nil {
+		return false
+	}
+	_, settled := state.settled[attemptIdx]
+	return settled
+}
+
+func (s *Result) settleAttempt(ttl, attemptIdx int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.markAttemptSettledLocked(ttl, attemptIdx)
 }
 
 func geoLookupMaxRetries(numMeasurements int) int {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -111,17 +111,18 @@ const (
 
 type probeResponse struct {
 	kind   probeResponseKind
+	detail string
 	marker string
 }
 
 func probeResponseFromICMP(response internal.ICMPResponse) probeResponse {
 	switch response.Kind {
 	case internal.ICMPResponseTransit:
-		return probeResponse{kind: probeResponseTransit}
+		return probeResponse{kind: probeResponseTransit, detail: response.Description}
 	case internal.ICMPResponseEchoReply, internal.ICMPResponsePortUnreachable:
-		return probeResponse{kind: probeResponseDestination}
+		return probeResponse{kind: probeResponseDestination, detail: response.Description}
 	case internal.ICMPResponseUnreachable:
-		return probeResponse{kind: probeResponseUnreachable, marker: response.Marker}
+		return probeResponse{kind: probeResponseUnreachable, detail: response.Description, marker: response.Marker}
 	default:
 		return probeResponse{}
 	}
@@ -341,9 +342,10 @@ type Result struct {
 }
 
 type StopReason struct {
-	Hop     int
-	Reason  string
-	Details []string `json:",omitempty"`
+	Hop       int
+	Reason    string
+	Responses []string `json:",omitempty"`
+	Details   []string `json:",omitempty"`
 }
 
 const (
@@ -483,14 +485,18 @@ func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
 	hasDestination := false
 	hasUnreachable := false
 	markers := make(map[string]struct{})
+	destinationDetails := make(map[string]struct{})
+	unreachableDetails := make(map[string]struct{})
 	for _, response := range s.responses[ttl] {
 		switch response.kind {
 		case probeResponseTransit:
 			hasTransit = true
 		case probeResponseDestination:
 			hasDestination = true
+			addResponseDetail(destinationDetails, response)
 		case probeResponseUnreachable:
 			hasUnreachable = true
+			addResponseDetail(unreachableDetails, response)
 			if response.marker != "" {
 				markers[response.marker] = struct{}{}
 			}
@@ -499,17 +505,21 @@ func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
 
 	switch {
 	case hasDestination:
-		s.StopReason = &StopReason{Hop: ttl, Reason: StopReasonDestination}
+		s.StopReason = &StopReason{
+			Hop:       ttl,
+			Reason:    StopReasonDestination,
+			Responses: sortedResponseDetails(destinationDetails),
+		}
 		return true
 	case hasTransit && ttl < maxHops:
 		return false
 	case !hasTransit && hasUnreachable:
-		details := make([]string, 0, len(markers))
-		for marker := range markers {
-			details = append(details, marker)
+		s.StopReason = &StopReason{
+			Hop:       ttl,
+			Reason:    StopReasonUnreachable,
+			Responses: sortedResponseDetails(unreachableDetails),
+			Details:   sortedResponseDetails(markers),
 		}
-		sort.Strings(details)
-		s.StopReason = &StopReason{Hop: ttl, Reason: StopReasonUnreachable, Details: details}
 		return true
 	case ttl >= maxHops:
 		s.StopReason = &StopReason{Hop: ttl, Reason: StopReasonMaxHops}
@@ -517,6 +527,26 @@ func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
 	default:
 		return false
 	}
+}
+
+func addResponseDetail(details map[string]struct{}, response probeResponse) {
+	if response.detail == "" {
+		return
+	}
+	detail := response.detail
+	if response.marker != "" {
+		detail = fmt.Sprintf("%s (%s)", detail, response.marker)
+	}
+	details[detail] = struct{}{}
+}
+
+func sortedResponseDetails(details map[string]struct{}) []string {
+	result := make([]string, 0, len(details))
+	for detail := range details {
+		result = append(result, detail)
+	}
+	sort.Strings(result)
+	return result
 }
 
 type Hop struct {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -90,12 +91,55 @@ type sentInfo struct {
 }
 
 type matchTask struct {
-	srcPort int
-	seq     int
-	ack     int
-	peer    net.Addr
-	finish  time.Time
-	mpls    []string
+	srcPort  int
+	seq      int
+	ack      int
+	peer     net.Addr
+	finish   time.Time
+	mpls     []string
+	response probeResponse
+}
+
+type probeResponseKind uint8
+
+const (
+	probeResponseUnknown probeResponseKind = iota
+	probeResponseTransit
+	probeResponseDestination
+	probeResponseUnreachable
+)
+
+type probeResponse struct {
+	kind   probeResponseKind
+	marker string
+}
+
+func probeResponseFromICMP(response internal.ICMPResponse) probeResponse {
+	switch response.Kind {
+	case internal.ICMPResponseTransit:
+		return probeResponse{kind: probeResponseTransit}
+	case internal.ICMPResponseEchoReply, internal.ICMPResponsePortUnreachable:
+		return probeResponse{kind: probeResponseDestination}
+	case internal.ICMPResponseUnreachable:
+		return probeResponse{kind: probeResponseUnreachable, marker: response.Marker}
+	default:
+		return probeResponse{}
+	}
+}
+
+func markDestinationFinal(final *atomic.Int32, ttl int, response probeResponse) {
+	if final == nil || response.kind != probeResponseDestination {
+		return
+	}
+	for {
+		old := final.Load()
+		if old != -1 && ttl >= int(old) {
+			return
+		}
+		if final.CompareAndSwap(old, int32(ttl)) {
+			return
+		}
+	}
 }
 
 type Tracer interface {
@@ -286,13 +330,27 @@ func normalizeRuntimeConfig(config *Config) {
 
 type Result struct {
 	Hops        [][]Hop
+	StopReason  *StopReason `json:",omitempty"`
 	lock        sync.RWMutex
 	tailDone    []bool
+	responses   map[int][]probeResponse
 	TraceMapUrl string
 	geoWait     time.Duration
 	geoWG       sync.WaitGroup
 	geoCanceled atomic.Bool
 }
+
+type StopReason struct {
+	Hop     int
+	Reason  string
+	Details []string `json:",omitempty"`
+}
+
+const (
+	StopReasonDestination = "destination_reached"
+	StopReasonUnreachable = "unreachable"
+	StopReasonMaxHops     = "max_hops"
+)
 
 const PendingGeoSource = "pending"
 const timeoutGeoSource = "timeout"
@@ -397,6 +455,67 @@ func (s *Result) reduce(final int) {
 
 	if final > 0 && final < len(s.Hops) {
 		s.Hops = s.Hops[:final]
+	}
+}
+
+func (s *Result) recordResponse(ttl int, response probeResponse) {
+	if ttl <= 0 || response.kind == probeResponseUnknown {
+		return
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.responses == nil {
+		s.responses = make(map[int][]probeResponse)
+	}
+	s.responses[ttl] = append(s.responses[ttl], response)
+}
+
+func (s *Result) stopAfterTTL(ttl, maxHops int) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if ttl <= 0 || ttl > len(s.Hops) {
+		return false
+	}
+
+	hasTransit := false
+	hasDestination := false
+	hasUnreachable := false
+	markers := make(map[string]struct{})
+	for _, response := range s.responses[ttl] {
+		switch response.kind {
+		case probeResponseTransit:
+			hasTransit = true
+		case probeResponseDestination:
+			hasDestination = true
+		case probeResponseUnreachable:
+			hasUnreachable = true
+			if response.marker != "" {
+				markers[response.marker] = struct{}{}
+			}
+		}
+	}
+
+	switch {
+	case hasDestination:
+		s.StopReason = &StopReason{Hop: ttl, Reason: StopReasonDestination}
+		return true
+	case hasTransit && ttl < maxHops:
+		return false
+	case !hasTransit && hasUnreachable:
+		details := make([]string, 0, len(markers))
+		for marker := range markers {
+			details = append(details, marker)
+		}
+		sort.Strings(details)
+		s.StopReason = &StopReason{Hop: ttl, Reason: StopReasonUnreachable, Details: details}
+		return true
+	case ttl >= maxHops:
+		s.StopReason = &StopReason{Hop: ttl, Reason: StopReasonMaxHops}
+		return true
+	default:
+		return false
 	}
 }
 
@@ -554,6 +673,12 @@ func (s *Result) markAllPendingGeoTimeout() {
 			hop.Geo = timeoutGeo()
 		}
 	}
+}
+
+func (s *Result) addMatchedHop(hop Hop, response probeResponse, final *atomic.Int32, attemptIdx, numMeasurements, maxAttempts int, cfg Config) {
+	s.recordResponse(hop.TTL, response)
+	markDestinationFinal(final, hop.TTL, response)
+	s.addWithGeoAsync(hop, attemptIdx, numMeasurements, maxAttempts, cfg)
 }
 
 func (s *Result) addWithGeoAsync(hop Hop, attemptIdx, numMeasurements, maxAttempts int, cfg Config) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -128,7 +128,7 @@ func probeResponseFromICMPForMethod(response internal.ICMPResponse, method Metho
 		return probeResponse{kind: probeResponseDestination, detail: response.Description}
 	case internal.ICMPResponsePortUnreachable:
 		if method == UDPTrace {
-			return probeResponse{kind: probeResponseDestination, detail: response.Description}
+			return probeResponse{kind: probeResponseDestination, detail: response.Description, marker: response.Marker}
 		}
 		return probeResponse{kind: probeResponseUnreachable, detail: response.Description, marker: response.Marker}
 	case internal.ICMPResponseUnreachable:
@@ -372,10 +372,10 @@ type StopReason struct {
 	Hop int `json:"hop"`
 	// Reason is one of the StopReason constants.
 	Reason string `json:"reason"`
-	// Responses contains sorted response descriptions, including markers and
-	// responder addresses when available.
+	// Responses contains sorted, deduplicated human-readable response
+	// descriptions and responder addresses when available.
 	Responses []string `json:"responses,omitempty"`
-	// Markers contains only the sorted ICMP marker values.
+	// Markers contains sorted, deduplicated machine-readable ICMP marker values.
 	Markers []string `json:"markers,omitempty"`
 }
 
@@ -607,7 +607,8 @@ func (s *Result) stopAfterTTLLocked(ttl, maxHops int) bool {
 	hasTransit := false
 	hasDestination := false
 	hasUnreachable := false
-	markers := make(map[string]struct{})
+	destinationMarkers := make(map[string]struct{})
+	unreachableMarkers := make(map[string]struct{})
 	destinationDetails := make(map[string]struct{})
 	unreachableDetails := make(map[string]struct{})
 	for _, response := range s.responses[ttl] {
@@ -617,11 +618,14 @@ func (s *Result) stopAfterTTLLocked(ttl, maxHops int) bool {
 		case probeResponseDestination:
 			hasDestination = true
 			addResponseDetail(destinationDetails, response)
+			if response.marker != "" {
+				destinationMarkers[response.marker] = struct{}{}
+			}
 		case probeResponseUnreachable:
 			hasUnreachable = true
 			addResponseDetail(unreachableDetails, response)
 			if response.marker != "" {
-				markers[response.marker] = struct{}{}
+				unreachableMarkers[response.marker] = struct{}{}
 			}
 		}
 	}
@@ -632,6 +636,7 @@ func (s *Result) stopAfterTTLLocked(ttl, maxHops int) bool {
 			Hop:       ttl,
 			Reason:    StopReasonDestination,
 			Responses: sortedResponseDetails(destinationDetails),
+			Markers:   sortedResponseDetails(destinationMarkers),
 		}
 		return true
 	case hasTransit && ttl < maxHops:
@@ -641,7 +646,7 @@ func (s *Result) stopAfterTTLLocked(ttl, maxHops int) bool {
 			Hop:       ttl,
 			Reason:    StopReasonUnreachable,
 			Responses: sortedResponseDetails(unreachableDetails),
-			Markers:   sortedResponseDetails(markers),
+			Markers:   sortedResponseDetails(unreachableMarkers),
 		}
 		return true
 	case ttl >= maxHops:
@@ -757,11 +762,7 @@ func addResponseDetail(details map[string]struct{}, response probeResponse) {
 	if response.detail == "" {
 		return
 	}
-	detail := response.detail
-	if response.marker != "" {
-		detail = fmt.Sprintf("%s (%s)", detail, response.marker)
-	}
-	details[detail] = struct{}{}
+	details[response.detail] = struct{}{}
 }
 
 func sortedResponseDetails(details map[string]struct{}) []string {

--- a/trace/trace_stop_test.go
+++ b/trace/trace_stop_test.go
@@ -17,9 +17,9 @@ func resultWithResponses(responses ...probeResponse) *Result {
 
 func TestStopAfterTTLDestinationWins(t *testing.T) {
 	res := resultWithResponses(
-		probeResponse{kind: probeResponseTransit},
-		probeResponse{kind: probeResponseDestination},
-		probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+		probeResponse{kind: probeResponseTransit, detail: "ICMP Time Exceeded"},
+		probeResponse{kind: probeResponseDestination, detail: "ICMP Echo Reply"},
+		probeResponse{kind: probeResponseUnreachable, detail: "ICMP Host Unreachable", marker: "!H"},
 	)
 
 	if !res.stopAfterTTL(1, 30) {
@@ -27,6 +27,9 @@ func TestStopAfterTTLDestinationWins(t *testing.T) {
 	}
 	if got := res.StopReason; got == nil || got.Reason != StopReasonDestination || got.Hop != 1 {
 		t.Fatalf("StopReason = %#v, want destination at hop 1", got)
+	}
+	if !reflect.DeepEqual(res.StopReason.Responses, []string{"ICMP Echo Reply"}) {
+		t.Fatalf("StopReason.Responses = %#v, want destination response only", res.StopReason.Responses)
 	}
 }
 
@@ -71,17 +74,20 @@ func TestStopAfterTTLTargetIPTimeExceededContinues(t *testing.T) {
 
 func TestStopAfterTTLAllResponsesUnreachable(t *testing.T) {
 	res := resultWithResponses(
-		probeResponse{kind: probeResponseUnreachable, marker: "!N"},
-		probeResponse{kind: probeResponseUnreachable, marker: "!H"},
-		probeResponse{kind: probeResponseUnreachable, marker: "!N"},
+		probeResponse{kind: probeResponseUnreachable, detail: "ICMP Network Unreachable", marker: "!N"},
+		probeResponse{kind: probeResponseUnreachable, detail: "ICMP Host Unreachable", marker: "!H"},
+		probeResponse{kind: probeResponseUnreachable, detail: "ICMP Network Unreachable", marker: "!N"},
 	)
 
 	if !res.stopAfterTTL(1, 30) {
 		t.Fatal("stopAfterTTL() = false, want true")
 	}
-	want := &StopReason{Hop: 1, Reason: StopReasonUnreachable, Details: []string{"!H", "!N"}}
-	if !reflect.DeepEqual(res.StopReason, want) {
-		t.Fatalf("StopReason = %#v, want %#v", res.StopReason, want)
+	if !reflect.DeepEqual(res.StopReason.Details, []string{"!H", "!N"}) {
+		t.Fatalf("StopReason.Details = %#v, want %#v", res.StopReason.Details, []string{"!H", "!N"})
+	}
+	wantResponses := []string{"ICMP Host Unreachable (!H)", "ICMP Network Unreachable (!N)"}
+	if !reflect.DeepEqual(res.StopReason.Responses, wantResponses) {
+		t.Fatalf("StopReason.Responses = %#v, want %#v", res.StopReason.Responses, wantResponses)
 	}
 }
 

--- a/trace/trace_stop_test.go
+++ b/trace/trace_stop_test.go
@@ -1,0 +1,191 @@
+package trace
+
+import (
+	"net"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func resultWithResponses(responses ...probeResponse) *Result {
+	res := &Result{Hops: make([][]Hop, 1)}
+	for _, response := range responses {
+		res.recordResponse(1, response)
+	}
+	return res
+}
+
+func TestStopAfterTTLDestinationWins(t *testing.T) {
+	res := resultWithResponses(
+		probeResponse{kind: probeResponseTransit},
+		probeResponse{kind: probeResponseDestination},
+		probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+	)
+
+	if !res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = false, want true")
+	}
+	if got := res.StopReason; got == nil || got.Reason != StopReasonDestination || got.Hop != 1 {
+		t.Fatalf("StopReason = %#v, want destination at hop 1", got)
+	}
+}
+
+func TestStopAfterTTLTransitContinuesDespiteUnreachable(t *testing.T) {
+	res := resultWithResponses(
+		probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+		probeResponse{kind: probeResponseTransit},
+		probeResponse{kind: probeResponseUnreachable, marker: "!N"},
+	)
+
+	if res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = true, want false")
+	}
+	if res.StopReason != nil {
+		t.Fatalf("StopReason = %#v, want nil", res.StopReason)
+	}
+}
+
+func TestStopAfterTTLTargetIPTimeExceededContinues(t *testing.T) {
+	target := &net.IPAddr{IP: net.ParseIP("192.0.2.1")}
+	tracer := &ICMPTracer{
+		Config: Config{
+			DstIP:           target.IP,
+			NumMeasurements: 1,
+			MaxAttempts:     1,
+		},
+		res: Result{
+			Hops:     make([][]Hop, 1),
+			tailDone: make([]bool, 1),
+		},
+	}
+	tracer.final.Store(-1)
+	tracer.addHopWithIndex(target, 1, 0, 0, nil, probeResponse{kind: probeResponseTransit})
+
+	if got := tracer.final.Load(); got != -1 {
+		t.Fatalf("final = %d, want -1", got)
+	}
+	if tracer.res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = true, want false")
+	}
+}
+
+func TestStopAfterTTLAllResponsesUnreachable(t *testing.T) {
+	res := resultWithResponses(
+		probeResponse{kind: probeResponseUnreachable, marker: "!N"},
+		probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+		probeResponse{kind: probeResponseUnreachable, marker: "!N"},
+	)
+
+	if !res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = false, want true")
+	}
+	want := &StopReason{Hop: 1, Reason: StopReasonUnreachable, Details: []string{"!H", "!N"}}
+	if !reflect.DeepEqual(res.StopReason, want) {
+		t.Fatalf("StopReason = %#v, want %#v", res.StopReason, want)
+	}
+}
+
+func TestStopAfterTTLUnreachableWithTimeoutsStops(t *testing.T) {
+	res := &Result{Hops: [][]Hop{{
+		{Success: true, TTL: 1},
+		{TTL: 1},
+		{TTL: 1},
+	}}}
+	res.recordResponse(1, probeResponse{kind: probeResponseUnreachable, marker: "!H"})
+
+	if !res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = false, want true")
+	}
+	if got := res.StopReason; got == nil || got.Reason != StopReasonUnreachable {
+		t.Fatalf("StopReason = %#v, want unreachable", got)
+	}
+}
+
+func TestStopAfterTTLUsesResponsesOutsideDisplayLimit(t *testing.T) {
+	res := &Result{
+		Hops:     make([][]Hop, 1),
+		tailDone: make([]bool, 1),
+	}
+	for i := range 3 {
+		res.addMatchedHop(
+			Hop{Success: true, TTL: 1},
+			probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+			nil, i, 3, 4, Config{},
+		)
+	}
+	res.addMatchedHop(
+		Hop{Success: true, TTL: 1},
+		probeResponse{kind: probeResponseTransit},
+		nil, 3, 3, 4, Config{},
+	)
+	if got := len(res.Hops[0]); got != 3 {
+		t.Fatalf("displayed hops = %d, want 3", got)
+	}
+
+	if res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = true, want false")
+	}
+	if res.StopReason != nil {
+		t.Fatalf("StopReason = %#v, want nil", res.StopReason)
+	}
+}
+
+func TestStopAfterTTLDestinationOutsideDisplayLimitStops(t *testing.T) {
+	res := &Result{
+		Hops:     make([][]Hop, 1),
+		tailDone: make([]bool, 1),
+	}
+	for i := range 3 {
+		res.addMatchedHop(
+			Hop{Success: true, TTL: 1},
+			probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+			nil, i, 3, 4, Config{},
+		)
+	}
+	res.addMatchedHop(
+		Hop{Success: true, TTL: 1},
+		probeResponse{kind: probeResponseDestination},
+		nil, 3, 3, 4, Config{},
+	)
+	if got := len(res.Hops[0]); got != 3 {
+		t.Fatalf("displayed hops = %d, want 3", got)
+	}
+
+	if !res.stopAfterTTL(1, 30) {
+		t.Fatal("stopAfterTTL() = false, want true")
+	}
+	if got := res.StopReason; got == nil || got.Reason != StopReasonDestination {
+		t.Fatalf("StopReason = %#v, want destination", got)
+	}
+}
+
+func TestStopAfterTTLTimeoutsContinueUntilMaxHops(t *testing.T) {
+	res := &Result{Hops: [][]Hop{{{TTL: 1}, {TTL: 1}, {TTL: 1}}}}
+	if res.stopAfterTTL(1, 2) {
+		t.Fatal("stopAfterTTL(1) = true, want false")
+	}
+
+	res.Hops = append(res.Hops, []Hop{{TTL: 2}, {TTL: 2}, {TTL: 2}})
+	if !res.stopAfterTTL(2, 2) {
+		t.Fatal("stopAfterTTL(2) = false, want true")
+	}
+	if got := res.StopReason; got == nil || got.Reason != StopReasonMaxHops || got.Hop != 2 {
+		t.Fatalf("StopReason = %#v, want max hops at hop 2", got)
+	}
+}
+
+func TestMarkDestinationFinalOnlyStopsForDestination(t *testing.T) {
+	var final atomic.Int32
+	final.Store(-1)
+	markDestinationFinal(&final, 4, probeResponse{kind: probeResponseTransit})
+	if got := final.Load(); got != -1 {
+		t.Fatalf("final after transit = %d, want -1", got)
+	}
+
+	markDestinationFinal(&final, 7, probeResponse{kind: probeResponseDestination})
+	markDestinationFinal(&final, 9, probeResponse{kind: probeResponseDestination})
+	markDestinationFinal(&final, 5, probeResponse{kind: probeResponseDestination})
+	if got := final.Load(); got != 5 {
+		t.Fatalf("final after destination replies = %d, want 5", got)
+	}
+}

--- a/trace/trace_stop_test.go
+++ b/trace/trace_stop_test.go
@@ -101,7 +101,7 @@ func TestStopAfterTTLAllResponsesUnreachable(t *testing.T) {
 	if !reflect.DeepEqual(res.StopReason.Markers, []string{"!H", "!N"}) {
 		t.Fatalf("StopReason.Markers = %#v, want %#v", res.StopReason.Markers, []string{"!H", "!N"})
 	}
-	wantResponses := []string{"ICMP Host Unreachable (!H)", "ICMP Network Unreachable (!N)"}
+	wantResponses := []string{"ICMP Host Unreachable", "ICMP Network Unreachable"}
 	if !reflect.DeepEqual(res.StopReason.Responses, wantResponses) {
 		t.Fatalf("StopReason.Responses = %#v, want %#v", res.StopReason.Responses, wantResponses)
 	}
@@ -220,14 +220,41 @@ func TestPortUnreachableDependsOnProbeMethod(t *testing.T) {
 		kind   probeResponseKind
 		marker string
 	}{
-		{name: "udp v4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, method: UDPTrace, kind: probeResponseDestination},
+		{name: "udp v4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, method: UDPTrace, kind: probeResponseDestination, marker: "!<3-3>"},
 		{name: "icmp v4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, method: ICMPTrace, kind: probeResponseUnreachable, marker: "!<3-3>"},
+		{name: "tcp v4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, method: TCPTrace, kind: probeResponseUnreachable, marker: "!<3-3>"},
+		{name: "udp v6", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMPv6 Port Unreachable", Marker: "!<1-4>"}, method: UDPTrace, kind: probeResponseDestination, marker: "!<1-4>"},
+		{name: "icmp v6", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMPv6 Port Unreachable", Marker: "!<1-4>"}, method: ICMPTrace, kind: probeResponseUnreachable, marker: "!<1-4>"},
 		{name: "tcp v6", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMPv6 Port Unreachable", Marker: "!<1-4>"}, method: TCPTrace, kind: probeResponseUnreachable, marker: "!<1-4>"},
 	} {
 		t.Run(response.name, func(t *testing.T) {
 			got := probeResponseFromICMPForMethod(response.icmp, response.method)
 			if got.kind != response.kind || got.marker != response.marker {
 				t.Fatalf("response = %#v, want kind=%v marker=%q", got, response.kind, response.marker)
+			}
+		})
+	}
+}
+
+func TestUDPPortUnreachableDestinationPreservesMarker(t *testing.T) {
+	for _, response := range []struct {
+		name   string
+		icmp   internal.ICMPResponse
+		marker string
+	}{
+		{name: "IPv4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, marker: "!<3-3>"},
+		{name: "IPv6", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMPv6 Port Unreachable", Marker: "!<1-4>"}, marker: "!<1-4>"},
+	} {
+		t.Run(response.name, func(t *testing.T) {
+			res := resultWithResponses(probeResponseFromICMPForMethod(response.icmp, UDPTrace))
+			if !res.stopAfterTTL(1, 30) {
+				t.Fatal("stopAfterTTL() = false, want destination")
+			}
+			if got := res.StopReason; got == nil || got.Reason != StopReasonDestination {
+				t.Fatalf("StopReason = %#v, want destination", got)
+			}
+			if !reflect.DeepEqual(res.StopReason.Markers, []string{response.marker}) {
+				t.Fatalf("StopReason.Markers = %#v, want %#v", res.StopReason.Markers, []string{response.marker})
 			}
 		})
 	}

--- a/trace/trace_stop_test.go
+++ b/trace/trace_stop_test.go
@@ -1,10 +1,20 @@
 package trace
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"net"
 	"reflect"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace/internal"
+	"github.com/nxtrace/NTrace-core/util"
 )
 
 func resultWithResponses(responses ...probeResponse) *Result {
@@ -13,6 +23,12 @@ func resultWithResponses(responses ...probeResponse) *Result {
 		res.recordResponse(1, response)
 	}
 	return res
+}
+
+func resultTTLStable(res *Result, ttl, numMeasurements int) bool {
+	res.lock.RLock()
+	defer res.lock.RUnlock()
+	return res.ttlStableLocked(ttl, numMeasurements)
 }
 
 func TestStopAfterTTLDestinationWins(t *testing.T) {
@@ -82,8 +98,8 @@ func TestStopAfterTTLAllResponsesUnreachable(t *testing.T) {
 	if !res.stopAfterTTL(1, 30) {
 		t.Fatal("stopAfterTTL() = false, want true")
 	}
-	if !reflect.DeepEqual(res.StopReason.Details, []string{"!H", "!N"}) {
-		t.Fatalf("StopReason.Details = %#v, want %#v", res.StopReason.Details, []string{"!H", "!N"})
+	if !reflect.DeepEqual(res.StopReason.Markers, []string{"!H", "!N"}) {
+		t.Fatalf("StopReason.Markers = %#v, want %#v", res.StopReason.Markers, []string{"!H", "!N"})
 	}
 	wantResponses := []string{"ICMP Host Unreachable (!H)", "ICMP Network Unreachable (!N)"}
 	if !reflect.DeepEqual(res.StopReason.Responses, wantResponses) {
@@ -193,5 +209,479 @@ func TestMarkDestinationFinalOnlyStopsForDestination(t *testing.T) {
 	markDestinationFinal(&final, 5, probeResponse{kind: probeResponseDestination})
 	if got := final.Load(); got != 5 {
 		t.Fatalf("final after destination replies = %d, want 5", got)
+	}
+}
+
+func TestPortUnreachableDependsOnProbeMethod(t *testing.T) {
+	for _, response := range []struct {
+		name   string
+		icmp   internal.ICMPResponse
+		method Method
+		kind   probeResponseKind
+		marker string
+	}{
+		{name: "udp v4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, method: UDPTrace, kind: probeResponseDestination},
+		{name: "icmp v4", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMP Port Unreachable", Marker: "!<3-3>"}, method: ICMPTrace, kind: probeResponseUnreachable, marker: "!<3-3>"},
+		{name: "tcp v6", icmp: internal.ICMPResponse{Kind: internal.ICMPResponsePortUnreachable, Description: "ICMPv6 Port Unreachable", Marker: "!<1-4>"}, method: TCPTrace, kind: probeResponseUnreachable, marker: "!<1-4>"},
+	} {
+		t.Run(response.name, func(t *testing.T) {
+			got := probeResponseFromICMPForMethod(response.icmp, response.method)
+			if got.kind != response.kind || got.marker != response.marker {
+				t.Fatalf("response = %#v, want kind=%v marker=%q", got, response.kind, response.marker)
+			}
+		})
+	}
+}
+
+func TestTCPDestinationResponseUsesDecoderAckContract(t *testing.T) {
+	if got := probeResponseFromTCPAck(0); got.detail != "TCP SYN/ACK" || got.kind != probeResponseDestination {
+		t.Fatalf("ack=0 response = %#v", got)
+	}
+	if got := probeResponseFromTCPAck(123); got.detail != "TCP RST" || got.kind != probeResponseDestination {
+		t.Fatalf("ack!=0 response = %#v", got)
+	}
+}
+
+func TestStopAfterTTLTransitAtMaxHopsStops(t *testing.T) {
+	res := resultWithResponses(probeResponse{kind: probeResponseTransit, detail: "ICMP Time Exceeded"})
+	if !res.stopAfterTTL(1, 1) {
+		t.Fatal("stopAfterTTL() = false, want true")
+	}
+	if got := res.StopReason; got == nil || got.Reason != StopReasonMaxHops {
+		t.Fatalf("StopReason = %#v, want max hops", got)
+	}
+}
+
+func TestTraceFinalOnlyDecreases(t *testing.T) {
+	var final atomic.Int32
+	final.Store(-1)
+	lowerTraceFinal(&final, 7)
+	lowerTraceFinal(&final, 9)
+	lowerTraceFinal(&final, 5)
+	if got := final.Load(); got != 5 {
+		t.Fatalf("final = %d, want 5", got)
+	}
+}
+
+func TestMatchedAndTimeoutAboveFinalAreDiscarded(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 3), tailDone: make([]bool, 3)}
+	var final atomic.Int32
+	final.Store(1)
+	res.markAttemptLaunched(2, 0, nil)
+	res.markAttemptLaunched(3, 0, nil)
+
+	if res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("192.0.2.2")}, TTL: 2},
+		probeResponse{kind: probeResponseTransit}, &final, 0, 1, 1, Config{},
+	) {
+		t.Fatal("matched hop above final was admitted")
+	}
+	if res.addTimeout(Hop{TTL: 3, Error: errHopLimitTimeout}, &final, 0, 1, 1) {
+		t.Fatal("timeout above final was admitted")
+	}
+	if len(res.Hops[1]) != 0 || len(res.Hops[2]) != 0 || len(res.responses[2]) != 0 {
+		t.Fatalf("higher TTL state leaked: hops=%#v responses=%#v", res.Hops, res.responses)
+	}
+}
+
+func TestHiddenDestinationIsVisibleAndLateFinalCanStop(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	for i := range 3 {
+		if !res.markAttemptLaunched(1, i, &final) {
+			t.Fatalf("attempt %d was not launched", i)
+		}
+	}
+	res.markTTLLaunchDone(1)
+	res.addTimeout(Hop{TTL: 1, Error: errHopLimitTimeout}, &final, 0, 2, 3)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("192.0.2.1")}, TTL: 1},
+		probeResponse{kind: probeResponseTransit, detail: "ICMP Time Exceeded"},
+		&final, 1, 2, 3, Config{},
+	)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("198.51.100.9")}, TTL: 1},
+		probeResponse{kind: probeResponseDestination, detail: "ICMP Port Unreachable"},
+		&final, 2, 2, 3, Config{},
+	)
+
+	if got := final.Load(); got != 1 {
+		t.Fatalf("final = %d, want 1", got)
+	}
+	if !res.stableFinalAtOrBefore(2, 30, 2, &final) {
+		t.Fatal("late final was not detected behind the print cursor")
+	}
+	found := false
+	for _, hop := range res.Hops[0] {
+		if ip := util.AddrIP(hop.Address); ip != nil && ip.Equal(net.ParseIP("198.51.100.9")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("winning responder is not visible: %#v", res.Hops[0])
+	}
+	if got := strings.Join(res.StopReason.Responses, ","); !strings.Contains(got, "198.51.100.9") {
+		t.Fatalf("StopReason.Responses = %q, want responder IP", got)
+	}
+}
+
+func TestHiddenDestinationReplacesVisibleTransitWhenNoTimeoutExists(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	for i := range 3 {
+		res.markAttemptLaunched(1, i, &final)
+	}
+	res.markTTLLaunchDone(1)
+	for i, raw := range []string{"192.0.2.1", "192.0.2.2"} {
+		res.addMatchedHop(
+			Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP(raw)}, TTL: 1},
+			probeResponse{kind: probeResponseTransit}, &final, i, 2, 3, Config{},
+		)
+	}
+	destination := net.ParseIP("198.51.100.9")
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: destination}, TTL: 1},
+		probeResponse{kind: probeResponseDestination}, &final, 2, 2, 3, Config{},
+	)
+
+	found := false
+	for _, hop := range res.Hops[0] {
+		if ip := util.AddrIP(hop.Address); ip != nil && ip.Equal(destination) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("hidden destination is not visible: %#v", res.Hops[0])
+	}
+}
+
+func TestTTLStableRequiresLaunchDoneAndEveryLaunchedAttemptSettled(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	res.markAttemptLaunched(1, 0, &final)
+	res.markAttemptLaunched(1, 1, &final)
+	res.addTimeout(Hop{TTL: 1, Error: errHopLimitTimeout}, &final, 0, 1, 2)
+	if resultTTLStable(res, 1, 1) {
+		t.Fatal("TTL became stable before launch completion")
+	}
+	res.markTTLLaunchDone(1)
+	if resultTTLStable(res, 1, 1) {
+		t.Fatal("TTL became stable before every launched attempt settled")
+	}
+	res.addTimeout(Hop{TTL: 1, Error: errHopLimitTimeout}, &final, 1, 1, 2)
+	if !resultTTLStable(res, 1, 1) {
+		t.Fatal("TTL did not become stable after launch and settlement completed")
+	}
+}
+
+func TestStableTracePrintWaitsForLateHiddenUnreachable(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	for i := range 3 {
+		res.markAttemptLaunched(1, i, &final)
+	}
+	res.markTTLLaunchDone(1)
+
+	for i, raw := range []string{"192.0.2.1", "192.0.2.2"} {
+		res.addMatchedHop(
+			Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP(raw)}, TTL: 1},
+			probeResponse{}, &final, i, 2, 3, Config{},
+		)
+	}
+
+	prints := 0
+	printer := func(snapshot *Result) { prints++ }
+	if cursor, stop := advanceStableTracePrint(context.Background(), res, 0, 30, 2, &final, printer, nil); cursor != 0 || stop {
+		t.Fatalf("advance before settlement = (%d, %v), want (0, false)", cursor, stop)
+	}
+	if prints != 0 {
+		t.Fatalf("prints before settlement = %d, want 0", prints)
+	}
+
+	peer := net.ParseIP("198.51.100.9")
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: peer}, TTL: 1},
+		probeResponse{kind: probeResponseUnreachable, detail: "ICMP Host Unreachable", marker: "!H"},
+		&final, 2, 2, 3, Config{},
+	)
+
+	var snapshot *Result
+	printer = func(got *Result) {
+		prints++
+		snapshot = got
+	}
+	cursor, stop := advanceStableTracePrint(context.Background(), res, 0, 30, 2, &final, printer, nil)
+	if cursor != 1 || !stop {
+		t.Fatalf("advance after settlement = (%d, %v), want (1, true)", cursor, stop)
+	}
+	if prints != 1 {
+		t.Fatalf("stable prints = %d, want 1", prints)
+	}
+	if snapshot == nil || snapshot.StopReason == nil || snapshot.StopReason.Reason != StopReasonUnreachable {
+		t.Fatalf("snapshot StopReason = %#v, want unreachable", snapshot)
+	}
+	found := false
+	for _, hop := range snapshot.Hops[0] {
+		if ip := util.AddrIP(hop.Address); ip != nil && ip.Equal(peer) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("hidden unreachable responder was not promoted: %#v", snapshot.Hops[0])
+	}
+}
+
+func TestHiddenTransitReplacesProvisionalUnreachablePromotion(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	for i := range 4 {
+		res.markAttemptLaunched(1, i, &final)
+	}
+	res.markTTLLaunchDone(1)
+	for i, raw := range []string{"192.0.2.1", "192.0.2.2"} {
+		res.addMatchedHop(
+			Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP(raw)}, TTL: 1},
+			probeResponse{}, &final, i, 2, 4, Config{},
+		)
+	}
+
+	unreachableIP := net.ParseIP("198.51.100.9")
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: unreachableIP}, TTL: 1},
+		probeResponse{kind: probeResponseUnreachable, marker: "!H"},
+		&final, 2, 2, 4, Config{},
+	)
+	transitIP := net.ParseIP("203.0.113.7")
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: transitIP}, TTL: 1},
+		probeResponse{kind: probeResponseTransit},
+		&final, 3, 2, 4, Config{},
+	)
+
+	cursor, stop := advanceStableTracePrint(context.Background(), res, 0, 30, 2, &final, nil, nil)
+	if cursor != 1 || stop {
+		t.Fatalf("advance = (%d, %v), want (1, false) because transit wins", cursor, stop)
+	}
+	foundTransit := false
+	foundUnreachable := false
+	for _, hop := range res.Hops[0] {
+		ip := util.AddrIP(hop.Address)
+		foundTransit = foundTransit || (ip != nil && ip.Equal(transitIP))
+		foundUnreachable = foundUnreachable || (ip != nil && ip.Equal(unreachableIP))
+	}
+	if !foundTransit || foundUnreachable {
+		t.Fatalf("visible hops = %#v, want transit promotion without provisional unreachable", res.Hops[0])
+	}
+}
+
+func TestLateMetadataCannotOverwritePromotedTerminalHop(t *testing.T) {
+	oldIP := net.ParseIP("8.8.4.101")
+	destinationIP := net.ParseIP("8.8.4.102")
+	oldKey := oldIP.String()
+	destinationKey := destinationIP.String()
+	geoCache.Delete(oldKey)
+	geoCache.Delete(destinationKey)
+	t.Cleanup(func() {
+		geoCache.Delete(oldKey)
+		geoCache.Delete(destinationKey)
+	})
+
+	oldStarted := make(chan struct{}, 1)
+	releaseOld := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseOld) }) }
+	t.Cleanup(release)
+	cfg := Config{
+		Context:         context.Background(),
+		NumMeasurements: 1,
+		IPGeoSource: func(ip string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+			if ip == oldKey {
+				select {
+				case oldStarted <- struct{}{}:
+				default:
+				}
+				<-releaseOld
+				return &ipgeo.IPGeoData{Country: "old"}, nil
+			}
+			return &ipgeo.IPGeoData{Country: "destination"}, nil
+		},
+	}
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	for i := range 2 {
+		res.markAttemptLaunched(1, i, &final)
+	}
+	res.markTTLLaunchDone(1)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: oldIP}, TTL: 1},
+		probeResponse{kind: probeResponseTransit}, &final, 0, 1, 2, cfg,
+	)
+	select {
+	case <-oldStarted:
+	case <-time.After(time.Second):
+		t.Fatal("old metadata lookup did not start")
+	}
+
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: destinationIP}, TTL: 1},
+		probeResponse{kind: probeResponseDestination}, &final, 1, 1, 2, cfg,
+	)
+	deadline := time.Now().Add(time.Second)
+	for {
+		res.lock.RLock()
+		hop := res.Hops[0][0]
+		ready := util.AddrIP(hop.Address).Equal(destinationIP) && hop.Geo != nil && hop.Geo.Country == "destination"
+		res.lock.RUnlock()
+		if ready {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("destination metadata was not applied")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	release()
+	res.geoWG.Wait()
+	res.lock.RLock()
+	defer res.lock.RUnlock()
+	hop := res.Hops[0][0]
+	if ip := util.AddrIP(hop.Address); ip == nil || !ip.Equal(destinationIP) {
+		t.Fatalf("visible IP = %v, want %v", ip, destinationIP)
+	}
+	if hop.Geo == nil || hop.Geo.Country != "destination" {
+		t.Fatalf("visible geo = %#v, want destination metadata", hop.Geo)
+	}
+}
+
+func TestStableTracePrintDoesNotReachMaxHopsWhileLowerTTLPending(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 2), tailDone: make([]bool, 2)}
+	var final atomic.Int32
+	final.Store(-1)
+	for ttl := 1; ttl <= 2; ttl++ {
+		res.markAttemptLaunched(ttl, 0, &final)
+		res.markTTLLaunchDone(ttl)
+	}
+	res.addTimeout(Hop{TTL: 2, Error: errHopLimitTimeout}, &final, 0, 1, 1)
+
+	prints := 0
+	printer := func(*Result) { prints++ }
+	if cursor, stop := advanceStableTracePrint(context.Background(), res, 0, 2, 1, &final, printer, nil); cursor != 0 || stop {
+		t.Fatalf("advance with TTL 1 pending = (%d, %v), want (0, false)", cursor, stop)
+	}
+	if prints != 0 || res.StopReason != nil {
+		t.Fatalf("premature max-hops result: prints=%d reason=%#v", prints, res.StopReason)
+	}
+
+	res.addTimeout(Hop{TTL: 1, Error: errHopLimitTimeout}, &final, 0, 1, 1)
+	cursor, stop := advanceStableTracePrint(context.Background(), res, 0, 2, 1, &final, printer, nil)
+	if cursor != 1 || stop {
+		t.Fatalf("TTL 1 advance = (%d, %v), want (1, false)", cursor, stop)
+	}
+	cursor, stop = advanceStableTracePrint(context.Background(), res, cursor, 2, 1, &final, printer, nil)
+	if cursor != 2 || !stop {
+		t.Fatalf("TTL 2 advance = (%d, %v), want (2, true)", cursor, stop)
+	}
+	if got := res.StopReason; got == nil || got.Hop != 2 || got.Reason != StopReasonMaxHops {
+		t.Fatalf("StopReason = %#v, want max_hops at 2", got)
+	}
+}
+
+func TestAllSendFailuresFillVisibleSlotsAndReachStableMaxHops(t *testing.T) {
+	const (
+		numMeasurements = 3
+		maxAttempts     = 6
+	)
+	res := &Result{Hops: make([][]Hop, 1), tailDone: make([]bool, 1)}
+	var final atomic.Int32
+	final.Store(-1)
+	for i := range maxAttempts {
+		res.markAttemptLaunched(1, i, &final)
+	}
+	res.markTTLLaunchDone(1)
+	for i := range maxAttempts {
+		res.addFailedAttempt(Hop{TTL: 1, Error: errors.New("send failed")}, &final, i, numMeasurements, maxAttempts)
+	}
+
+	if !resultTTLStable(res, 1, numMeasurements) {
+		t.Fatal("all failed sends did not make the TTL stable")
+	}
+	if got := len(res.Hops[0]); got != numMeasurements {
+		t.Fatalf("visible failures = %d, want %d", got, numMeasurements)
+	}
+	prints := 0
+	cursor, stop := advanceStableTracePrint(
+		context.Background(), res, 0, 1, numMeasurements, &final,
+		func(*Result) { prints++ }, nil,
+	)
+	if cursor != 1 || !stop || prints != 1 {
+		t.Fatalf("stable failure advance = (%d, %v, prints=%d), want (1, true, 1)", cursor, stop, prints)
+	}
+	if got := res.StopReason; got == nil || got.Reason != StopReasonMaxHops {
+		t.Fatalf("StopReason = %#v, want max_hops", got)
+	}
+}
+
+func TestStableTracePrintPassesDetachedSnapshot(t *testing.T) {
+	res := &Result{
+		Hops: [][]Hop{{{
+			Success: true,
+			Address: &net.IPAddr{IP: net.ParseIP("192.0.2.1")},
+			TTL:     1,
+			Geo:     &ipgeo.IPGeoData{Country: "original"},
+			MPLS:    []string{"label"},
+		}}},
+		tailDone:    []bool{true},
+		TraceMapUrl: "https://example.invalid/map",
+	}
+	var final atomic.Int32
+	final.Store(-1)
+	res.markAttemptLaunched(1, 0, &final)
+	res.settleAttempt(1, 0)
+	res.markTTLLaunchDone(1)
+
+	var snapshot *Result
+	cursor, stop := advanceStableTracePrint(
+		context.Background(), res, 0, 1, 1, &final,
+		func(got *Result) { snapshot = got }, nil,
+	)
+	if cursor != 1 || !stop || snapshot == nil {
+		t.Fatalf("advance = (%d, %v, %#v), want stable snapshot", cursor, stop, snapshot)
+	}
+	if snapshot.TraceMapUrl != res.TraceMapUrl || snapshot.StopReason == nil || snapshot.StopReason.Reason != StopReasonMaxHops {
+		t.Fatalf("snapshot metadata = %#v", snapshot)
+	}
+	snapshot.Hops[0][0].Geo.Country = "mutated"
+	snapshot.Hops[0][0].MPLS[0] = "mutated"
+	snapshot.StopReason.Reason = "mutated"
+	if res.Hops[0][0].Geo.Country != "original" || res.Hops[0][0].MPLS[0] != "label" || res.StopReason.Reason != StopReasonMaxHops {
+		t.Fatalf("printer snapshot mutated live result: hop=%#v reason=%#v", res.Hops[0][0], res.StopReason)
+	}
+}
+
+func TestStopReasonJSONUsesLowercaseNestedFields(t *testing.T) {
+	payload, err := json.Marshal(&Result{StopReason: &StopReason{
+		Hop:       7,
+		Reason:    StopReasonUnreachable,
+		Responses: []string{"ICMP Host Unreachable"},
+		Markers:   []string{"!H"},
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	got := string(payload)
+	for _, want := range []string{`"StopReason"`, `"hop":7`, `"reason":"unreachable"`, `"responses"`, `"markers"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("JSON %q does not contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, `"Hop"`) || strings.Contains(got, `"Details"`) {
+		t.Fatalf("JSON leaked legacy nested fields: %s", got)
 	}
 }

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -60,10 +60,7 @@ func (t *UDPTracer) waitAllReady(ctx context.Context) {
 }
 
 func (t *UDPTracer) ttlComp(ttl int) bool {
-	idx := ttl - 1
-	t.res.lock.RLock()
-	defer t.res.lock.RUnlock()
-	return idx < len(t.res.Hops) && len(t.res.Hops[idx]) >= t.NumMeasurements
+	return t.res.ttlDisplayComplete(ttl, t.NumMeasurements)
 }
 
 func (t *UDPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
@@ -74,22 +71,14 @@ func (t *UDPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFun
 	defer ticker.Stop()
 
 	for {
-		if t.AsyncPrinter != nil {
-			t.AsyncPrinter(&t.res)
-		}
-
-		// 接收的时候检查一下是不是 3 跳都齐了
-		if t.ttlComp(ttl + 1) {
-			if t.RealtimePrinter != nil {
-				t.res.waitGeo(ctx, ttl)
-				t.RealtimePrinter(&t.res, ttl)
-			}
-			ttl++
-			if t.res.stopAfterTTL(ttl, t.MaxHops) {
-				t.final.Store(int32(ttl))
-				cancel(errNaturalDone) // 标记为“自然完成”
-				return
-			}
+		nextTTL, stop := advanceStableTracePrint(
+			ctx, &t.res, ttl, t.MaxHops, t.NumMeasurements, &t.final,
+			t.AsyncPrinter, t.RealtimePrinter,
+		)
+		ttl = nextTTL
+		if stop {
+			cancel(errNaturalDone)
+			return
 		}
 
 		select {
@@ -101,20 +90,35 @@ func (t *UDPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFun
 }
 
 func (t *UDPTracer) launchTTL(ctx context.Context, s *internal.UDPSpec, ttl int) {
+	t.wg.Add(1)
 	go func(ttl int) {
+		defer t.wg.Done()
+		defer t.res.markTTLLaunchDone(ttl)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
 
+			if !t.res.markAttemptLaunched(ttl, i, &t.final) {
+				return
+			}
 			t.wg.Add(1)
 			go func(ttl, i int) {
-				if err := t.send(ctx, s, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
+				defer t.wg.Done()
+				err := t.send(ctx, s, ttl, i)
+				if err != nil && !errors.Is(err, context.Canceled) {
 					if util.EnvDevMode {
 						panic(err)
 					}
 					fmt.Fprintf(os.Stderr, "send error (ttl=%d, attempt=%d): %v\n", ttl, i, err)
+				}
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+						t.res.addFailedAttempt(Hop{TTL: ttl, Error: err}, &t.final, i, t.NumMeasurements, t.MaxAttempts)
+					} else {
+						t.res.settleAttempt(ttl, i)
+					}
 				}
 			}(ttl, i)
 
@@ -205,6 +209,7 @@ func (t *UDPTracer) dropByAttempt(ttl, i int) {
 
 func (t *UDPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return
 	}
 	h := Hop{
@@ -370,6 +375,7 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
+				t.res.markTTLLaunchDone(ttl)
 				return
 			}
 
@@ -419,7 +425,7 @@ func (t *UDPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time.
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMPForMethod(msg.ICMP, UDPTrace),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环
@@ -435,8 +441,9 @@ func randomPayload(size int, offset int) []byte {
 	return payload
 }
 
-func (t *UDPTracer) acquireSendPermit(ctx context.Context, ttl int) (func(), bool, error) {
+func (t *UDPTracer) acquireSendPermit(ctx context.Context, ttl, i int) (func(), bool, error) {
 	if t.ttlComp(ttl) {
+		t.res.settleAttempt(ttl, i)
 		return nil, true, nil
 	}
 	if err := acquireTraceSemaphore(ctx, t.sem); err != nil {
@@ -445,10 +452,12 @@ func (t *UDPTracer) acquireSendPermit(ctx context.Context, ttl int) (func(), boo
 	release := func() { t.sem.Release(1) }
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		release()
+		t.res.settleAttempt(ttl, i)
 		return nil, true, nil
 	}
 	if t.ttlComp(ttl) {
 		release()
+		t.res.settleAttempt(ttl, i)
 		return nil, true, nil
 	}
 	return release, false, nil
@@ -483,18 +492,15 @@ func (t *UDPTracer) buildUDPPacket(ttl, i, srcPort int) (int, *layers.IPv4, *lay
 
 func (t *UDPTracer) startSendTimeout(ctx context.Context, ttl, i, seq int) {
 	t.markPending(ttl, i)
+	t.wg.Add(1)
 	go func(seq, ttl, i int) {
+		defer t.wg.Done()
 		if !waitForTraceDelay(ctx, t.Timeout) {
 			_ = t.clearPending(ttl, i)
+			t.res.settleAttempt(ttl, i)
 			return
 		}
 		if !t.clearPending(ttl, i) {
-			return
-		}
-		if f := t.final.Load(); f != -1 && ttl > int(f) {
-			return
-		}
-		if t.ttlComp(ttl) {
 			return
 		}
 
@@ -505,7 +511,7 @@ func (t *UDPTracer) startSendTimeout(ctx context.Context, ttl, i, seq int) {
 			RTT:     0,
 			Error:   errHopLimitTimeout,
 		}
-		_, _ = t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
+		t.res.addTimeout(h, &t.final, i, t.NumMeasurements, t.MaxAttempts)
 		if t.OSType != 1 {
 			t.dropSent(seq)
 			return
@@ -527,9 +533,7 @@ func (t *UDPTracer) finalizeSent(seq, srcPort int, start time.Time) {
 }
 
 func (t *UDPTracer) send(ctx context.Context, s *internal.UDPSpec, ttl, i int) error {
-	defer t.wg.Done()
-
-	release, skip, err := t.acquireSendPermit(ctx, ttl)
+	release, skip, err := t.acquireSendPermit(ctx, ttl, i)
 	if err != nil {
 		return err
 	}

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -85,7 +85,8 @@ func (t *UDPTracer) PrintFunc(ctx context.Context, cancel context.CancelCauseFun
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
-			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+			if t.res.stopAfterTTL(ttl, t.MaxHops) {
+				t.final.Store(int32(ttl))
 				cancel(errNaturalDone) // 标记为“自然完成”
 				return
 			}
@@ -202,23 +203,10 @@ func (t *UDPTracer) dropByAttempt(ttl, i int) {
 	}
 }
 
-func (t *UDPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string) {
+func (t *UDPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		return
 	}
-
-	if ip := util.AddrIP(peer); ip != nil && ip.Equal(t.DstIP) {
-		for {
-			old := t.final.Load()
-			if old != -1 && ttl >= int(old) {
-				break
-			}
-			if t.final.CompareAndSwap(old, int32(ttl)) {
-				break
-			}
-		}
-	}
-
 	h := Hop{
 		Success: true,
 		Address: peer,
@@ -226,7 +214,7 @@ func (t *UDPTracer) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration
 		RTT:     rtt,
 		MPLS:    mpls,
 	}
-	t.res.addWithGeoAsync(h, i, t.NumMeasurements, t.MaxAttempts, t.Config)
+	t.res.addMatchedHop(h, response, &t.final, i, t.NumMeasurements, t.MaxAttempts, t.Config)
 }
 
 func (t *UDPTracer) matchWorker(ctx context.Context) {
@@ -274,7 +262,7 @@ func (t *UDPTracer) matchWorker(ctx context.Context) {
 
 			if t.clearPending(ttl, i) {
 				rtt := task.finish.Sub(start)
-				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls)
+				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls, task.response)
 			}
 			t.dropSent(task.seq)
 		}
@@ -431,7 +419,7 @@ func (t *UDPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time.
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls,
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -80,7 +80,8 @@ func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCaus
 				t.RealtimePrinter(&t.res, ttl)
 			}
 			ttl++
-			if ttl == int(t.final.Load()) || ttl >= t.MaxHops {
+			if t.res.stopAfterTTL(ttl, t.MaxHops) {
+				t.final.Store(int32(ttl))
 				cancel(errNaturalDone) // 标记为“自然完成”
 				return
 			}
@@ -158,23 +159,10 @@ func (t *UDPTracerIPv6) dropSent(seq int) {
 	delete(t.sentAt, seq)
 }
 
-func (t *UDPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string) {
+func (t *UDPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
 		return
 	}
-
-	if ip := util.AddrIP(peer); ip != nil && ip.Equal(t.DstIP) {
-		for {
-			old := t.final.Load()
-			if old != -1 && ttl >= int(old) {
-				break
-			}
-			if t.final.CompareAndSwap(old, int32(ttl)) {
-				break
-			}
-		}
-	}
-
 	h := Hop{
 		Success: true,
 		Address: peer,
@@ -182,7 +170,7 @@ func (t *UDPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Dura
 		RTT:     rtt,
 		MPLS:    mpls,
 	}
-	t.res.addWithGeoAsync(h, i, t.NumMeasurements, t.MaxAttempts, t.Config)
+	t.res.addMatchedHop(h, response, &t.final, i, t.NumMeasurements, t.MaxAttempts, t.Config)
 }
 
 func (t *UDPTracerIPv6) matchWorker(ctx context.Context) {
@@ -228,7 +216,7 @@ func (t *UDPTracerIPv6) matchWorker(ctx context.Context) {
 
 			if t.clearPending(task.seq) {
 				rtt := task.finish.Sub(start)
-				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls)
+				t.addHopWithIndex(task.peer, ttl, i, rtt, task.mpls, task.response)
 			}
 			t.dropSent(task.seq)
 		}
@@ -367,7 +355,7 @@ func (t *UDPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls,
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -55,10 +55,7 @@ func (t *UDPTracerIPv6) waitAllReady(ctx context.Context) {
 }
 
 func (t *UDPTracerIPv6) ttlComp(ttl int) bool {
-	idx := ttl - 1
-	t.res.lock.RLock()
-	defer t.res.lock.RUnlock()
-	return idx < len(t.res.Hops) && len(t.res.Hops[idx]) >= t.NumMeasurements
+	return t.res.ttlDisplayComplete(ttl, t.NumMeasurements)
 }
 
 func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCauseFunc) {
@@ -69,22 +66,14 @@ func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCaus
 	defer ticker.Stop()
 
 	for {
-		if t.AsyncPrinter != nil {
-			t.AsyncPrinter(&t.res)
-		}
-
-		// 接收的时候检查一下是不是 3 跳都齐了
-		if t.ttlComp(ttl + 1) {
-			if t.RealtimePrinter != nil {
-				t.res.waitGeo(ctx, ttl)
-				t.RealtimePrinter(&t.res, ttl)
-			}
-			ttl++
-			if t.res.stopAfterTTL(ttl, t.MaxHops) {
-				t.final.Store(int32(ttl))
-				cancel(errNaturalDone) // 标记为“自然完成”
-				return
-			}
+		nextTTL, stop := advanceStableTracePrint(
+			ctx, &t.res, ttl, t.MaxHops, t.NumMeasurements, &t.final,
+			t.AsyncPrinter, t.RealtimePrinter,
+		)
+		ttl = nextTTL
+		if stop {
+			cancel(errNaturalDone)
+			return
 		}
 
 		select {
@@ -96,20 +85,35 @@ func (t *UDPTracerIPv6) PrintFunc(ctx context.Context, cancel context.CancelCaus
 }
 
 func (t *UDPTracerIPv6) launchTTL(ctx context.Context, s *internal.UDPSpec, ttl int) {
+	t.wg.Add(1)
 	go func(ttl int) {
+		defer t.wg.Done()
+		defer t.res.markTTLLaunchDone(ttl)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
 				return
 			}
 
+			if !t.res.markAttemptLaunched(ttl, i, &t.final) {
+				return
+			}
 			t.wg.Add(1)
 			go func(ttl, i int) {
-				if err := t.send(ctx, s, ttl, i); err != nil && !errors.Is(err, context.Canceled) {
+				defer t.wg.Done()
+				err := t.send(ctx, s, ttl, i)
+				if err != nil && !errors.Is(err, context.Canceled) {
 					if util.EnvDevMode {
 						panic(err)
 					}
 					fmt.Fprintf(os.Stderr, "send error (ttl=%d, attempt=%d): %v\n", ttl, i, err)
+				}
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+						t.res.addFailedAttempt(Hop{TTL: ttl, Error: err}, &t.final, i, t.NumMeasurements, t.MaxAttempts)
+					} else {
+						t.res.settleAttempt(ttl, i)
+					}
 				}
 			}(ttl, i)
 
@@ -161,6 +165,7 @@ func (t *UDPTracerIPv6) dropSent(seq int) {
 
 func (t *UDPTracerIPv6) addHopWithIndex(peer net.Addr, ttl, i int, rtt time.Duration, mpls []string, response probeResponse) {
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return
 	}
 	h := Hop{
@@ -306,6 +311,7 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 
 			// 如果到达最终跳，则退出
 			if f := t.final.Load(); f != -1 && ttl > int(f) {
+				t.res.markTTLLaunchDone(ttl)
 				return
 			}
 
@@ -355,7 +361,7 @@ func (t *UDPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 	// 非阻塞投递；如果队列已满则直接丢弃该任务
 	select {
 	case t.matchQ <- matchTask{
-		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMP(msg.ICMP),
+		srcPort: srcPort, seq: seq, peer: msg.Peer, finish: finish, mpls: mpls, response: probeResponseFromICMPForMethod(msg.ICMP, UDPTrace),
 	}:
 	default:
 		// 丢弃以避免阻塞抓包循环
@@ -363,10 +369,9 @@ func (t *UDPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 }
 
 func (t *UDPTracerIPv6) send(ctx context.Context, s *internal.UDPSpec, ttl, i int) error {
-	defer t.wg.Done()
-
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -376,11 +381,13 @@ func (t *UDPTracerIPv6) send(ctx context.Context, s *internal.UDPSpec, ttl, i in
 	defer t.sem.Release(1)
 
 	if f := t.final.Load(); f != -1 && ttl > int(f) {
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
+		t.res.settleAttempt(ttl, i)
 		return nil
 	}
 
@@ -424,18 +431,15 @@ func (t *UDPTracerIPv6) send(ctx context.Context, s *internal.UDPSpec, ttl, i in
 
 	// 登记 pending，并启动超时守护
 	t.markPending(seq)
+	t.wg.Add(1)
 	go func(seq, ttl, i int) {
+		defer t.wg.Done()
 		if !waitForTraceDelay(ctx, t.Timeout) {
 			_ = t.clearPending(seq)
+			t.res.settleAttempt(ttl, i)
 			return
 		}
 		if !t.clearPending(seq) {
-			return
-		}
-		if f := t.final.Load(); f != -1 && ttl > int(f) {
-			return
-		}
-		if t.ttlComp(ttl) {
 			return
 		}
 
@@ -447,7 +451,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, s *internal.UDPSpec, ttl, i in
 			Error:   errHopLimitTimeout,
 		}
 
-		_, _ = t.res.add(h, i, t.NumMeasurements, t.MaxAttempts)
+		t.res.addTimeout(h, &t.final, i, t.NumMeasurements, t.MaxAttempts)
 		t.dropSent(seq)
 	}(seq, ttl, i)
 


### PR DESCRIPTION
Fixes #204 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - Traceroute 现在显示停止原因，包括到达目标、路径不可达和达到最大跳数。
  - JSON、HTTP、WebSocket、MTR 和 MCP 输出新增停止原因、路径终点及逐跳响应详情。
  - 增加 ICMP 响应分类与标记展示，支持中转、不可达、参数问题和数据包过大等情况。

- **改进**
  - 优化 Raw、表格、Classic、JSON 及文件输出；文件内容不含终端颜色控制符。
  - 改进 IPv4、IPv6、TCP、UDP 和 Windows 场景下的路径判断、追踪稳定性与结果准确性。
  - MTR 路径边界现在可根据后续探测结果动态修正。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->