### PR TITLE
fix(trace): 在稳定不可达响应后停止后续探测

### DIFF
--- a/trace/icmp_ipv4.go
+++ b/trace/icmp_ipv4.go
@@ -86,7 +86,7 @@ func (t *ICMPTracer) launchTTL(ctx context.Context, s *internal.ICMPSpec, ttl in
 	t.wg.Add(1)
 	go func(ttl int) {
 		defer t.wg.Done()
-		defer t.res.markTTLLaunchDone(ttl)
+		defer t.res.markTTLLaunchDoneAndCommit(ctx, ttl, t.NumMeasurements, &t.final)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
@@ -202,19 +202,12 @@ func (t *ICMPTracer) matchWorker(ctx context.Context) {
 				return
 			}
 
-			// 固定等待 10ms，缓解登记竞态
-			timer := time.NewTimer(10 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-			timer.Stop()
-
-			// 尝试一次匹配
-			start, ok := t.lookupSent(task.seq)
-			if !ok {
+			var start time.Time
+			if !retryTraceProbeLookup(ctx, func() bool {
+				var found bool
+				start, found = t.lookupSent(task.seq)
+				return found
+			}) {
 				continue
 			}
 
@@ -361,7 +354,7 @@ func (t *ICMPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time
 func (t *ICMPTracer) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int) error {
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 
@@ -377,7 +370,7 @@ func (t *ICMPTracer) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int)
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -86,7 +86,7 @@ func (t *ICMPTracerv6) launchTTL(ctx context.Context, s *internal.ICMPSpec, ttl 
 	t.wg.Add(1)
 	go func(ttl int) {
 		defer t.wg.Done()
-		defer t.res.markTTLLaunchDone(ttl)
+		defer t.res.markTTLLaunchDoneAndCommit(ctx, ttl, t.NumMeasurements, &t.final)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
@@ -202,19 +202,12 @@ func (t *ICMPTracerv6) matchWorker(ctx context.Context) {
 				return
 			}
 
-			// 固定等待 10ms，缓解登记竞态
-			timer := time.NewTimer(10 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-			timer.Stop()
-
-			// 尝试一次匹配
-			start, ok := t.lookupSent(task.seq)
-			if !ok {
+			var start time.Time
+			if !retryTraceProbeLookup(ctx, func() bool {
+				var found bool
+				start, found = t.lookupSent(task.seq)
+				return found
+			}) {
 				continue
 			}
 
@@ -361,7 +354,7 @@ func (t *ICMPTracerv6) handleICMPMessage(msg internal.ReceivedMessage, finish ti
 func (t *ICMPTracerv6) send(ctx context.Context, s *internal.ICMPSpec, ttl, i int) error {
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 
@@ -377,7 +370,7 @@ func (t *ICMPTracerv6) send(ctx context.Context, s *internal.ICMPSpec, ttl, i in
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -88,7 +88,7 @@ func (t *TCPTracer) launchTTL(ctx context.Context, s *internal.TCPSpec, ttl int)
 	t.wg.Add(1)
 	go func(ttl int) {
 		defer t.wg.Done()
-		defer t.res.markTTLLaunchDone(ttl)
+		defer t.res.markTTLLaunchDoneAndCommit(ctx, ttl, t.NumMeasurements, &t.final)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
@@ -196,29 +196,20 @@ func (t *TCPTracer) matchWorker(ctx context.Context) {
 				return
 			}
 
-			// 固定等待 10ms，缓解登记竞态
-			timer := time.NewTimer(10 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-			timer.Stop()
-
-			// 尝试一次匹配
 			var (
 				srcPort int
 				start   time.Time
-				matched bool
 			)
-			if task.ack != 0 {
-				task.seq, start, matched = t.lookupSentByAck(task.srcPort, task.ack)
-				srcPort = task.srcPort
-			} else {
-				srcPort, start, matched = t.lookupSent(task.seq)
-			}
-			if !matched || task.srcPort != srcPort {
+			if !retryTraceProbeLookup(ctx, func() bool {
+				var found bool
+				if task.ack != 0 {
+					task.seq, start, found = t.lookupSentByAck(task.srcPort, task.ack)
+					srcPort = task.srcPort
+				} else {
+					srcPort, start, found = t.lookupSent(task.seq)
+				}
+				return found
+			}) || task.srcPort != srcPort {
 				continue
 			}
 
@@ -399,7 +390,7 @@ func (t *TCPTracer) handleICMPMessage(msg internal.ReceivedMessage, finish time.
 func (t *TCPTracer) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) error {
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 
@@ -415,7 +406,7 @@ func (t *TCPTracer) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) e
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -88,7 +88,7 @@ func (t *TCPTracerIPv6) launchTTL(ctx context.Context, s *internal.TCPSpec, ttl 
 	t.wg.Add(1)
 	go func(ttl int) {
 		defer t.wg.Done()
-		defer t.res.markTTLLaunchDone(ttl)
+		defer t.res.markTTLLaunchDoneAndCommit(ctx, ttl, t.NumMeasurements, &t.final)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
@@ -196,29 +196,20 @@ func (t *TCPTracerIPv6) matchWorker(ctx context.Context) {
 				return
 			}
 
-			// 固定等待 10ms，缓解登记竞态
-			timer := time.NewTimer(10 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-			timer.Stop()
-
-			// 尝试一次匹配
 			var (
 				srcPort int
 				start   time.Time
-				matched bool
 			)
-			if task.ack != 0 {
-				task.seq, start, matched = t.lookupSentByAck(task.srcPort, task.ack)
-				srcPort = task.srcPort
-			} else {
-				srcPort, start, matched = t.lookupSent(task.seq)
-			}
-			if !matched || task.srcPort != srcPort {
+			if !retryTraceProbeLookup(ctx, func() bool {
+				var found bool
+				if task.ack != 0 {
+					task.seq, start, found = t.lookupSentByAck(task.srcPort, task.ack)
+					srcPort = task.srcPort
+				} else {
+					srcPort, start, found = t.lookupSent(task.seq)
+				}
+				return found
+			}) || task.srcPort != srcPort {
 				continue
 			}
 
@@ -399,7 +390,7 @@ func (t *TCPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 func (t *TCPTracerIPv6) send(ctx context.Context, s *internal.TCPSpec, ttl, i int) error {
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 
@@ -415,7 +406,7 @@ func (t *TCPTracerIPv6) send(ctx context.Context, s *internal.TCPSpec, ttl, i in
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -206,6 +206,19 @@ func waitForTraceDelay(ctx context.Context, d time.Duration) bool {
 	}
 }
 
+func retryTraceProbeLookup(ctx context.Context, lookup func() bool) bool {
+	if ctx != nil && ctx.Err() != nil {
+		return false
+	}
+	if lookup() {
+		return true
+	}
+	if !waitForTraceDelay(ctx, 10*time.Millisecond) {
+		return false
+	}
+	return lookup()
+}
+
 func stopAndDrainTimer(timer *time.Timer) {
 	if timer == nil {
 		return
@@ -520,6 +533,17 @@ func (s *Result) markTTLLaunchDone(ttl int) {
 	s.ttlAttemptsLocked(ttl).launchDone = true
 }
 
+func (s *Result) markTTLLaunchDoneAndCommit(ctx context.Context, ttl, numMeasurements int, final *atomic.Int32) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	state := s.ttlAttemptsLocked(ttl)
+	state.launchDone = true
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+	s.lowerStableResponseFinalLocked(ttl, numMeasurements, final)
+}
+
 func (s *Result) ttlDisplayComplete(ttl, numMeasurements int) bool {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -564,6 +588,29 @@ func (s *Result) markAttemptSettledLocked(ttl, attemptIdx int) {
 	state := s.ttlAttemptsLocked(ttl)
 	if _, launched := state.launched[attemptIdx]; launched {
 		state.settled[attemptIdx] = struct{}{}
+	}
+}
+
+func (s *Result) lowerStableResponseFinalLocked(ttl, numMeasurements int, final *atomic.Int32) {
+	if !s.ttlStableLocked(ttl, numMeasurements) {
+		return
+	}
+
+	hasTransit := false
+	hasDestination := false
+	hasUnreachable := false
+	for _, response := range s.responses[ttl] {
+		switch response.kind {
+		case probeResponseTransit:
+			hasTransit = true
+		case probeResponseDestination:
+			hasDestination = true
+		case probeResponseUnreachable:
+			hasUnreachable = true
+		}
+	}
+	if hasDestination || (!hasTransit && hasUnreachable) {
+		lowerTraceFinal(final, ttl)
 	}
 }
 
@@ -961,6 +1008,7 @@ func (s *Result) addMatchedHop(hop Hop, response probeResponse, final *atomic.In
 		added = idx >= 0
 	}
 	s.markAttemptSettledLocked(hop.TTL, attemptIdx)
+	s.lowerStableResponseFinalLocked(hop.TTL, numMeasurements, final)
 	s.lock.Unlock()
 
 	if added && needsMetadata {
@@ -1103,6 +1151,7 @@ func (s *Result) addTimeout(hop Hop, final *atomic.Int32, attemptIdx, numMeasure
 	}
 	added, _ := s.addLocked(hop, attemptIdx, numMeasurements, maxAttempts)
 	s.markAttemptSettledLocked(hop.TTL, attemptIdx)
+	s.lowerStableResponseFinalLocked(hop.TTL, numMeasurements, final)
 	return added
 }
 
@@ -1123,6 +1172,16 @@ func (s *Result) settleAttempt(ttl, attemptIdx int) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.markAttemptSettledLocked(ttl, attemptIdx)
+}
+
+func (s *Result) settleAttemptAndCommit(ctx context.Context, ttl, attemptIdx, numMeasurements int, final *atomic.Int32) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.markAttemptSettledLocked(ttl, attemptIdx)
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+	s.lowerStableResponseFinalLocked(ttl, numMeasurements, final)
 }
 
 func geoLookupMaxRetries(numMeasurements int) int {

--- a/trace/trace_runtime_test.go
+++ b/trace/trace_runtime_test.go
@@ -30,6 +30,47 @@ func TestWaitForTraceDelayZeroDelaySucceeds(t *testing.T) {
 	}
 }
 
+func TestRetryTraceProbeLookupDoesNotDelayRegisteredProbe(t *testing.T) {
+	calls := 0
+	if !retryTraceProbeLookup(context.Background(), func() bool {
+		calls++
+		return true
+	}) {
+		t.Fatal("retryTraceProbeLookup() = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls)
+	}
+}
+
+func TestRetryTraceProbeLookupRetriesRegistrationRace(t *testing.T) {
+	calls := 0
+	if !retryTraceProbeLookup(context.Background(), func() bool {
+		calls++
+		return calls == 2
+	}) {
+		t.Fatal("retryTraceProbeLookup() = false, want true")
+	}
+	if calls != 2 {
+		t.Fatalf("lookup calls = %d, want 2", calls)
+	}
+}
+
+func TestRetryTraceProbeLookupStopsOnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	if retryTraceProbeLookup(ctx, func() bool {
+		calls++
+		return false
+	}) {
+		t.Fatal("retryTraceProbeLookup() = true, want false")
+	}
+	if calls != 0 {
+		t.Fatalf("lookup calls = %d, want 0", calls)
+	}
+}
+
 func TestAcquireTraceSemaphoreChecksCanceledContextFirst(t *testing.T) {
 	sem := semaphore.NewWeighted(1)
 	if err := sem.Acquire(context.Background(), 1); err != nil {

--- a/trace/trace_stop_test.go
+++ b/trace/trace_stop_test.go
@@ -290,6 +290,146 @@ func TestTraceFinalOnlyDecreases(t *testing.T) {
 	}
 }
 
+func TestStableUnreachableLowersFinalBeforePrinting(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 3), tailDone: make([]bool, 3)}
+	var final atomic.Int32
+	final.Store(-1)
+	if !res.markAttemptLaunched(2, 0, &final) {
+		t.Fatal("TTL 2 attempt was not launched")
+	}
+	res.markTTLLaunchDoneAndCommit(context.Background(), 2, 1, &final)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::2")}, TTL: 2},
+		probeResponse{kind: probeResponseUnreachable, detail: "ICMPv6 No Route", marker: "!N"},
+		&final, 0, 1, 1, Config{},
+	)
+
+	if got := final.Load(); got != 2 {
+		t.Fatalf("final = %d, want 2 before printer advances", got)
+	}
+	if res.markAttemptLaunched(3, 0, &final) {
+		t.Fatal("TTL 3 attempt was admitted after the stable unreachable response")
+	}
+	if res.StopReason != nil {
+		t.Fatalf("StopReason = %#v, want printer to set it later", res.StopReason)
+	}
+}
+
+func TestStableUnreachableWaitsForTransitEvidence(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 2), tailDone: make([]bool, 2)}
+	var final atomic.Int32
+	final.Store(-1)
+	for attempt := range 2 {
+		res.markAttemptLaunched(2, attempt, &final)
+	}
+	res.markTTLLaunchDoneAndCommit(context.Background(), 2, 2, &final)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::2")}, TTL: 2},
+		probeResponse{kind: probeResponseUnreachable}, &final, 0, 2, 2, Config{},
+	)
+	if got := final.Load(); got != -1 {
+		t.Fatalf("final after pending unreachable = %d, want -1", got)
+	}
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::3")}, TTL: 2},
+		probeResponse{kind: probeResponseTransit}, &final, 1, 2, 2, Config{},
+	)
+	if got := final.Load(); got != -1 {
+		t.Fatalf("final after transit evidence = %d, want -1", got)
+	}
+}
+
+func TestLaunchDoneCommitsSettledUnreachable(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 2), tailDone: make([]bool, 2)}
+	var final atomic.Int32
+	final.Store(-1)
+	res.markAttemptLaunched(2, 0, &final)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::2")}, TTL: 2},
+		probeResponse{kind: probeResponseUnreachable}, &final, 0, 1, 1, Config{},
+	)
+	if got := final.Load(); got != -1 {
+		t.Fatalf("final before launch completion = %d, want -1", got)
+	}
+	res.markTTLLaunchDoneAndCommit(context.Background(), 2, 1, &final)
+	if got := final.Load(); got != 2 {
+		t.Fatalf("final after launch completion = %d, want 2", got)
+	}
+}
+
+func TestLastTimeoutCommitsStableUnreachable(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 2), tailDone: make([]bool, 2)}
+	var final atomic.Int32
+	final.Store(-1)
+	for attempt := range 2 {
+		res.markAttemptLaunched(2, attempt, &final)
+	}
+	res.markTTLLaunchDoneAndCommit(context.Background(), 2, 1, &final)
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::2")}, TTL: 2},
+		probeResponse{kind: probeResponseUnreachable}, &final, 0, 1, 2, Config{},
+	)
+	if got := final.Load(); got != -1 {
+		t.Fatalf("final before the last attempt settles = %d, want -1", got)
+	}
+	res.addTimeout(Hop{TTL: 2, Error: errHopLimitTimeout}, &final, 1, 1, 2)
+	if got := final.Load(); got != 2 {
+		t.Fatalf("final after the last timeout = %d, want 2", got)
+	}
+}
+
+func TestOnlyIntentionalSkippedAttemptCommitsUnreachable(t *testing.T) {
+	newResult := func() (*Result, *atomic.Int32) {
+		res := &Result{Hops: make([][]Hop, 2), tailDone: make([]bool, 2)}
+		final := &atomic.Int32{}
+		final.Store(-1)
+		for attempt := range 2 {
+			res.markAttemptLaunched(2, attempt, final)
+		}
+		res.markTTLLaunchDoneAndCommit(context.Background(), 2, 1, final)
+		res.addMatchedHop(
+			Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::2")}, TTL: 2},
+			probeResponse{kind: probeResponseUnreachable}, final, 0, 1, 2, Config{},
+		)
+		return res, final
+	}
+
+	canceled, canceledFinal := newResult()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	canceled.settleAttemptAndCommit(ctx, 2, 1, 1, canceledFinal)
+	if got := canceledFinal.Load(); got != -1 {
+		t.Fatalf("final after cancellation settlement = %d, want -1", got)
+	}
+
+	skipped, skippedFinal := newResult()
+	skipped.settleAttemptAndCommit(context.Background(), 2, 1, 1, skippedFinal)
+	if got := skippedFinal.Load(); got != 2 {
+		t.Fatalf("final after intentional skipped attempt = %d, want 2", got)
+	}
+}
+
+func TestCanceledLaunchDoneDoesNotCommitUnreachable(t *testing.T) {
+	res := &Result{Hops: make([][]Hop, 2), tailDone: make([]bool, 2)}
+	var final atomic.Int32
+	final.Store(-1)
+	for attempt := range 2 {
+		res.markAttemptLaunched(2, attempt, &final)
+	}
+	res.addMatchedHop(
+		Hop{Success: true, Address: &net.IPAddr{IP: net.ParseIP("2001:db8::2")}, TTL: 2},
+		probeResponse{kind: probeResponseUnreachable}, &final, 0, 1, 2, Config{},
+	)
+	res.settleAttempt(2, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	res.markTTLLaunchDoneAndCommit(ctx, 2, 1, &final)
+
+	if got := final.Load(); got != -1 {
+		t.Fatalf("final after canceled launch completion = %d, want -1", got)
+	}
+}
+
 func TestMatchedAndTimeoutAboveFinalAreDiscarded(t *testing.T) {
 	res := &Result{Hops: make([][]Hop, 3), tailDone: make([]bool, 3)}
 	var final atomic.Int32

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -93,7 +93,7 @@ func (t *UDPTracer) launchTTL(ctx context.Context, s *internal.UDPSpec, ttl int)
 	t.wg.Add(1)
 	go func(ttl int) {
 		defer t.wg.Done()
-		defer t.res.markTTLLaunchDone(ttl)
+		defer t.res.markTTLLaunchDoneAndCommit(ctx, ttl, t.NumMeasurements, &t.final)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
@@ -234,19 +234,17 @@ func (t *UDPTracer) matchWorker(ctx context.Context) {
 				return
 			}
 
-			// 固定等待 10ms，缓解登记竞态
-			timer := time.NewTimer(10 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-			timer.Stop()
-
-			// 尝试一次匹配
-			ttl, i, srcPort, start, ok := t.lookupSent(task.seq)
-			if !ok {
+			var (
+				ttl     int
+				i       int
+				srcPort int
+				start   time.Time
+			)
+			if !retryTraceProbeLookup(ctx, func() bool {
+				var found bool
+				ttl, i, srcPort, start, found = t.lookupSent(task.seq)
+				return found
+			}) {
 				continue
 			}
 
@@ -443,7 +441,7 @@ func randomPayload(size int, offset int) []byte {
 
 func (t *UDPTracer) acquireSendPermit(ctx context.Context, ttl, i int) (func(), bool, error) {
 	if t.ttlComp(ttl) {
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil, true, nil
 	}
 	if err := acquireTraceSemaphore(ctx, t.sem); err != nil {
@@ -457,7 +455,7 @@ func (t *UDPTracer) acquireSendPermit(ctx context.Context, ttl, i int) (func(), 
 	}
 	if t.ttlComp(ttl) {
 		release()
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil, true, nil
 	}
 	return release, false, nil

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -88,7 +88,7 @@ func (t *UDPTracerIPv6) launchTTL(ctx context.Context, s *internal.UDPSpec, ttl 
 	t.wg.Add(1)
 	go func(ttl int) {
 		defer t.wg.Done()
-		defer t.res.markTTLLaunchDone(ttl)
+		defer t.res.markTTLLaunchDoneAndCommit(ctx, ttl, t.NumMeasurements, &t.final)
 		for i := 0; i < t.MaxAttempts; i++ {
 			// 若此 TTL 已完成或 ctx 已取消，则不再发起新的尝试
 			if t.ttlComp(ttl) || ctx.Err() != nil {
@@ -190,19 +190,15 @@ func (t *UDPTracerIPv6) matchWorker(ctx context.Context) {
 				return
 			}
 
-			// 固定等待 10ms，缓解登记竞态
-			timer := time.NewTimer(10 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-			timer.Stop()
-
-			// 尝试一次匹配
-			srcPort, start, ok := t.lookupSent(task.seq)
-			if !ok {
+			var (
+				srcPort int
+				start   time.Time
+			)
+			if !retryTraceProbeLookup(ctx, func() bool {
+				var found bool
+				srcPort, start, found = t.lookupSent(task.seq)
+				return found
+			}) {
 				continue
 			}
 
@@ -371,7 +367,7 @@ func (t *UDPTracerIPv6) handleICMPMessage(msg internal.ReceivedMessage, finish t
 func (t *UDPTracerIPv6) send(ctx context.Context, s *internal.UDPSpec, ttl, i int) error {
 	if t.ttlComp(ttl) {
 		// 快路径短路：若该 TTL 已完成，直接返回避免竞争信号量与无谓发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 
@@ -387,7 +383,7 @@ func (t *UDPTracerIPv6) send(ctx context.Context, s *internal.UDPSpec, ttl, i in
 
 	if t.ttlComp(ttl) {
 		// 竞态兜底：获取信号量期间可能已完成，再次检查以避免冗余发包
-		t.res.settleAttempt(ttl, i)
+		t.res.settleAttemptAndCommit(ctx, ttl, i, t.NumMeasurements, &t.final)
 		return nil
 	}
 


### PR DESCRIPTION
### Summary

- 在同 TTL 的已发射尝试全部稳定后，立即把 terminal unreachable 提交为发送上界，不再等待 200ms 输出游标
- 已登记 probe 立即匹配；仅在回包先于发送登记时保留 10ms 重试
- 保持 destination > transit > unreachable、final 单调下降和取消路径不提交不完整证据

### Motivation

最新主线对 Issue #204 的显示结果已正确，但确定性 IPv6 unreachable 实机抓包发现：Hop 2 收到 `ICMPv6 No Route` 后，普通 Trace/REST/WS single 仍会新发 TTL 3+。本 PR 修复实际发送边界，而不是只裁剪输出。

### Testing

- `go test ./...`
- `go test -race ./trace -count=3`
- `go test -tags flavor_tiny ./cmd ./server ./trace`
- `go test -tags flavor_ntr ./cmd ./server ./trace`
- `go vet ./...`
- Full/Tiny/NTR builds
- Windows amd64 trace/internal test-binary cross compile
- `node --test server/web/assets/*.test.cjs`
- Linux namespace pcap smoke: UDP/TCP/ICMP 与 Deploy REST 在 10ms TTL 间隔下均只发送 Hop Limit 1、2

Follow-up to #204 and #205.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 提升 IPv4/IPv6 下 ICMP、TCP 和 UDP 路由追踪结果的稳定性与准确性。
  - 改进探测记录匹配机制，减少并发时因登记延迟导致的误判或漏报。
  - 优化不可达响应、超时及提前结束场景，避免错误启动更高 TTL 探测。
  - 支持在任务取消时及时停止重试，缩短退出等待时间。

- **测试**
  - 新增并发、取消、超时及探测登记竞争场景的覆盖，增强结果可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->