### PR TITLE
build: 升级 Go 1.27.1 并建立性能基线

### DIFF
--- a/.cross_compile.sh
+++ b/.cross_compile.sh
@@ -2,6 +2,9 @@
 
 set -Eeuo pipefail
 
+export GOTOOLCHAIN=go1.27.1
+export GOEXPERIMENT=nojsonv2
+
 # -------- Config --------
 # Usage: .cross_compile.sh [full|tiny|ntr|all] [debug]
 #   full  — build nexttrace (Full, includes WebUI + Globalping + MTR)
@@ -33,6 +36,7 @@ case "${FLAVOR_ARG}" in
 esac
 
 TARGET_DIR="dist"
+DARWIN_MIN_VERSION="13.0"
 PLATFORMS="linux/386 linux/amd64 linux/arm64 linux/mips linux/mips64 linux/mipsle linux/mips64le linux/loong64 windows/amd64 windows/arm64 openbsd/amd64 openbsd/arm64 freebsd/amd64 freebsd/arm64"
 UPX_BIN="${UPX_BIN:-$(command -v upx 2>/dev/null || true)}"
 UPX_FLAGS="${UPX_FLAGS:--9}"
@@ -80,8 +84,13 @@ build_one() {
     tags_flag=(-tags "${tags}")
   fi
 
+  local ldflags="${LD_BASE}"
+  if [[ "${goos}" == "darwin" ]]; then
+    ldflags="${ldflags} -macos=${DARWIN_MIN_VERSION}"
+  fi
+
   echo "build => ${target}  (tags: ${tags:-none})"
-  env "$@" go build "${GO_BUILD_FLAGS[@]}" "${tags_flag[@]}" -o "${target}" -ldflags "${LD_BASE}"
+  env "$@" go build "${GO_BUILD_FLAGS[@]}" "${tags_flag[@]}" -o "${target}" -ldflags "${ldflags}"
   compress_with_upx "${target}" "${goos}" "${goarch}" "${target_arm}" "quiet"
 }
 
@@ -187,8 +196,8 @@ if [[ "$(uname)" == "Darwin" ]]; then
     fi
 
     # 仅提供 SDK/架构/最低系统版本；-lpcap 交由源码中的 #cgo LDFLAGS 处理，避免重复
-    export CGO_CFLAGS="-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=11.0"
-    export CGO_LDFLAGS="-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=11.0"
+    export CGO_CFLAGS="-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=${DARWIN_MIN_VERSION}"
+    export CGO_LDFLAGS="-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=${DARWIN_MIN_VERSION}"
 
     for SPEC in "${FLAVOR_SPECS[@]}"; do
       BIN="${SPEC%%:*}"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.golden.json text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,23 @@ on:
     tags: [ "v*" ]
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
+      - ".cross_compile.sh"
+      - "scripts/perf/**"
       - ".github/workflows/*.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
+      - ".cross_compile.sh"
+      - "scripts/perf/**"
       - ".github/workflows/*.yml"
 
 jobs:
@@ -65,6 +73,8 @@ jobs:
           - { goos: openbsd, goarch: arm64 }
           - { goos: openbsd, goarch: arm,    goarm: 7 }
     env:
+      GOTOOLCHAIN: go1.27.1
+      GOEXPERIMENT: nojsonv2
       CGO_ENABLED: ${{ matrix.goos == 'android' && 1 || 0 }}
       GOOS:   ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
@@ -80,7 +90,7 @@ jobs:
       - name: Set up Go (built-in cache)
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.1'
           check-latest: true
           cache: true
 
@@ -211,6 +221,8 @@ jobs:
       fail-fast: false
       matrix: { goarch: [ amd64, arm64 ] }
     env:
+      GOTOOLCHAIN: go1.27.1
+      GOEXPERIMENT: nojsonv2
       CGO_ENABLED: 1
       GOOS: darwin
       GOARCH: ${{ matrix.goarch }}
@@ -224,7 +236,7 @@ jobs:
       - name: Set up Go (built-in cache)
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.1'
           check-latest: true
           cache: true
 
@@ -252,8 +264,8 @@ jobs:
           CC="$(xcrun -f clang)";  CXX="$(xcrun -f clang++)"
           echo "CC=${CC}"   >> "$GITHUB_ENV"
           echo "CXX=${CXX}" >> "$GITHUB_ENV"
-          echo "CGO_CFLAGS=-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=11.0"  >> "$GITHUB_ENV"
-          echo "CGO_LDFLAGS=-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=11.0" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=13.0"  >> "$GITHUB_ENV"
+          echo "CGO_LDFLAGS=-isysroot ${SDKROOT} ${ARCH_FLAG} -mmacosx-version-min=13.0" >> "$GITHUB_ENV"
 
           BUILD_VERSION="$(git describe --tags --always 2>/dev/null || echo dev)"
           BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -267,11 +279,12 @@ jobs:
 
       - name: Build all flavors (Darwin, CGO+libpcap via SDK)
         run: |
+          set -Eeuo pipefail
           mkdir -p dist
           LD_BASE="-X github.com/nxtrace/NTrace-core/config.Version=${BUILD_VERSION} \
                    -X github.com/nxtrace/NTrace-core/config.BuildDate=${BUILD_DATE} \
                    -X github.com/nxtrace/NTrace-core/config.CommitID=${COMMIT_SHA1} \
-                   -w -s"
+                   -macos=13.0 -w -s"
           for SPEC in "nexttrace:" "nexttrace-tiny:flavor_tiny" "ntr:flavor_ntr"; do
             BIN="${SPEC%%:*}"
             TAGS="${SPEC#*:}"
@@ -281,6 +294,39 @@ jobs:
             BUILD_ARGS+=( -o "dist/${NAME}" -ldflags "$LD_BASE" )
             echo "build => dist/${NAME}  (tags: ${TAGS:-none})"
             go build "${BUILD_ARGS[@]}"
+          done
+
+      - name: Verify Darwin minimum OS
+        run: |
+          set -Eeuo pipefail
+          shopt -s nullglob
+          artifacts=(dist/*_darwin_"${GOARCH}")
+          if [[ "${#artifacts[@]}" -ne 3 ]]; then
+            echo "FAIL: expected 3 Darwin artifacts, found ${#artifacts[@]}" >&2
+            exit 1
+          fi
+
+          for artifact in "${artifacts[@]}"; do
+            vtool_info="$(xcrun vtool -show-build "${artifact}")"
+            vtool_commands="$(awk '$1 == "cmd" && $2 == "LC_BUILD_VERSION" { count++ } END { print count + 0 }' <<<"${vtool_info}")"
+            vtool_minos="$(awk '$1 == "minos" { print $2 }' <<<"${vtool_info}")"
+            if [[ "${vtool_commands}" != "1" || "${vtool_minos}" != "13.0" ]]; then
+              echo "FAIL: ${artifact} does not have exactly one LC_BUILD_VERSION with minos 13.0" >&2
+              echo "${vtool_info}" >&2
+              exit 1
+            fi
+
+            otool_info="$(otool -l "${artifact}")"
+            otool_minos="$(awk '
+              $1 == "cmd" { in_build_version = ($2 == "LC_BUILD_VERSION") }
+              in_build_version && $1 == "minos" { print $2 }
+            ' <<<"${otool_info}")"
+            if [[ "${otool_minos}" != "13.0" ]]; then
+              echo "FAIL: otool did not confirm minos 13.0 for ${artifact}" >&2
+              echo "${otool_info}" >&2
+              exit 1
+            fi
+            echo "verified ${artifact}: LC_BUILD_VERSION minos 13.0"
           done
 
       - name: Verify tiny/ntr decoupling

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,16 +14,22 @@ on:
       - main
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
+      - "scripts/perf/**"
       - ".golangci.yml"
       - ".github/workflows/golangci-lint.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
+      - "scripts/perf/**"
       - ".golangci.yml"
       - ".github/workflows/golangci-lint.yml"
 
@@ -31,6 +37,8 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: go1.27.1
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v7
@@ -40,7 +48,7 @@ jobs:
       - name: Set up Go (built-in cache)
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.27.1"
           check-latest: true
           cache: true
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -55,5 +55,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12
+          version: v2.12.2
+          install-mode: goinstall
           only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.2
           install-mode: goinstall
           only-new-issues: true

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -114,11 +114,13 @@ jobs:
             echo "note=Linux measurements are cross-reference evidence only; no performance threshold is enforced."
           } | tee "${evidence_dir}/selection.txt"
 
-          echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "reference_sha=${reference_sha}" >> "${GITHUB_OUTPUT}"
-          echo "reference_kind=${reference_kind}" >> "${GITHUB_OUTPUT}"
-          echo "reference_go_version=${reference_go_version}" >> "${GITHUB_OUTPUT}"
-          echo "reference_toolchain=${reference_toolchain}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "head_sha=${HEAD_SHA}"
+            echo "reference_sha=${reference_sha}"
+            echo "reference_kind=${reference_kind}"
+            echo "reference_go_version=${reference_go_version}"
+            echo "reference_toolchain=${reference_toolchain}"
+          } >> "${GITHUB_OUTPUT}"
 
           git switch --detach "${reference_sha}"
           if [[ "$(git rev-parse HEAD)" != "${reference_sha}" ]]; then

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,6 +30,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Select comparison commit
         id: refs
@@ -76,6 +77,14 @@ jobs:
             echo "FAIL: no comparison commit contains the performance harness" >&2
             exit 1
           fi
+          if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ || ! "${reference_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "FAIL: head and comparison refs must be full commit SHAs" >&2
+            exit 1
+          fi
+          if [[ "${reference_sha}" == "${HEAD_SHA}" ]]; then
+            echo "FAIL: comparison commit must differ from head" >&2
+            exit 1
+          fi
 
           reference_go_directive="$(git show "${reference_sha}:go.mod" | awk '$1 == "go" { print $2; exit }')"
           case "${reference_go_directive}" in
@@ -111,13 +120,11 @@ jobs:
           echo "reference_go_version=${reference_go_version}" >> "${GITHUB_OUTPUT}"
           echo "reference_toolchain=${reference_toolchain}" >> "${GITHUB_OUTPUT}"
 
-      - name: Checkout comparison commit
-        if: ${{ steps.refs.outputs.reference_sha != '' }}
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ steps.refs.outputs.reference_sha }}
-          fetch-depth: 0
-          fetch-tags: true
+          git switch --detach "${reference_sha}"
+          if [[ "$(git rev-parse HEAD)" != "${reference_sha}" ]]; then
+            echo "FAIL: comparison checkout did not resolve to ${reference_sha}" >&2
+            exit 1
+          fi
 
       - name: Set up comparison Go
         if: ${{ steps.refs.outputs.reference_sha != '' }}
@@ -125,7 +132,7 @@ jobs:
         with:
           go-version: ${{ steps.refs.outputs.reference_go_version }}
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Record comparison environment
         if: ${{ steps.refs.outputs.reference_sha != '' }}
@@ -208,19 +215,28 @@ jobs:
           file "${binary_dir}"/* > "${result_dir}/binaries.txt"
           sha256sum "${binary_dir}"/* > "${result_dir}/binaries.sha256"
 
-      - name: Checkout head commit
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ steps.refs.outputs.head_sha }}
-          fetch-depth: 0
-          fetch-tags: true
+      - name: Switch to head commit
+        shell: bash
+        env:
+          HEAD_SHA: ${{ steps.refs.outputs.head_sha }}
+        run: |
+          set -Eeuo pipefail
+          if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "FAIL: head ref must be a full commit SHA" >&2
+            exit 1
+          fi
+          git switch --detach "${HEAD_SHA}"
+          if [[ "$(git rev-parse HEAD)" != "${HEAD_SHA}" ]]; then
+            echo "FAIL: head checkout did not resolve to ${HEAD_SHA}" >&2
+            exit 1
+          fi
 
       - name: Set up head Go 1.27.1
         uses: actions/setup-go@v7
         with:
           go-version: "1.27.1"
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Record head environment
         shell: bash

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,410 @@
+name: Performance Evidence
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  linux-reference:
+    name: Linux cross-reference (no threshold)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      BENCH_COUNT: "10"
+      BENCH_TIME: "1s"
+      BENCH_GOMAXPROCS: "10"
+      PROFILE_TIME: "30s"
+      GOEXPERIMENT: nojsonv2
+    steps:
+      - name: Checkout head history
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Select comparison commit
+        id: refs
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -Eeuo pipefail
+
+          has_harness() {
+            git cat-file -e "${1}:scripts/perf/run_benchmarks.sh" 2>/dev/null &&
+              git cat-file -e "${1}:scripts/perf/profile_benchmark.sh" 2>/dev/null
+          }
+
+          reference_sha=""
+          reference_kind="unavailable"
+          range=""
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            candidate_sha="${PR_BASE_SHA}"
+            range="${PR_BASE_SHA}..${HEAD_SHA}"
+          elif candidate_sha="$(git rev-parse "${HEAD_SHA}^" 2>/dev/null)"; then
+            range="${candidate_sha}..${HEAD_SHA}"
+          else
+            candidate_sha=""
+          fi
+
+          if [[ -n "${candidate_sha}" ]] && has_harness "${candidate_sha}"; then
+            reference_sha="${candidate_sha}"
+            reference_kind="base"
+          elif [[ -n "${range}" ]]; then
+            while IFS= read -r commit; do
+              if has_harness "${commit}"; then
+                reference_sha="${commit}"
+                reference_kind="first-harness"
+                break
+              fi
+            done < <(git rev-list --reverse "${range}")
+          fi
+
+          if [[ -z "${reference_sha}" ]]; then
+            echo "FAIL: no comparison commit contains the performance harness" >&2
+            exit 1
+          fi
+
+          reference_go_directive="$(git show "${reference_sha}:go.mod" | awk '$1 == "go" { print $2; exit }')"
+          case "${reference_go_directive}" in
+            1.26*)
+              reference_go_version="1.26.8"
+              reference_toolchain="go1.26.8"
+              ;;
+            1.27*)
+              reference_go_version="1.27.1"
+              reference_toolchain="go1.27.1"
+              ;;
+            *)
+              echo "FAIL: unsupported comparison go directive: ${reference_go_directive:-missing}" >&2
+              exit 1
+              ;;
+          esac
+
+          evidence_dir="${RUNNER_TEMP}/performance-evidence"
+          mkdir -p "${evidence_dir}"
+          {
+            echo "head_sha=${HEAD_SHA}"
+            echo "reference_sha=${reference_sha:-unavailable}"
+            echo "reference_kind=${reference_kind}"
+            echo "reference_go_directive=${reference_go_directive}"
+            echo "reference_toolchain=${reference_toolchain}"
+            echo "event=${EVENT_NAME}"
+            echo "note=Linux measurements are cross-reference evidence only; no performance threshold is enforced."
+          } | tee "${evidence_dir}/selection.txt"
+
+          echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "reference_sha=${reference_sha}" >> "${GITHUB_OUTPUT}"
+          echo "reference_kind=${reference_kind}" >> "${GITHUB_OUTPUT}"
+          echo "reference_go_version=${reference_go_version}" >> "${GITHUB_OUTPUT}"
+          echo "reference_toolchain=${reference_toolchain}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout comparison commit
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.refs.outputs.reference_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up comparison Go
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ steps.refs.outputs.reference_go_version }}
+          check-latest: true
+          cache: true
+
+      - name: Record comparison environment
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        shell: bash
+        env:
+          GOTOOLCHAIN: ${{ steps.refs.outputs.reference_toolchain }}
+          REFERENCE_KIND: ${{ steps.refs.outputs.reference_kind }}
+        run: |
+          set -Eeuo pipefail
+          result_dir="${RUNNER_TEMP}/performance-evidence/reference"
+          mkdir -p "${result_dir}"
+          {
+            echo "kind=${REFERENCE_KIND}"
+            echo "commit=$(git rev-parse HEAD)"
+            go version
+            echo "GOEXPERIMENT=$(go env GOEXPERIMENT)"
+            echo "GOMAXPROCS=${BENCH_GOMAXPROCS}"
+            echo "benchmark_count=${BENCH_COUNT}"
+            echo "benchmark_time=${BENCH_TIME}"
+            uname -a
+            lscpu
+          } > "${result_dir}/environment.txt"
+
+      - name: Benchmark comparison commit
+        id: reference_bench
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: ${{ steps.refs.outputs.reference_toolchain }}
+          PERF_RESULT_DIR: ${{ runner.temp }}/performance-evidence/reference
+        run: bash scripts/perf/run_benchmarks.sh reference
+
+      - name: Time comparison test suite
+        id: reference_tests
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: ${{ steps.refs.outputs.reference_toolchain }}
+        run: |
+          set -Eeuo pipefail
+          result_dir="${RUNNER_TEMP}/performance-evidence/reference"
+          /usr/bin/time -f 'elapsed_seconds=%e\nmax_rss_kb=%M\nexit_status=%x' \
+            -o "${result_dir}/tests.time.txt" \
+            go test -count=1 ./... 2>&1 | tee "${result_dir}/tests.txt"
+
+      - name: Profile comparison MTR benchmark
+        id: reference_profile
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: ${{ steps.refs.outputs.reference_toolchain }}
+          PERF_RESULT_DIR: ${{ runner.temp }}/performance-evidence/reference
+        run: bash scripts/perf/profile_benchmark.sh ./trace BenchmarkMTRAggregatorSnapshot64TTL4Paths reference-mtr
+
+      - name: Build comparison binaries
+        id: reference_build
+        if: ${{ steps.refs.outputs.reference_sha != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: ${{ steps.refs.outputs.reference_toolchain }}
+        run: |
+          set -Eeuo pipefail
+          result_dir="${RUNNER_TEMP}/performance-evidence/reference"
+          binary_dir="${result_dir}/binaries"
+          mkdir -p "${binary_dir}"
+          build_flags=(-buildvcs=false -trimpath -ldflags '-s -w -buildid=')
+
+          go build "${build_flags[@]}" -o "${binary_dir}/nexttrace" .
+          go build "${build_flags[@]}" -tags flavor_tiny -o "${binary_dir}/nexttrace-tiny" .
+          go build "${build_flags[@]}" -tags flavor_ntr -o "${binary_dir}/ntr" .
+
+          printf 'flavor\tbytes\n' > "${result_dir}/sizes.tsv"
+          for binary in "${binary_dir}"/*; do
+            printf '%s\t%s\n' "$(basename "${binary}")" "$(stat -c '%s' "${binary}")" >> "${result_dir}/sizes.tsv"
+          done
+          file "${binary_dir}"/* > "${result_dir}/binaries.txt"
+          sha256sum "${binary_dir}"/* > "${result_dir}/binaries.sha256"
+
+      - name: Checkout head commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.refs.outputs.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up head Go 1.27.1
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.27.1"
+          check-latest: true
+          cache: true
+
+      - name: Record head environment
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+        run: |
+          set -Eeuo pipefail
+          result_dir="${RUNNER_TEMP}/performance-evidence/head"
+          mkdir -p "${result_dir}"
+          {
+            echo "kind=head"
+            echo "commit=$(git rev-parse HEAD)"
+            go version
+            echo "GOEXPERIMENT=$(go env GOEXPERIMENT)"
+            echo "GOMAXPROCS=${BENCH_GOMAXPROCS}"
+            echo "benchmark_count=${BENCH_COUNT}"
+            echo "benchmark_time=${BENCH_TIME}"
+            uname -a
+            lscpu
+          } > "${result_dir}/environment.txt"
+
+      - name: Benchmark head commit
+        id: head_bench
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+          PERF_RESULT_DIR: ${{ runner.temp }}/performance-evidence/head
+        run: bash scripts/perf/run_benchmarks.sh head
+
+      - name: Time head test suite
+        id: head_tests
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+        run: |
+          set -Eeuo pipefail
+          result_dir="${RUNNER_TEMP}/performance-evidence/head"
+          /usr/bin/time -f 'elapsed_seconds=%e\nmax_rss_kb=%M\nexit_status=%x' \
+            -o "${result_dir}/tests.time.txt" \
+            go test -count=1 ./... 2>&1 | tee "${result_dir}/tests.txt"
+
+      - name: Profile head MTR benchmark
+        id: head_profile
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+          PERF_RESULT_DIR: ${{ runner.temp }}/performance-evidence/head
+        run: bash scripts/perf/profile_benchmark.sh ./trace BenchmarkMTRAggregatorSnapshot64TTL4Paths head-mtr
+
+      - name: Build head binaries
+        id: head_build
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+        run: |
+          set -Eeuo pipefail
+          result_dir="${RUNNER_TEMP}/performance-evidence/head"
+          binary_dir="${result_dir}/binaries"
+          mkdir -p "${binary_dir}"
+          build_flags=(-buildvcs=false -trimpath -ldflags '-s -w -buildid=')
+
+          go build "${build_flags[@]}" -o "${binary_dir}/nexttrace" .
+          go build "${build_flags[@]}" -tags flavor_tiny -o "${binary_dir}/nexttrace-tiny" .
+          go build "${build_flags[@]}" -tags flavor_ntr -o "${binary_dir}/ntr" .
+
+          printf 'flavor\tbytes\n' > "${result_dir}/sizes.tsv"
+          for binary in "${binary_dir}"/*; do
+            printf '%s\t%s\n' "$(basename "${binary}")" "$(stat -c '%s' "${binary}")" >> "${result_dir}/sizes.tsv"
+          done
+          file "${binary_dir}"/* > "${result_dir}/binaries.txt"
+          sha256sum "${binary_dir}"/* > "${result_dir}/binaries.sha256"
+
+      - name: Summarize benchmark comparison
+        id: benchstat
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+        run: |
+          set -Eeuo pipefail
+          evidence_dir="${RUNNER_TEMP}/performance-evidence"
+          reference_raw="${evidence_dir}/reference/reference.bench.txt"
+          head_raw="${evidence_dir}/head/head.bench.txt"
+          summary="${evidence_dir}/benchstat.txt"
+
+          if [[ ! -s "${reference_raw}" || ! -s "${head_raw}" ]]; then
+            echo "benchstat unavailable: reference or head benchmark output is missing" | tee "${summary}"
+            exit 1
+          fi
+
+          bash scripts/perf/compare_benchmarks.sh "${reference_raw}" "${head_raw}" | tee "${summary}"
+          {
+            echo "## Linux performance cross-reference"
+            echo
+            echo "These measurements are informational; no performance threshold is enforced."
+            echo
+            echo '```text'
+            cat "${summary}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload performance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: performance-linux-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/performance-evidence/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Verify performance evidence
+        if: ${{ always() }}
+        shell: bash
+        env:
+          REFERENCE_SHA: ${{ steps.refs.outputs.reference_sha }}
+          REFERENCE_BENCH_OUTCOME: ${{ steps.reference_bench.outcome }}
+          REFERENCE_TESTS_OUTCOME: ${{ steps.reference_tests.outcome }}
+          REFERENCE_PROFILE_OUTCOME: ${{ steps.reference_profile.outcome }}
+          REFERENCE_BUILD_OUTCOME: ${{ steps.reference_build.outcome }}
+          HEAD_BENCH_OUTCOME: ${{ steps.head_bench.outcome }}
+          HEAD_TESTS_OUTCOME: ${{ steps.head_tests.outcome }}
+          HEAD_PROFILE_OUTCOME: ${{ steps.head_profile.outcome }}
+          HEAD_BUILD_OUTCOME: ${{ steps.head_build.outcome }}
+          BENCHSTAT_OUTCOME: ${{ steps.benchstat.outcome }}
+        run: |
+          set -Eeuo pipefail
+          evidence_dir="${RUNNER_TEMP}/performance-evidence"
+          failed=0
+
+          require_success() {
+            local label="$1"
+            local outcome="$2"
+            if [[ "${outcome}" != "success" ]]; then
+              echo "FAIL: ${label} step outcome is ${outcome:-unavailable}" >&2
+              failed=1
+            fi
+          }
+
+          require_file() {
+            local path="$1"
+            if [[ ! -s "${path}" ]]; then
+              echo "FAIL: missing or empty evidence file: ${path}" >&2
+              failed=1
+            fi
+          }
+
+          require_success "head benchmark" "${HEAD_BENCH_OUTCOME}"
+          require_success "head tests" "${HEAD_TESTS_OUTCOME}"
+          require_success "head profile" "${HEAD_PROFILE_OUTCOME}"
+          require_success "head binary build" "${HEAD_BUILD_OUTCOME}"
+          require_success "benchstat" "${BENCHSTAT_OUTCOME}"
+
+          require_file "${evidence_dir}/selection.txt"
+          require_file "${evidence_dir}/head/head.bench.txt"
+          require_file "${evidence_dir}/head/tests.time.txt"
+          require_file "${evidence_dir}/head/head-mtr.cpu.pprof"
+          require_file "${evidence_dir}/head/head-mtr.heap.pprof"
+          require_file "${evidence_dir}/head/sizes.tsv"
+          require_file "${evidence_dir}/head/binaries/nexttrace"
+          require_file "${evidence_dir}/head/binaries/nexttrace-tiny"
+          require_file "${evidence_dir}/head/binaries/ntr"
+          require_file "${evidence_dir}/benchstat.txt"
+
+          if [[ -n "${REFERENCE_SHA}" ]]; then
+            require_success "comparison benchmark" "${REFERENCE_BENCH_OUTCOME}"
+            require_success "comparison tests" "${REFERENCE_TESTS_OUTCOME}"
+            require_success "comparison profile" "${REFERENCE_PROFILE_OUTCOME}"
+            require_success "comparison binary build" "${REFERENCE_BUILD_OUTCOME}"
+
+            require_file "${evidence_dir}/reference/reference.bench.txt"
+            require_file "${evidence_dir}/reference/tests.time.txt"
+            require_file "${evidence_dir}/reference/reference-mtr.cpu.pprof"
+            require_file "${evidence_dir}/reference/reference-mtr.heap.pprof"
+            require_file "${evidence_dir}/reference/sizes.tsv"
+            require_file "${evidence_dir}/reference/binaries/nexttrace"
+            require_file "${evidence_dir}/reference/binaries/nexttrace-tiny"
+            require_file "${evidence_dir}/reference/binaries/ntr"
+          fi
+
+          if (( failed != 0 )); then
+            exit 1
+          fi

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,23 +13,31 @@ on:
     branches: [ main ]
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
       - "scripts/regression/**"
+      - "scripts/perf/**"
       - ".github/workflows/*.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
       - "scripts/regression/**"
+      - "scripts/perf/**"
       - ".github/workflows/*.yml"
 
 jobs:
   regression:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      GOTOOLCHAIN: go1.27.1
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.27.1"
           check-latest: true
           cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,14 +65,16 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
-          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" go test -v -covermode=count -coverprofile='coverage.out' ./...
+          GO_BIN="$(command -v go)"
+          sudo env GOTOOLCHAIN=go1.27.1 "${GO_BIN}" test -v -covermode=count -coverprofile='coverage.out' ./...
 
       - name: Test alternate flavors with unix
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
-          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" go test -tags flavor_tiny ./cmd ./server
-          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" go test -tags flavor_ntr ./cmd ./server
+          GO_BIN="$(command -v go)"
+          sudo env GOTOOLCHAIN=go1.27.1 "${GO_BIN}" test -tags flavor_tiny ./cmd ./server
+          sudo env GOTOOLCHAIN=go1.27.1 "${GO_BIN}" test -tags flavor_ntr ./cmd ./server
 
       - name: Verify q v0.19.12 adapter parity
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -152,9 +154,10 @@ jobs:
 
       - name: Test with legacy JSON implementation
         run: |
-          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" GOEXPERIMENT="${GOEXPERIMENT}" go test ./...
-          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" GOEXPERIMENT="${GOEXPERIMENT}" go test -tags flavor_tiny ./cmd ./server
-          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" GOEXPERIMENT="${GOEXPERIMENT}" go test -tags flavor_ntr ./cmd ./server
+          GO_BIN="$(command -v go)"
+          sudo env GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 "${GO_BIN}" test ./...
+          sudo env GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 "${GO_BIN}" test -tags flavor_tiny ./cmd ./server
+          sudo env GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 "${GO_BIN}" test -tags flavor_ntr ./cmd ./server
 
   race:
     name: Race detector (Ubuntu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,17 +64,14 @@ jobs:
       - name: Test with unix
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
-        run: |
-          GO_BIN="$(command -v go)"
-          sudo env GOTOOLCHAIN=go1.27.1 "${GO_BIN}" test -v -covermode=count -coverprofile='coverage.out' ./...
+        run: go test -v -covermode=count -coverprofile='coverage.out' ./...
 
       - name: Test alternate flavors with unix
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
-          GO_BIN="$(command -v go)"
-          sudo env GOTOOLCHAIN=go1.27.1 "${GO_BIN}" test -tags flavor_tiny ./cmd ./server
-          sudo env GOTOOLCHAIN=go1.27.1 "${GO_BIN}" test -tags flavor_ntr ./cmd ./server
+          go test -tags flavor_tiny ./cmd ./server
+          go test -tags flavor_ntr ./cmd ./server
 
       - name: Verify q v0.19.12 adapter parity
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -154,10 +151,9 @@ jobs:
 
       - name: Test with legacy JSON implementation
         run: |
-          GO_BIN="$(command -v go)"
-          sudo env GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 "${GO_BIN}" test ./...
-          sudo env GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 "${GO_BIN}" test -tags flavor_tiny ./cmd ./server
-          sudo env GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 "${GO_BIN}" test -tags flavor_ntr ./cmd ./server
+          go test ./...
+          go test -tags flavor_tiny ./cmd ./server
+          go test -tags flavor_ntr ./cmd ./server
 
   race:
     name: Race detector (Ubuntu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,10 @@ jobs:
       - name: Check shell syntax
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
-        run: bash -n .cross_compile.sh scripts/perf/*.sh
+        run: |
+          for script in .cross_compile.sh scripts/perf/*.sh; do
+            bash -n "${script}"
+          done
 
       - name: Build all flavors on Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,25 +13,36 @@ on:
       - main
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
       - "nt_install.sh"
+      - ".cross_compile.sh"
       - "scripts/test_nt_install.sh"
+      - "scripts/perf/**"
       - ".github/workflows/*.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "**/*.go"
+      - "**/testdata/**"
       - "go.mod"
       - "go.sum"
+      - "default.pgo"
       - "nt_install.sh"
+      - ".cross_compile.sh"
       - "scripts/test_nt_install.sh"
+      - "scripts/perf/**"
       - ".github/workflows/*.yml"
   workflow_dispatch:
 
 jobs:
   test:
+    name: Default JSON (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      GOTOOLCHAIN: go1.27.1
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +57,7 @@ jobs:
       - name: Set up Go (built-in cache)
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.1'
           check-latest: true
           cache: true
 
@@ -54,14 +65,19 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
-          sudo go env -w GOTOOLCHAIN=go1.26.5+auto
-          sudo go test -v -covermode=count -coverprofile='coverage.out' ./...
+          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" go test -v -covermode=count -coverprofile='coverage.out' ./...
+
+      - name: Test alternate flavors with unix
+        if: ${{ matrix.os != 'windows-latest' }}
+        shell: bash
+        run: |
+          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" go test -tags flavor_tiny ./cmd ./server
+          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" go test -tags flavor_ntr ./cmd ./server
 
       - name: Verify q v0.19.12 adapter parity
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: |
-          export GOTOOLCHAIN=go1.26.5+auto
           go mod download github.com/natesales/q@v0.19.12
           Q_SOURCE="$(go env GOMODCACHE)/github.com/natesales/q@v0.19.12"
           (cd "${Q_SOURCE}" && go build -trimpath -o "${RUNNER_TEMP}/q-v0.19.12" .)
@@ -76,8 +92,85 @@ jobs:
           sh -n nt_install.sh
           bash scripts/test_nt_install.sh
 
+      - name: Verify module state
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          go mod verify
+          go mod tidy -diff
+
+      - name: Run go vet
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: go vet ./...
+
+      - name: Test WebUI assets
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: node --test server/web/assets/*.test.cjs
+
+      - name: Check shell syntax
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: bash -n .cross_compile.sh scripts/perf/*.sh
+
+      - name: Build all flavors on Linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          go build -buildvcs=false -trimpath -o "${RUNNER_TEMP}/nexttrace" .
+          go build -buildvcs=false -trimpath -tags flavor_tiny -o "${RUNNER_TEMP}/nexttrace-tiny" .
+          go build -buildvcs=false -trimpath -tags flavor_ntr -o "${RUNNER_TEMP}/ntr" .
+
       - name: Test with windows
         if: ${{ matrix.os == 'windows-latest' }}
+        run: go test -v -covermode=count -coverprofile="coverage.out" ./...
+
+      - name: Test tiny flavor with windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: go test -tags flavor_tiny ./cmd ./server
+
+      - name: Test ntr flavor with windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: go test -tags flavor_ntr ./cmd ./server
+
+  test-nojsonv2:
+    name: JSON compatibility (nojsonv2)
+    runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: go1.27.1
+      GOEXPERIMENT: nojsonv2
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v7
+
+      - name: Set up Go (built-in cache)
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.27.1'
+          check-latest: true
+          cache: true
+
+      - name: Test with legacy JSON implementation
         run: |
-          go env -w GOTOOLCHAIN=go1.26.5+auto
-          go test -v -covermode=count -coverprofile="coverage.out" ./...
+          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" GOEXPERIMENT="${GOEXPERIMENT}" go test ./...
+          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" GOEXPERIMENT="${GOEXPERIMENT}" go test -tags flavor_tiny ./cmd ./server
+          sudo env GOTOOLCHAIN="${GOTOOLCHAIN}" GOEXPERIMENT="${GOEXPERIMENT}" go test -tags flavor_ntr ./cmd ./server
+
+  race:
+    name: Race detector (Ubuntu)
+    runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: go1.27.1
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v7
+
+      - name: Set up Go (built-in cache)
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.27.1'
+          check-latest: true
+          cache: true
+
+      - name: Run race detector
+        run: go test -race -count=1 ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - 名称：NextTrace (NTrace-core)
 - 仓库：github.com/nxtrace/NTrace-core
 - 模块：`github.com/nxtrace/NTrace-core`
-- 语言：Go（`go 1.26.5`）
+- 语言：Go（`go 1.27.1`）
 - 入口：`main.go -> cmd.Execute()`
 - 核心能力：ICMP/TCP/UDP traceroute、GeoIP/RDNS、MTR 连续探测、Web/API、多平台构建
 
@@ -352,15 +352,17 @@
 
 ## CI 与工具链（当前）
 
-- `go.mod`: `go 1.26.5`
+- `go.mod`: `go 1.27.1`；通过 `tool` directive 固定 `golang.org/x/perf/cmd/benchstat` 版本。
 - GitHub Actions：
-  - `.github/workflows/build.yml` 使用 `setup-go@v7` + `go-version: 1.26.5`
-  - `.github/workflows/test.yml` 使用 `setup-go@v7` + `go-version: 1.26.5`
-  - `.github/workflows/regression.yml` 使用 `setup-go@v7` + `go-version: 1.26.5`
-  - `.github/workflows/golangci-lint.yml` 使用 `setup-go@v7` + `go-version: 1.26.5`
-  - test workflow 中 `GOTOOLCHAIN=go1.26.5+auto`
+  - `.github/workflows/build.yml` 使用 `setup-go@v7` + `go-version: 1.27.1`
+  - `.github/workflows/test.yml` 使用 `setup-go@v7` + `go-version: 1.27.1`
+  - `.github/workflows/regression.yml` 使用 `setup-go@v7` + `go-version: 1.27.1`
+  - `.github/workflows/golangci-lint.yml` 使用 `setup-go@v7` + `go-version: 1.27.1`
+  - test workflow 同时覆盖 Go 1.27 默认 JSON 与 `GOEXPERIMENT=nojsonv2`
+  - 正式发布构建暂用 `GOEXPERIMENT=nojsonv2`
   - build matrix 已移除 `windows/arm`
-- `.cross_compile.sh` 与 workflow 里的 `go build` 现在都用数组构造 `-tags` 参数，避免 shell word-splitting；脚本也会把当前 `GOARM` 传给 `compress_with_upx`，使 linux/armv7 目标能命中对应压缩分支。
+- `.cross_compile.sh` 固定 `GOTOOLCHAIN=go1.27.1` 与 `GOEXPERIMENT=nojsonv2`；脚本与 workflow 里的 `go build` 都用数组构造 `-tags` 参数，避免 shell word-splitting；脚本也会把当前 `GOARM` 传给 `compress_with_upx`，使 linux/armv7 目标能命中对应压缩分支。
+- Darwin 正式构建最低支持 macOS 13.0：CGO 编译/链接使用 `-mmacosx-version-min=13.0`，Go linker 显式传 `-macos=13.0`。
 - `ipgeo/ipdbone.go` 不再原地修改全局 `defaultClient.httpClient.Timeout`；超时覆盖会通过克隆 client（复用 token cache / token init，同步替换整个 HTTP client）实现，避免 dial timeout 与 client timeout 脱节。
 
 ## 关键文件导航

--- a/README.md
+++ b/README.md
@@ -205,9 +205,12 @@ Starting from this release, NextTrace is published in **three flavors** under th
 
 ### Manual Build
 
-Build from source with Go 1.26.5+ installed:
+Build from source with Go 1.27.1+ installed. Release-equivalent builds currently use `GOEXPERIMENT=nojsonv2` to retain the established JSON behavior during the transition:
 
 ```bash
+export GOTOOLCHAIN=go1.27.1
+export GOEXPERIMENT=nojsonv2
+
 # Full (all features)
 go build -trimpath -o dist/nexttrace -ldflags "-w -s" .
 
@@ -218,15 +221,18 @@ go build -tags flavor_tiny -trimpath -o dist/nexttrace-tiny -ldflags "-w -s" .
 go build -tags flavor_ntr -trimpath -o dist/ntr -ldflags "-w -s" .
 ```
 
-On macOS, source builds require Xcode Command Line Tools and cgo because TCP/UDP packet capture links against the system `libpcap`. For a native build, `go env CGO_ENABLED` must report `1`. If it reports `0`, remove any persistent override with `go env -u CGO_ENABLED`, ensure `xcode-select -p` succeeds, and build with `CGO_ENABLED=1`.
+On macOS, source builds require macOS 13.0 or later, Xcode Command Line Tools, and cgo because TCP/UDP packet capture links against the system `libpcap`. For a native build, `go env CGO_ENABLED` must report `1`. If it reports `0`, remove any persistent override with `go env -u CGO_ENABLED`, ensure `xcode-select -p` succeeds, and build with `CGO_ENABLED=1`.
 
 Cross-compile example:
 
 ```bash
 # Linux arm64, Tiny flavor
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 \
+  GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
   go build -tags flavor_tiny -trimpath -o dist/nexttrace-tiny_linux_arm64 -ldflags "-w -s" .
 ```
+
+Benchmark tooling is pinned in `go.mod`; compare saved results with `go tool benchstat before.txt after.txt`.
 
 The `tiny` and `ntr` flavors use **compile-time build tags** to exclude modules — this is not a runtime switch. You can verify with `go version -m <binary>` that `gin`, `globalping-cli`, and `github.com/natesales/q` are absent from `nexttrace-tiny` and `ntr`.
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -206,9 +206,12 @@ Document Language: [English](README.md) | 简体中文
 
 ### 手动编译
 
-需要 Go 1.26.5+ 环境：
+需要 Go 1.27.1+ 环境。与正式发布一致的构建目前使用 `GOEXPERIMENT=nojsonv2`，以在迁移期间保持既有 JSON 行为：
 
 ```bash
+export GOTOOLCHAIN=go1.27.1
+export GOEXPERIMENT=nojsonv2
+
 # 完整版（所有功能）
 go build -trimpath -o dist/nexttrace -ldflags "-w -s" .
 
@@ -219,15 +222,18 @@ go build -tags flavor_tiny -trimpath -o dist/nexttrace-tiny -ldflags "-w -s" .
 go build -tags flavor_ntr -trimpath -o dist/ntr -ldflags "-w -s" .
 ```
 
-macOS 源码编译需要 Xcode Command Line Tools 和 cgo，因为 TCP/UDP 抓包会链接系统 `libpcap`。原生编译时，`go env CGO_ENABLED` 必须输出 `1`；若输出 `0`，请用 `go env -u CGO_ENABLED` 清除持久化覆盖，确认 `xcode-select -p` 成功后，再以 `CGO_ENABLED=1` 编译。
+macOS 源码编译需要 macOS 13.0 或更高版本、Xcode Command Line Tools 和 cgo，因为 TCP/UDP 抓包会链接系统 `libpcap`。原生编译时，`go env CGO_ENABLED` 必须输出 `1`；若输出 `0`，请用 `go env -u CGO_ENABLED` 清除持久化覆盖，确认 `xcode-select -p` 成功后，再以 `CGO_ENABLED=1` 编译。
 
 交叉编译示例：
 
 ```bash
 # Linux arm64 精简版
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 \
+  GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
   go build -tags flavor_tiny -trimpath -o dist/nexttrace-tiny_linux_arm64 -ldflags "-w -s" .
 ```
+
+benchmark 工具已由 `go.mod` 固定版本；可用 `go tool benchstat before.txt after.txt` 比较保存的结果。
 
 `tiny` 和 `ntr` 版本通过 **编译期 build tags** 裁剪模块——不是运行时开关。可通过 `go version -m <binary>` 验证 `nexttrace-tiny` 和 `ntr` 中不包含 `gin`、`globalping-cli` 与 `github.com/natesales/q`。
 

--- a/dn42/geofeed_benchmark_test.go
+++ b/dn42/geofeed_benchmark_test.go
@@ -1,0 +1,169 @@
+package dn42
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+const benchmarkGeoFeedEntryCount = 4096
+
+var (
+	benchmarkGeoFeedRowsSink  []GeoFeedRow
+	benchmarkGeoFeedRowSink   GeoFeedRow
+	benchmarkGeoFeedFoundSink bool
+)
+
+func BenchmarkReadGeoFeedCSV(b *testing.B) {
+	content := buildBenchmarkGeoFeedCSV(false, benchmarkGeoFeedEntryCount/2) +
+		buildBenchmarkGeoFeedCSV(true, benchmarkGeoFeedEntryCount/2)
+	setBenchmarkGeoFeedPath(b, writeBenchmarkGeoFeed(b, content))
+
+	b.ReportAllocs()
+	var (
+		rows []GeoFeedRow
+		err  error
+	)
+	for b.Loop() {
+		rows, err = ReadGeoFeed()
+		if err != nil {
+			b.Fatalf("ReadGeoFeed() error = %v", err)
+		}
+	}
+	benchmarkGeoFeedRowsSink = rows
+}
+
+func BenchmarkFindGeoFeedRow(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		ipv6 bool
+	}{
+		{name: "IPv4", ipv6: false},
+		{name: "IPv6", ipv6: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			content := buildBenchmarkGeoFeedCSV(tc.ipv6, benchmarkGeoFeedEntryCount)
+			setBenchmarkGeoFeedPath(b, writeBenchmarkGeoFeed(b, content))
+			rows, err := ReadGeoFeed()
+			if err != nil {
+				b.Fatalf("ReadGeoFeed() setup error = %v", err)
+			}
+			if len(rows) != benchmarkGeoFeedEntryCount {
+				b.Fatalf("ReadGeoFeed() rows = %d, want %d", len(rows), benchmarkGeoFeedEntryCount)
+			}
+
+			lookupCases := []struct {
+				name     string
+				target   string
+				wantCIDR string
+				wantHit  bool
+			}{
+				{
+					name:     "HeadHit",
+					target:   rows[0].IPNet.IP.String(),
+					wantCIDR: rows[0].CIDR,
+					wantHit:  true,
+				},
+				{
+					name:     "MiddleHit",
+					target:   rows[len(rows)/2].IPNet.IP.String(),
+					wantCIDR: rows[len(rows)/2].CIDR,
+					wantHit:  true,
+				},
+				{
+					name:     "TailHit",
+					target:   rows[len(rows)-1].IPNet.IP.String(),
+					wantCIDR: rows[len(rows)-1].CIDR,
+					wantHit:  true,
+				},
+				{
+					name:    "Miss",
+					target:  benchmarkGeoFeedMissTarget(tc.ipv6),
+					wantHit: false,
+				},
+			}
+
+			for _, lookup := range lookupCases {
+				b.Run(lookup.name, func(b *testing.B) {
+					b.ReportAllocs()
+					var (
+						row   GeoFeedRow
+						found bool
+					)
+					for b.Loop() {
+						row, found = FindGeoFeedRow(lookup.target, rows)
+					}
+					if found != lookup.wantHit || found && row.CIDR != lookup.wantCIDR {
+						b.Fatalf(
+							"FindGeoFeedRow(%q) = (%+v, %v), want CIDR %q, found %v",
+							lookup.target,
+							row,
+							found,
+							lookup.wantCIDR,
+							lookup.wantHit,
+						)
+					}
+					benchmarkGeoFeedRowSink = row
+					benchmarkGeoFeedFoundSink = found
+				})
+			}
+		})
+	}
+}
+
+func benchmarkGeoFeedMissTarget(ipv6 bool) string {
+	if ipv6 {
+		return "2001:db8::1"
+	}
+	return "192.0.2.1"
+}
+
+func buildBenchmarkGeoFeedCSV(ipv6 bool, entries int) string {
+	var content strings.Builder
+	content.Grow(entries * 72)
+	for i := 0; i < entries; i++ {
+		if ipv6 {
+			_, _ = fmt.Fprintf(
+				&content,
+				"fd00:%x::/64,us,US,City-%d,AS%d,Owner-%d\n",
+				i,
+				i,
+				64512+i,
+				i,
+			)
+			continue
+		}
+		_, _ = fmt.Fprintf(
+			&content,
+			"10.%d.%d.0/24,us,US,City-%d,AS%d,Owner-%d\n",
+			(i/256)%256,
+			i%256,
+			i,
+			64512+i,
+			i,
+		)
+	}
+	return content.String()
+}
+
+func writeBenchmarkGeoFeed(b *testing.B, content string) string {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "geofeed.csv")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		b.Fatalf("write benchmark geofeed: %v", err)
+	}
+	return path
+}
+
+func setBenchmarkGeoFeedPath(b *testing.B, path string) {
+	b.Helper()
+	previous := viper.Get("geoFeedPath")
+	viper.Set("geoFeedPath", path)
+	b.Cleanup(func() {
+		viper.Set("geoFeedPath", previous)
+	})
+}

--- a/docs/performance/go127-baseline.md
+++ b/docs/performance/go127-baseline.md
@@ -1,0 +1,124 @@
+# Go 1.27.1 性能与产物基线
+
+## 范围与结论
+
+本基线比较仅改变工具链和发布约束，不包含运行时算法优化：
+
+- 生产代码基线：`40ac803ca233b0bc3d4b3bf1cacc8f7e0d8368f2`
+- Go 1.26.8 测量点：`2cab379`，只在生产基线上增加 benchmark、golden 和性能脚本
+- Go 1.27.1 测量点：`b771e8d`
+- 发布构建暂时使用 `GOEXPERIMENT=nojsonv2`
+- 最低支持版本改为 macOS 13.0
+
+Go 1.27.1 缩小了三种 flavor 的产物，并改善了部分解析路径；同时，现有
+WebSocket JSON marshal、Geo cache 和 Geo HTTP client 路径出现了可重复的回退。
+这些结果作为后续 PR-2、PR-4、PR-5 和 PR-8A 的优化基线，不在工具链升级中
+混入算法调整。
+
+## 测量环境
+
+| 项目 | 值 |
+| --- | --- |
+| 主机 | Apple M5，10 核，32 GB 内存 |
+| 系统 | macOS 26.6.2 (25G83)，AC 供电 |
+| 工具链 | Go 1.26.8 与 Go 1.27.1，darwin/arm64 |
+| 并发 | `GOMAXPROCS=10` |
+| benchmark | 每组 10 次，每次 1 秒 |
+| 热点复测 | 反向运行顺序，各追加 10 次；合并后 `n=20` |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+| 压缩工具 | UPX 5.2.1，`-9` |
+
+第一轮先运行 Go 1.26.8，再运行 Go 1.27.1。超过 1% 且可能受持续负载影响的
+热点随后按 Go 1.27.1、Go 1.26.8 的反向顺序各补 10 次；下表的 `n=20`
+项目使用合并结果。`~` 表示 benchstat 未确认显著差异。
+
+## Go 1.26.8 与 Go 1.27.1
+
+两侧均使用 `GOEXPERIMENT=nojsonv2`。
+
+| Benchmark | Go 1.26.8 | Go 1.27.1 | 变化 |
+| --- | ---: | ---: | ---: |
+| GeoFeed CSV parse | 1.190 ms | 1.149 ms | -3.44% (`n=10`) |
+| GeoFeed IPv4 miss | 23.61 µs | 22.90 µs | -3.00% (`n=20`) |
+| MTR Update, 64×4 | 83.13 µs | 82.92 µs | ~ (`n=10`) |
+| MTR Clone, 64×4 | 37.12 µs | 37.28 µs | ~ (`n=10`) |
+| MTR Snapshot, 64×4 | 27.75 µs | 27.26 µs | -1.75% (`n=10`) |
+| MTR preview clone/update, 64×4 | 68.85 µs | 68.64 µs | ~ (`n=10`) |
+| WebSocket JSON marshal | 470.9 ns | 532.4 ns | +13.05% (`n=20`) |
+| WebSocket JSON unmarshal | 2.574 µs | 2.481 µs | -3.61% (`n=10`) |
+| Geo cache hit | 6.706 ns | 7.444 ns | +11.01% (`n=20`) |
+| Geo cache miss | 4.018 ns | 4.823 ns | +20.02% (`n=20`) |
+| Geo HTTP client construct | 207.7 ns | 246.5 ns | +18.69% (`n=20`) |
+| Geo HTTP sequential request | 30.65 µs | 33.06 µs | +7.85% (`n=20`) |
+| Geo HTTP concurrent request | 43.40 µs | 48.13 µs | +10.90% (`n=20`) |
+| ICMPv4 decoder | 95.94 ns | 87.43 ns | -8.87% (`n=10`) |
+| UDPv4 decoder | 92.80 ns | 107.50 ns | +15.85% (`n=20`) |
+| MTU embedded UDP IPv4 | 10.70 ns | 10.37 ns | -3.09% (`n=10`) |
+| MTU embedded UDP IPv6 ext | 14.66 ns | 13.24 ns | -9.72% (`n=10`) |
+| nali span scan | 4.246 µs | 4.272 µs | +0.62% (`n=10`) |
+
+Geo HTTP 构造由 6 增至 7 alloc/op，单次分配量增加 160 B；其余表中路径的
+alloc/op 未因工具链改变。Geo cache 的相对回退较大，但绝对差值分别只有
+0.738 ns/op 和 0.805 ns/op。UDP decoder 与 Geo HTTP 网络 benchmark 的离散度
+高于纯 CPU benchmark；反向复测后方向未消失，但仍须在后续 PR 和不同平台复核。
+
+## Go 1.27 JSON 后端预检
+
+同一 Go 1.27.1 head 上直接比较默认 JSON 后端与 `nojsonv2`：
+
+| Benchmark | `nojsonv2` | 默认后端 | 默认后端变化 |
+| --- | ---: | ---: | ---: |
+| WebSocket marshal | 494.9 ns, 416 B, 2 allocs | 730.8 ns, 896 B, 5 allocs | +47.66% |
+| WebSocket unmarshal | 2.427 µs, 656 B, 15 allocs | 1.204 µs, 368 B, 3 allocs | -50.41% |
+
+两种后端均通过现有 JSON golden。marshal 与 unmarshal 的方向相反，PR-0 不据此
+切换正式发布后端；发布继续使用 `nojsonv2`，默认后端和 `nojsonv2` 测试 lane
+同时保留，最终决策留给 PR-8A 的完整 schema 与 workload 证据。
+
+## Profile
+
+`BenchmarkMTRAggregatorSnapshot64TTL4Paths` 分别采集 30 秒 CPU 与 heap profile：
+
+| 指标 | Go 1.26.8 | Go 1.27.1 |
+| --- | ---: | ---: |
+| 单次耗时 | 27.466 µs | 25.627 µs |
+| 分配 | 106,544 B/op | 106,544 B/op |
+| 分配次数 | 458 allocs/op | 458 allocs/op |
+
+两版的应用热点结构一致。`snapshotLocked` 占分配空间约 90%，
+`buildMTRHopStat` 约占 7.7%；CPU profile 中 `snapshotLocked` 的累计占比约
+27%–28%。这两个位置是 PR-5 的主要优化目标。原始 profile 由性能工作流作为
+artifact 保存，不提交二进制 profile。
+
+## 产物大小
+
+产物使用相同参数：`-buildvcs=false -trimpath -ldflags '-s -w -buildid='`。
+
+### Darwin arm64，未压缩
+
+| Flavor | Go 1.26.8 | Go 1.27.1 | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,756,194 B | 29,994,386 B | -2.48% |
+| nexttrace-tiny | 11,182,482 B | 10,901,186 B | -2.52% |
+| ntr | 11,182,482 B | 10,901,186 B | -2.52% |
+
+### Linux arm64，未压缩 / UPX `-9`
+
+| Flavor | Go 1.26.8 | Go 1.27.1 | 未压缩变化 | UPX 变化 |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 30,408,830 / 9,844,644 B | 29,622,396 / 9,682,520 B | -2.59% | -1.65% |
+| nexttrace-tiny | 11,075,710 / 4,119,380 B | 10,813,564 / 4,063,688 B | -2.37% | -1.35% |
+| ntr | 11,075,710 / 4,119,076 B | 10,813,564 / 4,063,672 B | -2.37% | -1.35% |
+
+Darwin 三 flavor 的 `LC_BUILD_VERSION` 均验证为 `minos 13.0`。
+
+## 验证与复现
+
+本地已分别通过 Go 1.26.8 `nojsonv2`、Go 1.27.1 默认 JSON 和 Go 1.27.1
+`nojsonv2` 的 `go test -count=1 ./...`。同机预热单次 wall time 分别约为
+25.0 秒、24.9 秒和 25.7 秒；单次测试耗时不作性能结论，性能工作流会为每个
+exact head 重新保存原始时间。
+
+性能工作流保存两侧原始 benchmark、benchstat、测试耗时、CPU/heap profile、
+三 flavor stripped binary、大小和校验和。仓库内的 `scripts/perf` 可在相同环境
+重现同一采集流程。

--- a/docs/performance/go127-baseline.md
+++ b/docs/performance/go127-baseline.md
@@ -12,8 +12,8 @@
 
 Go 1.27.1 缩小了三种 flavor 的产物，并改善了部分解析路径；同时，现有
 WebSocket JSON marshal、Geo cache 和 Geo HTTP client 路径出现了可重复的回退。
-这些结果作为后续 PR-2、PR-4、PR-5 和 PR-8A 的优化基线，不在工具链升级中
-混入算法调整。
+这些结果作为后续 PR-1、PR-2、PR-3、PR-4、PR-5 和 PR-8A 的优化基线，
+不在工具链升级中混入算法调整。
 
 ## 测量环境
 
@@ -28,9 +28,9 @@ WebSocket JSON marshal、Geo cache 和 Geo HTTP client 路径出现了可重复�
 | 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
 | 压缩工具 | UPX 5.2.1，`-9` |
 
-第一轮先运行 Go 1.26.8，再运行 Go 1.27.1。超过 1% 且可能受持续负载影响的
-热点随后按 Go 1.27.1、Go 1.26.8 的反向顺序各补 10 次；下表的 `n=20`
-项目使用合并结果。`~` 表示 benchstat 未确认显著差异。
+第一轮先运行 Go 1.26.8，再运行 Go 1.27.1。选取可能受持续负载影响的热点，
+随后按 Go 1.27.1、Go 1.26.8 的反向顺序各补 10 次；下表的 `n=20` 项目使用
+合并结果。`~` 表示 benchstat 未确认显著差异。
 
 ## Go 1.26.8 与 Go 1.27.1
 
@@ -51,6 +51,8 @@ WebSocket JSON marshal、Geo cache 和 Geo HTTP client 路径出现了可重复�
 | Geo HTTP client construct | 207.7 ns | 246.5 ns | +18.69% (`n=20`) |
 | Geo HTTP sequential request | 30.65 µs | 33.06 µs | +7.85% (`n=20`) |
 | Geo HTTP concurrent request | 43.40 µs | 48.13 µs | +10.90% (`n=20`) |
+| Geo HTTP multi-client sequential | 28.79 µs | 31.86 µs | +10.67% (`n=20`) |
+| Geo HTTP multi-client concurrent | 69.65 µs | 78.74 µs | +13.04% (`n=20`) |
 | ICMPv4 decoder | 95.94 ns | 87.43 ns | -8.87% (`n=10`) |
 | UDPv4 decoder | 92.80 ns | 107.50 ns | +15.85% (`n=20`) |
 | MTU embedded UDP IPv4 | 10.70 ns | 10.37 ns | -3.09% (`n=10`) |
@@ -81,14 +83,13 @@ alloc/op 未因工具链改变。Geo cache 的相对回退较大，但绝对差�
 
 | 指标 | Go 1.26.8 | Go 1.27.1 |
 | --- | ---: | ---: |
-| 单次耗时 | 27.466 µs | 25.627 µs |
 | 分配 | 106,544 B/op | 106,544 B/op |
 | 分配次数 | 458 allocs/op | 458 allocs/op |
 
 两版的应用热点结构一致。`snapshotLocked` 占分配空间约 90%，
 `buildMTRHopStat` 约占 7.7%；CPU profile 中 `snapshotLocked` 的累计占比约
-27%–28%。这两个位置是 PR-5 的主要优化目标。原始 profile 由性能工作流作为
-artifact 保存，不提交二进制 profile。
+27%–28%。这两个位置是 PR-5 的主要优化目标。本地 Apple M5 原始 profile
+不入库；性能工作流会另行生成并保存 Linux cross-reference profile artifact。
 
 ## 产物大小
 
@@ -115,9 +116,8 @@ Darwin 三 flavor 的 `LC_BUILD_VERSION` 均验证为 `minos 13.0`。
 ## 验证与复现
 
 本地已分别通过 Go 1.26.8 `nojsonv2`、Go 1.27.1 默认 JSON 和 Go 1.27.1
-`nojsonv2` 的 `go test -count=1 ./...`。同机预热单次 wall time 分别约为
-25.0 秒、24.9 秒和 25.7 秒；单次测试耗时不作性能结论，性能工作流会为每个
-exact head 重新保存原始时间。
+`nojsonv2` 的 `go test -count=1 ./...`。单次测试耗时不作性能结论，性能工作流
+会为每个 exact head 重新保存原始时间。
 
 性能工作流保存两侧原始 benchmark、benchstat、测试耗时、CPU/heap profile、
 三 flavor stripped binary、大小和校验和。仓库内的 `scripts/perf` 可在相同环境

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nxtrace/NTrace-core
 
-go 1.26.5
+go 1.27.1
+
+tool golang.org/x/perf/cmd/benchstat
 
 require (
 	github.com/akamensky/argparse v1.4.0
@@ -36,6 +38,7 @@ require (
 
 require (
 	github.com/AdguardTeam/golibs v0.35.9 // indirect
+	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 // indirect
 	github.com/ameshkov/dnsstamps v1.0.3 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -95,8 +98,9 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
-	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
-	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/exp v0.0.0-20260812173653-3d80eb74bc5b // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/perf v0.0.0-20260825160852-19be9d8e6c70 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 git.schwanenlied.me/yawning/x448.git v0.0.0-20170617130356-01b048fb03d6/go.mod h1:wQaGCqEu44ykB17jZHCevrgSVl3KJnwQBObUtrKU4uU=
 github.com/AdguardTeam/golibs v0.35.9 h1:KmmPBgE+PnXmxd+sp5fACRjU6oYT8r7okWEU3L9B6Qo=
 github.com/AdguardTeam/golibs v0.35.9/go.mod h1:kuLQ0yNRTl0Em2FmmXtSri7ZdVT7p62oojyc51RvP38=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/akamensky/argparse v1.4.0 h1:YGzvsTqCvbEZhL8zZu2AiA5nq805NZh75JNj4ajn1xc=
 github.com/akamensky/argparse v1.4.0/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz4IZQuw64xA=
 github.com/ameshkov/dnscrypt/v2 v2.4.0 h1:if6ZG2cuQmcP2TwSY+D0+8+xbPfoatufGlOQTMNkI9o=
@@ -208,8 +210,8 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
-golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa h1:Zt3DZoOFFYkKhDT3v7Lm9FDMEV06GpzjG2jrqW+QTE0=
-golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
+golang.org/x/exp v0.0.0-20260812173653-3d80eb74bc5b h1:3XR0v9KL97wjTmRb+6RqMylL4d7ZWM1sQYIITGDxtmg=
+golang.org/x/exp v0.0.0-20260812173653-3d80eb74bc5b/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
@@ -218,8 +220,10 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
-golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
-golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
+golang.org/x/perf v0.0.0-20260825160852-19be9d8e6c70 h1:M+kM03JKR23KkrutTue5KEQYDSbZTZTJ4FJ1v5zYrHM=
+golang.org/x/perf v0.0.0-20260825160852-19be9d8e6c70/go.mod h1:ihD/LfJrdVe40PFEzKgix8YPzoXS4LFO4elW9HAFNqo=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=

--- a/internal/nali/nali_benchmark_test.go
+++ b/internal/nali/nali_benchmark_test.go
@@ -1,0 +1,24 @@
+package nali
+
+import (
+	"strings"
+	"testing"
+)
+
+var naliBenchmarkSpansSink []Span
+
+func BenchmarkFindIPSpans(b *testing.B) {
+	line := strings.Repeat(
+		" 1  192.0.2.1  1.25 ms  2  198.51.100.2:443  2.50 ms  3  [2001:db8::3]  3.75 ms  via fe80::1%en0\n",
+		8,
+	)
+	if spans := FindIPSpans(line); len(spans) != 32 {
+		b.Fatalf("FindIPSpans() found %d spans, want 32", len(spans))
+	}
+	b.SetBytes(int64(len(line)))
+	b.ReportAllocs()
+
+	for b.Loop() {
+		naliBenchmarkSpansSink = FindIPSpans(line)
+	}
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -5,18 +5,21 @@ settings. The scripts default to `GOMAXPROCS=10`, ten samples, one second per
 sample, and store raw results below the ignored `.cache/perf` directory.
 
 ```sh
-scripts/perf/run_benchmarks.sh base
-scripts/perf/run_benchmarks.sh head
+GOEXPERIMENT=nojsonv2 scripts/perf/run_benchmarks.sh base
+GOEXPERIMENT=nojsonv2 scripts/perf/run_benchmarks.sh head
 scripts/perf/compare_benchmarks.sh .cache/perf/base.bench.txt .cache/perf/head.bench.txt
-scripts/perf/measure_binaries.sh head
+GOEXPERIMENT=nojsonv2 scripts/perf/measure_binaries.sh head
 ```
+
+These commands select the release JSON runtime explicitly. Set
+`GOEXPERIMENT=` instead when measuring the Go 1.27 default JSON runtime.
 
 If a result crosses a merge threshold without a statistically clear result,
 repeat both sides with `BENCH_COUNT=20`. Generate CPU and heap profiles for a
 single representative benchmark with:
 
 ```sh
-scripts/perf/profile_benchmark.sh ./trace BenchmarkMTRAggregatorSnapshot64TTL4Paths profile-name
+GOEXPERIMENT=nojsonv2 scripts/perf/profile_benchmark.sh ./trace BenchmarkMTRAggregatorSnapshot64TTL4Paths profile-name
 ```
 
 Record `go version`, `go env GOEXPERIMENT`, the exact commit IDs, machine,

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,29 @@
+# Performance evidence
+
+Run benchmarks on the same idle machine, with the same Go toolchain and power
+settings. The scripts default to `GOMAXPROCS=10`, ten samples, one second per
+sample, and store raw results below the ignored `.cache/perf` directory.
+
+```sh
+scripts/perf/run_benchmarks.sh base
+scripts/perf/run_benchmarks.sh head
+scripts/perf/compare_benchmarks.sh .cache/perf/base.bench.txt .cache/perf/head.bench.txt
+scripts/perf/measure_binaries.sh head
+```
+
+If a result crosses a merge threshold without a statistically clear result,
+repeat both sides with `BENCH_COUNT=20`. Generate CPU and heap profiles for a
+single representative benchmark with:
+
+```sh
+scripts/perf/profile_benchmark.sh ./trace BenchmarkMTRAggregatorSnapshot64TTL4Paths profile-name
+```
+
+Record `go version`, `go env GOEXPERIMENT`, the exact commit IDs, machine,
+operating system, `GOMAXPROCS`, sample count, and any profiler or UPX version in
+the pull request. Keep raw profiles and binaries as CI artifacts rather than
+committing them.
+
+`measure_binaries.sh` records stripped local-platform sizes. Set `UPX_BIN` to an
+exact UPX executable when that target format is supported; use the same binary
+and flags for both sides of a comparison.

--- a/scripts/perf/compare_benchmarks.sh
+++ b/scripts/perf/compare_benchmarks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: $0 BASE.bench.txt HEAD.bench.txt" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CALLER_DIR="${PWD}"
+
+resolve_input_path() {
+  local path="$1"
+  if [[ "${path}" == /* ]]; then
+    printf '%s\n' "${path}"
+    return
+  fi
+  printf '%s/%s\n' "${CALLER_DIR}" "${path}"
+}
+
+BASE_FILE="$(resolve_input_path "$1")"
+HEAD_FILE="$(resolve_input_path "$2")"
+
+(
+  cd "${ROOT_DIR}"
+  go tool benchstat "${BASE_FILE}" "${HEAD_FILE}"
+)

--- a/scripts/perf/measure_binaries.sh
+++ b/scripts/perf/measure_binaries.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CALLER_DIR="${PWD}"
+RESULT_NAME="${1:-$(git -C "${ROOT_DIR}" rev-parse --short HEAD)}"
+RESULT_DIR="${PERF_RESULT_DIR:-${ROOT_DIR}/.cache/perf}"
+BUILD_DIR="$(mktemp -d)"
+
+if [[ "${RESULT_DIR}" != /* ]]; then
+  RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
+fi
+
+cleanup() {
+  rm -rf -- "${BUILD_DIR}"
+}
+trap cleanup EXIT
+
+mkdir -p "${RESULT_DIR}"
+OUTPUT_FILE="${RESULT_DIR}/${RESULT_NAME}.sizes.tsv"
+
+printf 'flavor\tuncompressed_bytes\tupx_bytes\n' >"${OUTPUT_FILE}"
+
+measure_flavor() {
+  local flavor="$1"
+  local tags="$2"
+  local binary="${BUILD_DIR}/${flavor}"
+  local -a tags_flag=()
+  if [[ -n "${tags}" ]]; then
+    tags_flag=(-tags "${tags}")
+  fi
+
+  go build -buildvcs=false -trimpath "${tags_flag[@]}" -ldflags '-s -w -buildid=' -o "${binary}" .
+
+  local plain_size
+  plain_size="$(wc -c <"${binary}" | tr -d ' ')"
+  local upx_size="n/a"
+  if [[ -n "${UPX_BIN:-}" ]]; then
+    local packed="${binary}.upx"
+    local -a upx_flags
+    read -r -a upx_flags <<<"${UPX_FLAGS:--9}"
+    cp "${binary}" "${packed}"
+    if ! "${UPX_BIN}" "${upx_flags[@]}" "${packed}" >/dev/null; then
+      echo "UPX failed for ${flavor}: ${UPX_BIN}" >&2
+      return 1
+    fi
+    upx_size="$(wc -c <"${packed}" | tr -d ' ')"
+  fi
+
+  printf '%s\t%s\t%s\n' "${flavor}" "${plain_size}" "${upx_size}" >>"${OUTPUT_FILE}"
+}
+
+cd "${ROOT_DIR}"
+measure_flavor nexttrace ''
+measure_flavor nexttrace-tiny flavor_tiny
+measure_flavor ntr flavor_ntr
+
+cat "${OUTPUT_FILE}"

--- a/scripts/perf/profile_benchmark.sh
+++ b/scripts/perf/profile_benchmark.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+  echo "Usage: $0 PACKAGE BENCHMARK [RESULT_NAME]" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CALLER_DIR="${PWD}"
+PACKAGE="$1"
+BENCHMARK="$2"
+RESULT_NAME="${3:-$(git -C "${ROOT_DIR}" rev-parse --short HEAD)}"
+RESULT_DIR="${PERF_RESULT_DIR:-${ROOT_DIR}/.cache/perf}"
+PROFILE_TIME="${PROFILE_TIME:-30s}"
+BENCH_GOMAXPROCS="${BENCH_GOMAXPROCS:-10}"
+
+if [[ "${RESULT_DIR}" != /* ]]; then
+  RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
+fi
+
+mkdir -p "${RESULT_DIR}"
+export GOMAXPROCS="${BENCH_GOMAXPROCS}"
+
+benchmark_list="$(
+  cd "${ROOT_DIR}"
+  go test -run '^$' -list "^${BENCHMARK}$" "${PACKAGE}"
+)"
+benchmark_found=false
+while IFS= read -r name; do
+  if [[ "${name}" == "${BENCHMARK}" ]]; then
+    benchmark_found=true
+    break
+  fi
+done <<<"${benchmark_list}"
+if [[ "${benchmark_found}" != true ]]; then
+  echo "Benchmark not found in ${PACKAGE}: ${BENCHMARK}" >&2
+  exit 1
+fi
+
+(
+  cd "${ROOT_DIR}"
+  go test \
+    -run '^$' \
+    -bench "^${BENCHMARK}$" \
+    -benchtime "${PROFILE_TIME}" \
+    -count 1 \
+    -cpuprofile "${RESULT_DIR}/${RESULT_NAME}.cpu.pprof" \
+    -memprofile "${RESULT_DIR}/${RESULT_NAME}.heap.pprof" \
+    "${PACKAGE}"
+)
+
+echo "CPU profile: ${RESULT_DIR}/${RESULT_NAME}.cpu.pprof"
+echo "heap profile: ${RESULT_DIR}/${RESULT_NAME}.heap.pprof"

--- a/scripts/perf/run_benchmarks.sh
+++ b/scripts/perf/run_benchmarks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CALLER_DIR="${PWD}"
+RESULT_NAME="${1:-$(git -C "${ROOT_DIR}" rev-parse --short HEAD)}"
+RESULT_DIR="${PERF_RESULT_DIR:-${ROOT_DIR}/.cache/perf}"
+BENCH_COUNT="${BENCH_COUNT:-10}"
+BENCH_TIME="${BENCH_TIME:-1s}"
+BENCH_GOMAXPROCS="${BENCH_GOMAXPROCS:-10}"
+
+if [[ "${RESULT_DIR}" != /* ]]; then
+  RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
+fi
+
+mkdir -p "${RESULT_DIR}"
+
+export GOMAXPROCS="${BENCH_GOMAXPROCS}"
+
+(
+  cd "${ROOT_DIR}"
+  go test \
+    -run '^$' \
+    -bench '^Benchmark' \
+    -benchmem \
+    -benchtime "${BENCH_TIME}" \
+    -count "${BENCH_COUNT}" \
+    ./dn42 ./util ./trace ./trace/internal ./trace/mtu ./server ./internal/nali
+) | tee "${RESULT_DIR}/${RESULT_NAME}.bench.txt"
+
+echo "benchmark results: ${RESULT_DIR}/${RESULT_NAME}.bench.txt"

--- a/server/testdata/ws_envelopes.golden.json
+++ b/server/testdata/ws_envelopes.golden.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "start",
+    "data": {
+      "data_provider": "NextTrace-API",
+      "language": "en",
+      "protocol": "UDP",
+      "resolved_ip": "2001:db8::9",
+      "target": "example.test"
+    }
+  },
+  {
+    "type": "mtr_raw",
+    "data": {
+      "iteration": 1,
+      "ttl": 2,
+      "success": true,
+      "ip": "2001:db8::2",
+      "host": "router.example",
+      "rtt_ms": 12.5,
+      "lat": 0,
+      "lng": 0,
+      "mpls": [
+        "[MPLS: Lbl 16000, TC 0, S 1, TTL 63]"
+      ],
+      "response": {
+        "kind": "unreachable",
+        "description": "ICMP Host Unreachable",
+        "marker": "!H"
+      }
+    }
+  },
+  {
+    "type": "path_end",
+    "data": {
+      "hop": 2,
+      "reason": "unreachable",
+      "responses": [
+        "ICMP Host Unreachable"
+      ],
+      "markers": [
+        "!H"
+      ]
+    }
+  },
+  {
+    "type": "complete",
+    "data": {
+      "iteration": 1,
+      "path_end": {
+        "hop": 2,
+        "reason": "unreachable",
+        "responses": [
+          "ICMP Host Unreachable"
+        ],
+        "markers": [
+          "!H"
+        ]
+      }
+    }
+  }
+]

--- a/server/ws_json_benchmark_test.go
+++ b/server/ws_json_benchmark_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+var (
+	wsJSONBytesSink   []byte
+	wsJSONRequestSink traceRequest
+)
+
+func BenchmarkWebSocketJSONMarshalEnvelope(b *testing.B) {
+	envelope := wsEnvelope{
+		Type: "mtr_raw",
+		Data: trace.MTRRawRecord{
+			Iteration: 8,
+			TTL:       12,
+			Success:   true,
+			IP:        "2001:db8::12",
+			Host:      "router.example",
+			RTTMs:     12.75,
+			ASN:       "AS64512",
+			Country:   "ZZ",
+			City:      "Example City",
+			Owner:     "Example Network",
+			Lat:       31.25,
+			Lng:       121.5,
+			MPLS:      []string{"[MPLS: Lbl 16000, TC 0, S 1, TTL 63]"},
+			Response: &trace.MTRProbeResponse{
+				Kind:        trace.MTRResponseTransit,
+				Description: "ICMP Time Exceeded",
+			},
+		},
+	}
+	sample, err := json.Marshal(envelope)
+	if err != nil {
+		b.Fatalf("marshal sample envelope: %v", err)
+	}
+	b.SetBytes(int64(len(sample)))
+	b.ReportAllocs()
+
+	for b.Loop() {
+		encoded, err := json.Marshal(envelope)
+		if err != nil {
+			b.Fatalf("marshal websocket envelope: %v", err)
+		}
+		wsJSONBytesSink = encoded
+	}
+}
+
+func BenchmarkWebSocketJSONUnmarshalRequest(b *testing.B) {
+	payload := []byte(`{"target":"example.test","protocol":"udp","port":33494,"queries":3,"max_hops":64,"timeout_ms":2000,"packet_size":84,"tos":32,"parallel_requests":16,"begin_hop":1,"ipv6_only":true,"data_provider":"NextTrace-API","dot_server":"dns.example:853","always_rdns":true,"disable_maptrace":true,"language":"en","source_address":"2001:db8::10","source_device":"en0","packet_interval":50,"ttl_interval":300,"mode":"mtr","hop_interval_ms":1000,"max_rounds":10}`)
+	var sample traceRequest
+	if err := json.Unmarshal(payload, &sample); err != nil {
+		b.Fatalf("unmarshal sample websocket request: %v", err)
+	}
+	if sample.Target != "example.test" {
+		b.Fatalf("sample Target = %q, want example.test", sample.Target)
+	}
+	if sample.PacketSize == nil || *sample.PacketSize != 84 {
+		b.Fatalf("sample PacketSize = %v, want 84", sample.PacketSize)
+	}
+	if sample.TOS == nil || *sample.TOS != 32 {
+		b.Fatalf("sample TOS = %v, want 32", sample.TOS)
+	}
+	if sample.Mode != "mtr" {
+		b.Fatalf("sample Mode = %q, want mtr", sample.Mode)
+	}
+	if sample.HopIntervalMs != 1000 {
+		b.Fatalf("sample HopIntervalMs = %d, want 1000", sample.HopIntervalMs)
+	}
+	if sample.Protocol != "udp" || !sample.IPv6Only || sample.MaxRounds != 10 {
+		b.Fatalf(
+			"sample representative fields = (protocol=%q, ipv6_only=%v, max_rounds=%d), want (udp, true, 10)",
+			sample.Protocol,
+			sample.IPv6Only,
+			sample.MaxRounds,
+		)
+	}
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var request traceRequest
+		if err := json.Unmarshal(payload, &request); err != nil {
+			b.Fatalf("unmarshal websocket request: %v", err)
+		}
+		wsJSONRequestSink = request
+	}
+}

--- a/server/ws_json_golden_test.go
+++ b/server/ws_json_golden_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nxtrace/NTrace-core/internal/service"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestWebSocketEnvelopeGolden(t *testing.T) {
+	pathEnd := &service.TraceStopReason{
+		Hop:       2,
+		Reason:    trace.StopReasonUnreachable,
+		Responses: []string{"ICMP Host Unreachable"},
+		Markers:   []string{"!H"},
+	}
+	envelopes := []wsEnvelope{
+		{
+			Type: "start",
+			Data: gin.H{
+				"target":        "example.test",
+				"resolved_ip":   "2001:db8::9",
+				"protocol":      "UDP",
+				"data_provider": "NextTrace-API",
+				"language":      "en",
+			},
+		},
+		{
+			Type: "mtr_raw",
+			Data: trace.MTRRawRecord{
+				Iteration: 1,
+				TTL:       2,
+				Success:   true,
+				IP:        "2001:db8::2",
+				Host:      "router.example",
+				RTTMs:     12.5,
+				MPLS:      []string{"[MPLS: Lbl 16000, TC 0, S 1, TTL 63]"},
+				Response: &trace.MTRProbeResponse{
+					Kind:        trace.MTRResponseUnreachable,
+					Description: "ICMP Host Unreachable",
+					Marker:      "!H",
+				},
+			},
+		},
+		{Type: "path_end", Data: pathEnd},
+		{Type: "complete", Data: gin.H{"iteration": 1, "path_end": pathEnd}},
+	}
+
+	gotJSON, err := json.Marshal(envelopes)
+	if err != nil {
+		t.Fatalf("marshal websocket envelopes: %v", err)
+	}
+	wantJSON, err := os.ReadFile("testdata/ws_envelopes.golden.json")
+	if err != nil {
+		t.Fatalf("read websocket envelope golden: %v", err)
+	}
+
+	var got any
+	if err := json.Unmarshal(gotJSON, &got); err != nil {
+		t.Fatalf("decode generated websocket envelopes: %v", err)
+	}
+	var want any
+	if err := json.Unmarshal(wantJSON, &want); err != nil {
+		t.Fatalf("decode websocket envelope golden: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		formatted, _ := json.MarshalIndent(got, "", "  ")
+		t.Fatalf("websocket envelope schema changed\n--- got ---\n%s\n--- want ---\n%s", formatted, wantJSON)
+	}
+}

--- a/trace/geo_cache_benchmark_test.go
+++ b/trace/geo_cache_benchmark_test.go
@@ -1,0 +1,63 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+var (
+	benchmarkGeoCacheDataSink  *ipgeo.IPGeoData
+	benchmarkGeoCacheValueSink any
+	benchmarkGeoCacheOKSink    bool
+)
+
+func BenchmarkGeoCacheAccess(b *testing.B) {
+	const (
+		hitKey  = "benchmark-geo-cache-hit"
+		missKey = "benchmark-geo-cache-miss"
+	)
+	geoCache.Store(hitKey, &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335"})
+	geoCache.Delete(missKey)
+	b.Cleanup(func() {
+		geoCache.Delete(hitKey)
+		geoCache.Delete(missKey)
+	})
+
+	b.Run("Hit", func(b *testing.B) {
+		b.ReportAllocs()
+		var (
+			data *ipgeo.IPGeoData
+			ok   bool
+		)
+		for b.Loop() {
+			value, loaded := geoCache.Load(hitKey)
+			if loaded {
+				data, ok = value.(*ipgeo.IPGeoData)
+			} else {
+				data, ok = nil, false
+			}
+		}
+		if !ok || data == nil {
+			b.Fatal("geo cache hit benchmark did not load the seeded value")
+		}
+		benchmarkGeoCacheDataSink = data
+		benchmarkGeoCacheOKSink = ok
+	})
+
+	b.Run("Miss", func(b *testing.B) {
+		b.ReportAllocs()
+		var (
+			value any
+			ok    bool
+		)
+		for b.Loop() {
+			value, ok = geoCache.Load(missKey)
+		}
+		if ok {
+			b.Fatal("geo cache miss benchmark unexpectedly loaded a value")
+		}
+		benchmarkGeoCacheValueSink = value
+		benchmarkGeoCacheOKSink = ok
+	})
+}

--- a/trace/internal/decode_benchmark_test.go
+++ b/trace/internal/decode_benchmark_test.go
@@ -1,0 +1,251 @@
+package internal
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+var (
+	decodeBenchmarkFinishSink   time.Time
+	decodeBenchmarkSrcPortSink  int
+	decodeBenchmarkSeqSink      int
+	decodeBenchmarkAckSink      int
+	decodeBenchmarkDataSink     []byte
+	decodeBenchmarkResponseSink ICMPResponse
+	decodeBenchmarkPeerSink     net.Addr
+	decodeBenchmarkOKSink       bool
+)
+
+func BenchmarkDecodeICMPSocketMessage(b *testing.B) {
+	tests := []struct {
+		name      string
+		ipVersion int
+		dstIP     net.IP
+		peerIP    net.IP
+		echoID    int
+		seq       int
+	}{
+		{
+			name:      "IPv4TimeExceeded",
+			ipVersion: 4,
+			dstIP:     net.ParseIP("192.0.2.9"),
+			peerIP:    net.ParseIP("198.51.100.1"),
+			echoID:    401,
+			seq:       1234,
+		},
+		{
+			name:      "IPv6TimeExceeded",
+			ipVersion: 6,
+			dstIP:     net.ParseIP("2001:db8::9"),
+			peerIP:    net.ParseIP("2001:db8::1"),
+			echoID:    402,
+			seq:       2345,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			inner := benchmarkEmbeddedICMPPacket(tt.ipVersion, tt.dstIP, tt.echoID, tt.seq)
+			raw := benchmarkICMPTimeExceeded(b, tt.ipVersion, inner)
+			spec := &ICMPSpec{IPVersion: tt.ipVersion, EchoID: tt.echoID, DstIP: tt.dstIP}
+			msg := ReceivedMessage{Peer: &net.IPAddr{IP: tt.peerIP}, Msg: raw}
+			if _, seq, response, ok := spec.decodeICMPSocketMessage(msg); !ok || seq != tt.seq || response.Kind != ICMPResponseTransit {
+				b.Fatalf("decodeICMPSocketMessage() = (_, %d, %#v, %v), want (_, %d, Transit, true)", seq, response, ok, tt.seq)
+			}
+			b.SetBytes(int64(len(raw)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				decodeBenchmarkFinishSink, decodeBenchmarkSeqSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = spec.decodeICMPSocketMessage(msg)
+			}
+		})
+	}
+}
+
+func BenchmarkDecodeTCPProbePacket(b *testing.B) {
+	tests := []struct {
+		name      string
+		ipVersion int
+		dstPort   int
+		packet    func(*testing.B) gopacket.Packet
+	}{
+		{
+			name:      "IPv4RSTAck",
+			ipVersion: 4,
+			dstPort:   443,
+			packet: func(b *testing.B) gopacket.Packet {
+				return benchmarkSerializeTCPPacket(b, &layers.IPv4{
+					Version:  4,
+					IHL:      5,
+					Protocol: layers.IPProtocolTCP,
+					SrcIP:    net.ParseIP("198.51.100.1").To4(),
+					DstIP:    net.ParseIP("192.0.2.9").To4(),
+				}, &layers.TCP{SrcPort: 443, DstPort: 32100, ACK: true, RST: true, Ack: 200})
+			},
+		},
+		{
+			name:      "IPv6SYNAck",
+			ipVersion: 6,
+			dstPort:   8443,
+			packet: func(b *testing.B) gopacket.Packet {
+				return benchmarkSerializeTCPPacket(b, &layers.IPv6{
+					Version:    6,
+					NextHeader: layers.IPProtocolTCP,
+					SrcIP:      net.ParseIP("2001:db8::1"),
+					DstIP:      net.ParseIP("2001:db8::9"),
+				}, &layers.TCP{SrcPort: 8443, DstPort: 45678, ACK: true, SYN: true, Ack: 91})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			packet := tt.packet(b)
+			if _, _, _, _, ok := decodeTCPProbePacket(tt.ipVersion, tt.dstPort, packet); !ok {
+				b.Fatal("decodeTCPProbePacket() ok = false")
+			}
+			b.ReportAllocs()
+
+			for b.Loop() {
+				decodeBenchmarkSrcPortSink, decodeBenchmarkSeqSink, decodeBenchmarkAckSink, decodeBenchmarkPeerSink, decodeBenchmarkOKSink = decodeTCPProbePacket(tt.ipVersion, tt.dstPort, packet)
+			}
+		})
+	}
+}
+
+func BenchmarkDecodeUDPSocketMessage(b *testing.B) {
+	tests := []struct {
+		name      string
+		ipVersion int
+		dstIP     net.IP
+		peerIP    net.IP
+		srcPort   int
+		dstPort   int
+	}{
+		{
+			name:      "IPv4TimeExceeded",
+			ipVersion: 4,
+			dstIP:     net.ParseIP("192.0.2.9"),
+			peerIP:    net.ParseIP("198.51.100.1"),
+			srcPort:   40000,
+			dstPort:   33494,
+		},
+		{
+			name:      "IPv6TimeExceeded",
+			ipVersion: 6,
+			dstIP:     net.ParseIP("2001:db8::9"),
+			peerIP:    net.ParseIP("2001:db8::1"),
+			srcPort:   40001,
+			dstPort:   33494,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			inner := benchmarkEmbeddedUDPPacket(tt.ipVersion, tt.dstIP, tt.srcPort, tt.dstPort)
+			raw := benchmarkICMPTimeExceeded(b, tt.ipVersion, inner)
+			spec := &UDPSpec{IPVersion: tt.ipVersion, DstIP: tt.dstIP, DstPort: tt.dstPort}
+			msg := ReceivedMessage{Peer: &net.IPAddr{IP: tt.peerIP}, Msg: raw}
+			if _, data, response, ok := spec.decodeICMPSocketMessage(msg); !ok || len(data) != len(inner) || response.Kind != ICMPResponseTransit {
+				b.Fatalf("decodeICMPSocketMessage() = (_, %d bytes, %#v, %v), want (_, %d bytes, Transit, true)", len(data), response, ok, len(inner))
+			}
+			b.SetBytes(int64(len(raw)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				decodeBenchmarkFinishSink, decodeBenchmarkDataSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = spec.decodeICMPSocketMessage(msg)
+			}
+		})
+	}
+}
+
+func benchmarkICMPTimeExceeded(b *testing.B, ipVersion int, inner []byte) []byte {
+	b.Helper()
+
+	var messageType icmp.Type = ipv4.ICMPTypeTimeExceeded
+	if ipVersion == 6 {
+		messageType = ipv6.ICMPTypeTimeExceeded
+	}
+	raw, err := (&icmp.Message{
+		Type: messageType,
+		Code: 0,
+		Body: &icmp.TimeExceeded{Data: inner},
+	}).Marshal(nil)
+	if err != nil {
+		b.Fatalf("marshal ICMP time-exceeded message: %v", err)
+	}
+	return raw
+}
+
+func benchmarkEmbeddedICMPPacket(ipVersion int, dstIP net.IP, echoID, seq int) []byte {
+	if ipVersion == 4 {
+		packet := make([]byte, 28)
+		packet[0] = 0x45
+		packet[9] = 1
+		copy(packet[16:20], dstIP.To4())
+		binary.BigEndian.PutUint16(packet[24:26], uint16(echoID))
+		binary.BigEndian.PutUint16(packet[26:28], uint16(seq))
+		return packet
+	}
+
+	packet := make([]byte, 48)
+	packet[0] = 0x60
+	packet[6] = 58
+	copy(packet[24:40], dstIP.To16())
+	binary.BigEndian.PutUint16(packet[44:46], uint16(echoID))
+	binary.BigEndian.PutUint16(packet[46:48], uint16(seq))
+	return packet
+}
+
+func benchmarkEmbeddedUDPPacket(ipVersion int, dstIP net.IP, srcPort, dstPort int) []byte {
+	if ipVersion == 4 {
+		packet := make([]byte, 28)
+		packet[0] = 0x45
+		packet[9] = 17
+		copy(packet[16:20], dstIP.To4())
+		binary.BigEndian.PutUint16(packet[20:22], uint16(srcPort))
+		binary.BigEndian.PutUint16(packet[22:24], uint16(dstPort))
+		return packet
+	}
+
+	packet := make([]byte, 48)
+	packet[0] = 0x60
+	packet[6] = 17
+	copy(packet[24:40], dstIP.To16())
+	binary.BigEndian.PutUint16(packet[40:42], uint16(srcPort))
+	binary.BigEndian.PutUint16(packet[42:44], uint16(dstPort))
+	return packet
+}
+
+func benchmarkSerializeTCPPacket(b *testing.B, ipLayer gopacket.NetworkLayer, tcp *layers.TCP) gopacket.Packet {
+	b.Helper()
+
+	if err := tcp.SetNetworkLayerForChecksum(ipLayer); err != nil {
+		b.Fatalf("set TCP network layer: %v", err)
+	}
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	switch ip := ipLayer.(type) {
+	case *layers.IPv4:
+		if err := gopacket.SerializeLayers(buf, opts, ip, tcp); err != nil {
+			b.Fatalf("serialize IPv4 TCP packet: %v", err)
+		}
+		return gopacket.NewPacket(buf.Bytes(), layers.LayerTypeIPv4, gopacket.NoCopy)
+	case *layers.IPv6:
+		if err := gopacket.SerializeLayers(buf, opts, ip, tcp); err != nil {
+			b.Fatalf("serialize IPv6 TCP packet: %v", err)
+		}
+		return gopacket.NewPacket(buf.Bytes(), layers.LayerTypeIPv6, gopacket.NoCopy)
+	default:
+		b.Fatalf("unexpected IP layer type %T", ipLayer)
+		return nil
+	}
+}

--- a/trace/mtr_stats_benchmark_test.go
+++ b/trace/mtr_stats_benchmark_test.go
@@ -1,0 +1,96 @@
+package trace
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+const (
+	mtrBenchmarkTTLCount  = 64
+	mtrBenchmarkPathCount = 4
+)
+
+var (
+	mtrBenchmarkStatsSink []MTRHopStat
+	mtrBenchmarkCloneSink *MTRAggregator
+)
+
+func newMTRBenchmarkResult() *Result {
+	res := &Result{Hops: make([][]Hop, mtrBenchmarkTTLCount)}
+	for ttl := 1; ttl <= mtrBenchmarkTTLCount; ttl++ {
+		attempts := make([]Hop, 0, mtrBenchmarkPathCount)
+		for path := 1; path <= mtrBenchmarkPathCount; path++ {
+			attempts = append(attempts, Hop{
+				Success:  true,
+				Address:  &net.IPAddr{IP: net.IPv4(198, 18, byte(ttl), byte(path))},
+				Hostname: fmt.Sprintf("hop-%02d-path-%d.example", ttl, path),
+				TTL:      ttl,
+				RTT:      time.Duration(ttl*path) * time.Millisecond,
+				MPLS: []string{
+					fmt.Sprintf("[MPLS: Lbl %d, TC 0, S 0, TTL %d]", ttl*100+path, ttl),
+					fmt.Sprintf("[MPLS: Lbl %d, TC 1, S 1, TTL %d]", ttl*1000+path, ttl),
+				},
+			})
+		}
+		res.Hops[ttl-1] = attempts
+	}
+	return res
+}
+
+func newMTRBenchmarkPartialResult(ttl int) *Result {
+	full := newMTRBenchmarkResult()
+	partial := &Result{Hops: make([][]Hop, len(full.Hops))}
+	partial.Hops[ttl-1] = full.Hops[ttl-1]
+	return partial
+}
+
+func newPopulatedMTRBenchmarkAggregator(res *Result) *MTRAggregator {
+	agg := NewMTRAggregator()
+	agg.Update(res, mtrBenchmarkPathCount)
+	return agg
+}
+
+func BenchmarkMTRAggregatorUpdate64TTL4Paths(b *testing.B) {
+	res := newMTRBenchmarkResult()
+	agg := newPopulatedMTRBenchmarkAggregator(res)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		mtrBenchmarkStatsSink = agg.Update(res, mtrBenchmarkPathCount)
+	}
+}
+
+func BenchmarkMTRAggregatorClone64TTL4Paths(b *testing.B) {
+	res := newMTRBenchmarkResult()
+	agg := newPopulatedMTRBenchmarkAggregator(res)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		mtrBenchmarkCloneSink = agg.Clone()
+	}
+}
+
+func BenchmarkMTRAggregatorSnapshot64TTL4Paths(b *testing.B) {
+	res := newMTRBenchmarkResult()
+	agg := newPopulatedMTRBenchmarkAggregator(res)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		mtrBenchmarkStatsSink = agg.Snapshot()
+	}
+}
+
+func BenchmarkMTRAggregatorPreviewCloneUpdate64TTL4Paths(b *testing.B) {
+	res := newMTRBenchmarkResult()
+	agg := newPopulatedMTRBenchmarkAggregator(res)
+	partial := newMTRBenchmarkPartialResult(mtrBenchmarkTTLCount / 2)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		preview := agg.Clone()
+		mtrBenchmarkStatsSink = preview.Update(partial, mtrBenchmarkPathCount)
+	}
+	b.ReportMetric(1, "affected-TTLs/op")
+}

--- a/trace/mtr_stats_golden_test.go
+++ b/trace/mtr_stats_golden_test.go
@@ -1,0 +1,70 @@
+package trace
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestMTRAggregatorSnapshotGolden(t *testing.T) {
+	agg := NewMTRAggregator()
+
+	agg.Update(mtrGoldenResult(1,
+		Hop{
+			Success:  true,
+			Address:  &net.IPAddr{IP: net.ParseIP("192.0.2.1")},
+			Hostname: "edge.example",
+			TTL:      1,
+			RTT:      10 * time.Millisecond,
+			MPLS: []string{
+				"[MPLS: Lbl 200, TC 0, S 1, TTL 63]",
+				"[MPLS: Lbl 100, TC 0, S 0, TTL 64]",
+			},
+		},
+		Hop{TTL: 1},
+	), 2)
+	agg.Update(mtrGoldenResult(2, Hop{
+		Success:  true,
+		Address:  &net.IPAddr{IP: net.ParseIP("198.51.100.1")},
+		Hostname: "core-a.example",
+		TTL:      2,
+		RTT:      20 * time.Millisecond,
+	}), 1)
+	agg.Update(mtrGoldenResult(2, Hop{
+		Success:  true,
+		Address:  &net.IPAddr{IP: net.ParseIP("198.51.100.2")},
+		Hostname: "core-b.example",
+		TTL:      2,
+		RTT:      30 * time.Millisecond,
+	}), 1)
+	agg.Update(mtrGoldenResult(2, Hop{TTL: 2}), 1)
+	agg.Update(mtrGoldenResult(3, Hop{
+		Success: true,
+		Address: &net.IPAddr{IP: net.ParseIP("2001:db8::3")},
+		TTL:     3,
+		RTT:     40 * time.Millisecond,
+	}), 1)
+
+	got, err := json.MarshalIndent(MTRSnapshot{Iteration: 3, Stats: agg.Snapshot()}, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal MTR snapshot: %v", err)
+	}
+	got = append(got, '\n')
+
+	want, err := os.ReadFile("testdata/mtr_snapshot.golden.json")
+	if err != nil {
+		t.Fatalf("read MTR snapshot golden: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("MTR snapshot changed\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func mtrGoldenResult(ttl int, attempts ...Hop) *Result {
+	res := &Result{Hops: make([][]Hop, ttl)}
+	res.Hops[ttl-1] = attempts
+	return res
+}

--- a/trace/mtu/decode_benchmark_test.go
+++ b/trace/mtu/decode_benchmark_test.go
@@ -1,0 +1,61 @@
+package mtu
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+var (
+	embeddedUDPBenchmarkPacketSink embeddedUDPPacket
+	embeddedUDPBenchmarkOKSink     bool
+)
+
+func BenchmarkParseEmbeddedUDPPacket(b *testing.B) {
+	tests := []struct {
+		name      string
+		ipVersion int
+		packet    []byte
+	}{
+		{name: "IPv4", ipVersion: 4, packet: benchmarkEmbeddedIPv4UDP()},
+		{name: "IPv6ExtensionHeader", ipVersion: 6, packet: benchmarkEmbeddedIPv6UDP()},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			if _, ok := parseEmbeddedUDPPacket(tt.packet, tt.ipVersion); !ok {
+				b.Fatal("parseEmbeddedUDPPacket() ok = false")
+			}
+			b.SetBytes(int64(len(tt.packet)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				embeddedUDPBenchmarkPacketSink, embeddedUDPBenchmarkOKSink = parseEmbeddedUDPPacket(tt.packet, tt.ipVersion)
+			}
+		})
+	}
+}
+
+func benchmarkEmbeddedIPv4UDP() []byte {
+	dstIP := net.ParseIP("203.0.113.9").To4()
+	packet := make([]byte, 28)
+	packet[0] = 0x45
+	packet[9] = 17
+	copy(packet[16:20], dstIP)
+	binary.BigEndian.PutUint16(packet[20:22], 40000)
+	binary.BigEndian.PutUint16(packet[22:24], 33494)
+	return packet
+}
+
+func benchmarkEmbeddedIPv6UDP() []byte {
+	dstIP := net.ParseIP("2001:db8::9").To16()
+	packet := make([]byte, 56)
+	packet[0] = 0x60
+	packet[6] = 0
+	copy(packet[24:40], dstIP)
+	packet[40] = 17
+	packet[41] = 0
+	binary.BigEndian.PutUint16(packet[48:50], 40001)
+	binary.BigEndian.PutUint16(packet[50:52], 33494)
+	return packet
+}

--- a/trace/testdata/mtr_snapshot.golden.json
+++ b/trace/testdata/mtr_snapshot.golden.json
@@ -1,0 +1,71 @@
+{
+  "iteration": 3,
+  "stats": [
+    {
+      "ttl": 1,
+      "host": "edge.example",
+      "ip": "192.0.2.1",
+      "loss_percent": 50,
+      "snt": 2,
+      "last_ms": 10,
+      "avg_ms": 10,
+      "best_ms": 10,
+      "wrst_ms": 10,
+      "stdev_ms": 0,
+      "mpls": [
+        "[MPLS: Lbl 100, TC 0, S 0, TTL 64]",
+        "[MPLS: Lbl 200, TC 0, S 1, TTL 63]"
+      ],
+      "received": 1
+    },
+    {
+      "ttl": 2,
+      "host": "core-a.example",
+      "ip": "198.51.100.1",
+      "loss_percent": 0,
+      "snt": 1,
+      "last_ms": 20,
+      "avg_ms": 20,
+      "best_ms": 20,
+      "wrst_ms": 20,
+      "stdev_ms": 0,
+      "received": 1
+    },
+    {
+      "ttl": 2,
+      "host": "core-b.example",
+      "ip": "198.51.100.2",
+      "loss_percent": 0,
+      "snt": 1,
+      "last_ms": 30,
+      "avg_ms": 30,
+      "best_ms": 30,
+      "wrst_ms": 30,
+      "stdev_ms": 0,
+      "received": 1
+    },
+    {
+      "ttl": 2,
+      "loss_percent": 100,
+      "snt": 1,
+      "last_ms": 0,
+      "avg_ms": 0,
+      "best_ms": 0,
+      "wrst_ms": 0,
+      "stdev_ms": 0,
+      "received": 0
+    },
+    {
+      "ttl": 3,
+      "ip": "2001:db8::3",
+      "loss_percent": 0,
+      "snt": 1,
+      "last_ms": 40,
+      "avg_ms": 40,
+      "best_ms": 40,
+      "wrst_ms": 40,
+      "stdev_ms": 0,
+      "received": 1
+    }
+  ]
+}

--- a/util/http_client_geo_benchmark_test.go
+++ b/util/http_client_geo_benchmark_test.go
@@ -1,0 +1,180 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	benchmarkGeoHTTPConcurrency = http.DefaultMaxIdleConnsPerHost
+	benchmarkGeoHTTPClientCount = 4
+)
+
+var (
+	benchmarkGeoHTTPBytesSink  int64
+	benchmarkGeoHTTPClientSink *http.Client
+)
+
+func BenchmarkNewGeoHTTPClient(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "geo")
+	}))
+	b.Cleanup(server.Close)
+
+	b.Run("Construct", func(b *testing.B) {
+		b.ReportAllocs()
+		var client *http.Client
+		for b.Loop() {
+			client = NewGeoHTTPClient(5 * time.Second)
+		}
+		b.ReportMetric(1, "clients/op")
+		benchmarkGeoHTTPClientSink = client
+	})
+
+	b.Run("Sequential", func(b *testing.B) {
+		client := NewGeoHTTPClient(5 * time.Second)
+		b.Cleanup(client.CloseIdleConnections)
+
+		b.ReportAllocs()
+		var total int64
+		for b.Loop() {
+			n, err := runGeoHTTPBenchmarkRequest(client, server.URL)
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += n
+		}
+		benchmarkGeoHTTPBytesSink = total
+	})
+
+	b.Run("Concurrent2", func(b *testing.B) {
+		client := NewGeoHTTPClient(5 * time.Second)
+		b.Cleanup(client.CloseIdleConnections)
+		results := make([]int64, benchmarkGeoHTTPConcurrency)
+		errs := make([]error, benchmarkGeoHTTPConcurrency)
+
+		b.ReportAllocs()
+		var total int64
+		for b.Loop() {
+			var wg sync.WaitGroup
+			wg.Add(benchmarkGeoHTTPConcurrency)
+			for i := 0; i < benchmarkGeoHTTPConcurrency; i++ {
+				go func(index int) {
+					defer wg.Done()
+					results[index], errs[index] = runGeoHTTPBenchmarkRequest(client, server.URL)
+				}(i)
+			}
+			wg.Wait()
+			for i, err := range errs {
+				if err != nil {
+					b.Fatalf("request %d: %v", i, err)
+				}
+				total += results[i]
+			}
+		}
+		b.ReportMetric(benchmarkGeoHTTPConcurrency, "requests/op")
+		benchmarkGeoHTTPBytesSink = total
+	})
+
+	b.Run("MultiClientSequential", func(b *testing.B) {
+		clients := newGeoHTTPBenchmarkClients(benchmarkGeoHTTPClientCount)
+		b.Cleanup(func() { closeGeoHTTPBenchmarkClients(clients) })
+		warmGeoHTTPBenchmarkClients(b, clients, server.URL)
+
+		b.ReportAllocs()
+		var total int64
+		clientIndex := 0
+		for b.Loop() {
+			n, err := runGeoHTTPBenchmarkRequest(clients[clientIndex], server.URL)
+			if err != nil {
+				b.Fatalf("client %d: %v", clientIndex, err)
+			}
+			total += n
+			clientIndex++
+			if clientIndex == len(clients) {
+				clientIndex = 0
+			}
+		}
+		b.ReportMetric(benchmarkGeoHTTPClientCount, "clients/set")
+		b.ReportMetric(1, "requests/op")
+		benchmarkGeoHTTPBytesSink = total
+	})
+
+	b.Run("MultiClientConcurrent", func(b *testing.B) {
+		clients := newGeoHTTPBenchmarkClients(benchmarkGeoHTTPClientCount)
+		b.Cleanup(func() { closeGeoHTTPBenchmarkClients(clients) })
+		warmGeoHTTPBenchmarkClients(b, clients, server.URL)
+		results := make([]int64, benchmarkGeoHTTPClientCount)
+		errs := make([]error, benchmarkGeoHTTPClientCount)
+
+		b.ReportAllocs()
+		var total int64
+		for b.Loop() {
+			var wg sync.WaitGroup
+			wg.Add(benchmarkGeoHTTPClientCount)
+			for i, client := range clients {
+				go func(index int, requestClient *http.Client) {
+					defer wg.Done()
+					results[index], errs[index] = runGeoHTTPBenchmarkRequest(requestClient, server.URL)
+				}(i, client)
+			}
+			wg.Wait()
+			for i, err := range errs {
+				if err != nil {
+					b.Fatalf("client %d: %v", i, err)
+				}
+				total += results[i]
+			}
+		}
+		b.ReportMetric(benchmarkGeoHTTPClientCount, "clients/set")
+		b.ReportMetric(benchmarkGeoHTTPClientCount, "requests/op")
+		benchmarkGeoHTTPBytesSink = total
+	})
+}
+
+func newGeoHTTPBenchmarkClients(count int) []*http.Client {
+	clients := make([]*http.Client, count)
+	for i := range clients {
+		clients[i] = NewGeoHTTPClient(5 * time.Second)
+	}
+	return clients
+}
+
+func closeGeoHTTPBenchmarkClients(clients []*http.Client) {
+	for _, client := range clients {
+		client.CloseIdleConnections()
+	}
+}
+
+func warmGeoHTTPBenchmarkClients(b *testing.B, clients []*http.Client, url string) {
+	b.Helper()
+	for i, client := range clients {
+		if _, err := runGeoHTTPBenchmarkRequest(client, url); err != nil {
+			b.Fatalf("warm client %d: %v", i, err)
+		}
+	}
+}
+
+func runGeoHTTPBenchmarkRequest(client *http.Client, url string) (int64, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	n, readErr := io.Copy(io.Discard, resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return 0, readErr
+	}
+	if closeErr != nil {
+		return 0, closeErr
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+	}
+	return n, nil
+}

--- a/util/http_client_geo_benchmark_test.go
+++ b/util/http_client_geo_benchmark_test.go
@@ -52,7 +52,7 @@ func BenchmarkNewGeoHTTPClient(b *testing.B) {
 		benchmarkGeoHTTPBytesSink = total
 	})
 
-	b.Run("Concurrent2", func(b *testing.B) {
+	b.Run(fmt.Sprintf("Concurrent%d", benchmarkGeoHTTPConcurrency), func(b *testing.B) {
 		client := NewGeoHTTPClient(5 * time.Second)
 		b.Cleanup(client.CloseIdleConnections)
 		results := make([]int64, benchmarkGeoHTTPConcurrency)

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -18,7 +18,12 @@ import (
 )
 
 func newStartedTestWsConn() *WsConn {
+	return newStartedTestWsConnWithContext(context.Background())
+}
+
+func newStartedTestWsConnWithContext(ctx context.Context) *WsConn {
 	c := newWsConn(nil, make(chan os.Signal, 1))
+	c.baseCtx = ctx
 	c.setDoneChan(make(chan struct{}))
 	c.setConnectionState(false, false)
 	c.startLoop(c.keepAlive)
@@ -140,8 +145,7 @@ func TestReplaceGlobalWsConnDoesNotRewriteBaseContext(t *testing.T) {
 	replacementCtx, replacementCancel := context.WithCancel(context.Background())
 	defer replacementCancel()
 
-	newConn := newStartedTestWsConn()
-	newConn.baseCtx = originalCtx
+	newConn := newStartedTestWsConnWithContext(originalCtx)
 
 	got := replaceGlobalWsConn(newConn, replacementCtx)
 	defer got.Close()


### PR DESCRIPTION
## Summary

- 将模块、CI、发布流程和构建矩阵统一升级到 Go 1.27.1。
- 将 Darwin 最低版本统一提高到 macOS 13.0，并在 CI 校验三种 flavor 的 `LC_BUILD_VERSION`。
- 建立 GeoFeed、Geo HTTP、Geo cache、MTR、WebSocket JSON、nali 与协议 decoder 的可复现 benchmark、golden、profile 和产物大小证据链。
- 正式发布暂用 `GOEXPERIMENT=nojsonv2`，默认 JSON 与 `nojsonv2` 两条测试 lane 同时保留。

## Motivation

原基线使用 Go 1.26.5，缺少能跨工具链复用的统一性能基准、关键输出 golden 和 exact-head 性能 artifact。Go 1.27 的 Darwin 最低要求同时需要明确提高到 macOS 13.0。本 PR 先锁定工具链、兼容性边界和测量方法，为后续运行时优化提供可复核基线。

## Before / After Call Chain

### Before

`setup-go 1.26.5` → 各 workflow 分散测试/构建 → 发布构建未固定 JSON runtime → Darwin deployment target 11.0 → 无统一 benchmark/profile/size artifact

### After

`setup-go 1.27.1` + exact `GOTOOLCHAIN` → default JSON 与 `nojsonv2` 门禁 → 发布固定 `nojsonv2` → Darwin CGO/linker target 13.0 → `vtool`/`otool` 校验 `minos 13.0`

`scripts/perf/run_benchmarks.sh` → 原始 benchmark → `go tool benchstat` → 30 秒 CPU/heap profile + 三 flavor stripped/UPX size → CI artifact + 可读基线报告

## Changes

- `go.mod` 设为 `go 1.27.1`，使用 `tool` directive 固定 `benchstat`。
- 所有 `setup-go`、`GOTOOLCHAIN`、测试、回归、lint 和发布路径使用精确 Go 1.27.1。
- PR 测试以 runner 用户执行，不向未受信任的测试代码授予 root 权限；golangci-lint v2.13.2 由 Go 1.27.1 源码构建。
- 发布 workflow 与 `.cross_compile.sh` 使用 `nojsonv2`；普通源码和 CI 同时覆盖默认 JSON 后端。
- Darwin CGO target 和 Go linker target 均设为 13.0，三 flavor 均检查 Mach-O 最低版本。
- 新增统一性能 workflow、benchmark 脚本、profile 脚本、大小脚本及关键 JSON golden。
- 性能 workflow 禁止凭据持久化和共享 Go cache，并校验、隔离两侧 exact SHA checkout。
- 修正一个仅测试夹具中的初始化竞态：在启动 WebSocket worker 前注入 `baseCtx`。
- 新增 `docs/performance/go127-baseline.md`，记录本机 benchmark、profile、大小和 JSON runtime 预检。

## Compatibility

- 有意停止支持 macOS 12 及以下版本；新的最低版本为 macOS 13.0。
- Go module 构建最低工具链为 Go 1.27.1。
- 未改变现有 CLI flag、退出码、stdout/stderr、导出 API、JSON schema、MTR 统计或协议包布局。
- `golang.org/x/perf` 作为 root tool 进入同一模块图，MVS 因而连带更新 `x/oauth2`、`x/exp` 并加入 `go-moremath`；生产使用到的 `x/exp/constraints` 接口未改变。

## Testing

- `go test -count=1 ./...`：Go 1.27.1 default JSON 通过。
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`：通过。
- `go test -race -count=1 ./...`：通过。
- full、tiny、ntr 的 default/nojsonv2 专项测试与构建：通过。
- Linux amd64、Windows amd64、Darwin arm64 现有交叉构建：通过。
- `go build ./...`、`go vet ./...`、`go mod verify`、`go mod tidy -diff`：通过。
- `node --test server/web/assets/*.test.cjs`：15/15 通过。
- `.cross_compile.sh` 与 `scripts/perf/*.sh` 逐文件 `bash -n`：通过。
- `golangci-lint run --new-from-rev=origin/main`：0 issues。
- Darwin full/tiny/ntr：`LC_BUILD_VERSION minos 13.0`。

## Race

- 完整 race suite 通过。
- Go 1.26.8 旧侧复现了 `TestReplaceGlobalWsConnDoesNotRewriteBaseContext` 的测试夹具竞态；修复仅把 `baseCtx` 初始化移到 worker 启动前。Go 1.27.1 下 targeted race 连续 10 次和完整 race suite 均通过。

## Benchstat

测量环境：Apple M5、macOS 26.6.2、AC 供电、`GOMAXPROCS=10`。旧侧为 `2cab379` + Go 1.26.8，新侧为 `b771e8d` + Go 1.27.1，两侧均用 `nojsonv2`。完整集合各 10 次；超过关注门槛的热点反向再跑 10 次并以 20 个样本判定。

- GeoFeed parse `-3.44%`；MTR Update/Clone/preview 无显著变化，Snapshot `-1.75%`。
- ICMPv4 decoder `-8.87%`；MTU embedded UDP IPv4/IPv6 分别 `-3.09%` / `-9.72%`。
- WebSocket marshal `+13.05%`，Geo cache hit/miss `+11.01%` / `+20.02%`。
- Geo HTTP construct `+18.69%` 且增加 1 alloc / 160 B；顺序与并发 loopback 请求 `+7.85%` 至 `+13.04%`。
- UDPv4 decoder `+15.85%`，样本离散度约 ±14%，保留为后续跨平台复核项。

本 PR 不混入运行时算法修改；回退项分别作为后续 Geo transport、bounded cache、MTR aggregator 和 JSON 决策 PR 的基线。

### Go 1.27.1 JSON 预检

- 默认后端相对 `nojsonv2`：WebSocket marshal `+47.66%`，896 B / 5 allocs；unmarshal `-50.41%`，368 B / 3 allocs。
- 两种后端的现有 golden 均一致。编码与解码方向相反，发布继续使用 `nojsonv2`，最终决策留给完整 JSON ADR PR。

## Profile

- 30 秒 `BenchmarkMTRAggregatorSnapshot64TTL4Paths` profile 两侧的单次分配均为 106,544 B / 458 allocs；独立 10 轮 benchstat 为 27.75 µs → 27.26 µs（-1.75%）。
- heap profile 中 `snapshotLocked` 占约 90%，`buildMTRHopStat` 占约 7.7%。
- CPU profile 中两者累计占比约 27%–28% 与 14%–15%，作为后续 MTR 优化靶点。

## Binary Size

- Darwin arm64 未压缩：nexttrace `-2.48%`，tiny/ntr `-2.52%`。
- Linux arm64 未压缩：nexttrace `-2.59%`，tiny/ntr `-2.37%`。
- Linux arm64 UPX 5.2.1 `-9`：nexttrace `-1.65%`，tiny/ntr `-1.35%`。

## Platform Risks

- macOS 12 及以下产物将不再启动，这是已批准的兼容性变更。
- 本机 Apple M5 数据是当前性能判断基线；GitHub Linux 性能 artifact 只作跨平台参考。
- 默认 JSON runtime 仍处于兼容验证阶段，正式发布在完整 JSON 决策前保持 `nojsonv2`。

## Rollback

- 回退工具链时按提交逆序还原 Go/CI/发布与 Darwin target；benchmark、golden 和性能脚本可独立保留。
- 若发布侧出现 JSON 行为差异，继续固定 `GOEXPERIMENT=nojsonv2`，无需改动运行时代码。
- 该回退说明仅用于故障处置，不改变已锁定的 Go 1.27.1 / macOS 13 交付目标。

## Commits

- `2cab379` `test(bench): 建立 geo mtr websocket 性能与输出基线`
- `9ccd7d5` `test(wshandle): 在启动 worker 前注入基础上下文`
- `b771e8d` `build(go): 升级 Go 1.27.1 并提高 Darwin 最低版本`
- `73f9365` `docs(perf): 记录 Go 1.27.1 性能与产物基线`
- `5cb27f7` `ci(lint): 使用 Go 1.27.1 源码构建 golangci-lint`
- `82ba2ad` `ci(lint): 升级支持 Go 1.27 的 golangci-lint`
- `1b2348b` `ci(test): 使用 setup-go 绝对路径运行提权测试`
- `a28d3ad` `ci(perf): 隔离基准 checkout 与缓存`
- `a6d5c47` `docs(perf): 澄清性能基线证据范围`
- `c4b4f30` `test(bench): 让 Geo HTTP 并发名称跟随配置`
- `74d9bf3` `ci(test): 避免以 root 运行 PR 测试`
- `66098f6` `ci(test): 逐一校验性能脚本语法`
- `2e13e69` `ci(perf): 明确基线运行时并合并输出写入`

## Notes for Reviewers

- Exact-head Linux cross-reference 已通过并保存 [performance artifact](https://github.com/nxtrace/NTrace-dev/actions/runs/33845542295)；其中包含两侧 10 次 benchmark、CPU/heap profile、测试耗时及三 flavor 二进制和校验值。
- 仓库全量 lint 当前仍有 79 个既有问题；本 PR 增量 lint 为 0，未在工具链 PR 中扩大范围清理。
- `build.yml` 中未声明的 `matrix.allow_fail` 是既有 actionlint 告警，本 PR 未修改该无关行为。
- 性能原始文件、profile 和二进制由 performance workflow 上传为 artifact，不提交到 Git。
