### PR TITLE
refactor(runtime): 采用 Go 1.27 安全运行时接口

### DIFF
--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -413,7 +412,7 @@ func TestAttachMTRHistoryIfTTY(t *testing.T) {
 		t.Fatalf("history did not collect TTY probe event: %+v", snap)
 	}
 
-	atomic.StoreInt32(&ttyUI.restartReq, 1)
+	ttyUI.restartReq.Store(true)
 	if ttyOpts.IsResetRequested == nil || !ttyOpts.IsResetRequested() {
 		t.Fatal("wrapped reset callback should consume reset request")
 	}
@@ -628,7 +627,7 @@ func TestMTRUI_ConsumeRestartRequest(t *testing.T) {
 	}
 
 	// 模拟按下 r 键
-	atomic.StoreInt32(&ui.restartReq, 1)
+	ui.restartReq.Store(true)
 
 	// 第一次消费应返回 true
 	if !ui.ConsumeRestartRequest() {
@@ -694,7 +693,7 @@ func TestMTRUI_DisplayModeNotResetByRestart(t *testing.T) {
 	ui.CycleDisplayMode() // 1 → 2
 
 	// 模拟重置请求
-	atomic.StoreInt32(&ui.restartReq, 1)
+	ui.restartReq.Store(true)
 	ui.ConsumeRestartRequest()
 
 	// 显示模式不应被重置
@@ -841,7 +840,7 @@ func TestMTRUI_NameModeNotResetByRestart(t *testing.T) {
 	}
 
 	// 模拟重置请求
-	atomic.StoreInt32(&ui.restartReq, 1)
+	ui.restartReq.Store(true)
 	ui.ConsumeRestartRequest()
 
 	// nameMode 不应被重置

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -18,13 +18,13 @@ import (
 type mtrUI struct {
 	isTTY       bool
 	oldState    *term.State // raw mode 之前的终端状态
-	paused      int32       // 0=running, 1=paused（atomic）
-	restartReq  int32       // 1=请求重置统计（atomic）
-	displayMode int32       // 显示模式 0-4（atomic）
-	nameMode    int32       // Host 基础显示 0=PTR/IP, 1=IP only（atomic）
-	disableMPLS int32       // 0=显示 MPLS, 1=隐藏 MPLS（atomic）
-	historyMode int32       // 0=classic, 1=history（atomic）
-	chartMode   int32       // history chart mode 0-2（atomic）
+	paused      atomic.Bool
+	restartReq  atomic.Bool
+	displayMode atomic.Int32 // 显示模式 0-4
+	nameMode    atomic.Int32 // Host 基础显示 0=PTR/IP, 1=IP only
+	disableMPLS atomic.Bool
+	historyMode atomic.Bool
+	chartMode   atomic.Int32 // history chart mode 0-2
 	cancel      context.CancelFunc
 }
 
@@ -32,11 +32,12 @@ type mtrUI struct {
 // initialDisplayMode 设置 TUI 初始显示模式 (0-4)。
 // stdin 和 stdout 都必须是终端才会启用交互式 TUI。
 func newMTRUI(cancel context.CancelFunc, initialDisplayMode int) *mtrUI {
-	return &mtrUI{
-		isTTY:       term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())),
-		cancel:      cancel,
-		displayMode: int32(initialDisplayMode),
+	ui := &mtrUI{
+		isTTY:  term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())),
+		cancel: cancel,
 	}
+	ui.displayMode.Store(int32(initialDisplayMode))
+	return ui
 }
 
 // IsTTY 返回 stdin 和 stdout 是否都是终端。
@@ -56,15 +57,15 @@ func CheckTTY(fds ...int) bool {
 
 // IsPaused 返回当前是否处于暂停状态（供 MTROptions.IsPaused 使用）。
 func (u *mtrUI) IsPaused() bool {
-	return atomic.LoadInt32(&u.paused) == 1
+	return u.paused.Load()
 }
 
 // CycleDisplayMode 循环切换显示模式 (0 → 1 → 2 → 3 → 4 → 0)。
 func (u *mtrUI) CycleDisplayMode() {
 	for {
-		old := atomic.LoadInt32(&u.displayMode)
+		old := u.displayMode.Load()
 		next := (old + 1) % 5
-		if atomic.CompareAndSwapInt32(&u.displayMode, old, next) {
+		if u.displayMode.CompareAndSwap(old, next) {
 			return
 		}
 	}
@@ -72,15 +73,14 @@ func (u *mtrUI) CycleDisplayMode() {
 
 // CurrentDisplayMode 返回当前显示模式 (0-4)。
 func (u *mtrUI) CurrentDisplayMode() int {
-	return int(atomic.LoadInt32(&u.displayMode))
+	return int(u.displayMode.Load())
 }
 
 // ToggleHistoryMode 在 classic 和 history TUI 之间切换。
 func (u *mtrUI) ToggleHistoryMode() {
 	for {
-		old := atomic.LoadInt32(&u.historyMode)
-		next := int32(1) - old
-		if atomic.CompareAndSwapInt32(&u.historyMode, old, next) {
+		old := u.historyMode.Load()
+		if u.historyMode.CompareAndSwap(old, !old) {
 			return
 		}
 	}
@@ -88,7 +88,7 @@ func (u *mtrUI) ToggleHistoryMode() {
 
 // IsHistoryMode 返回当前是否显示 history TUI。
 func (u *mtrUI) IsHistoryMode() bool {
-	return atomic.LoadInt32(&u.historyMode) != 0
+	return u.historyMode.Load()
 }
 
 // CycleHistoryChartMode 仅在 history TUI 下循环切换图表模式。
@@ -97,9 +97,9 @@ func (u *mtrUI) CycleHistoryChartMode() {
 		return
 	}
 	for {
-		old := atomic.LoadInt32(&u.chartMode)
+		old := u.chartMode.Load()
 		next := (old + 1) % 3
-		if atomic.CompareAndSwapInt32(&u.chartMode, old, next) {
+		if u.chartMode.CompareAndSwap(old, next) {
 			return
 		}
 	}
@@ -107,15 +107,15 @@ func (u *mtrUI) CycleHistoryChartMode() {
 
 // CurrentHistoryChartMode 返回 history 图表模式。
 func (u *mtrUI) CurrentHistoryChartMode() int {
-	return int(atomic.LoadInt32(&u.chartMode))
+	return int(u.chartMode.Load())
 }
 
 // ToggleNameMode 在 PTR/IP (0) 和 IP only (1) 之间切换。
 func (u *mtrUI) ToggleNameMode() int32 {
 	for {
-		old := atomic.LoadInt32(&u.nameMode)
+		old := u.nameMode.Load()
 		next := int32(1) - old // 0→1, 1→0
-		if atomic.CompareAndSwapInt32(&u.nameMode, old, next) {
+		if u.nameMode.CompareAndSwap(old, next) {
 			return next
 		}
 	}
@@ -123,15 +123,14 @@ func (u *mtrUI) ToggleNameMode() int32 {
 
 // CurrentNameMode 返回当前 Host 基础显示模式 (0=PTR/IP, 1=IP only)。
 func (u *mtrUI) CurrentNameMode() int {
-	return int(atomic.LoadInt32(&u.nameMode))
+	return int(u.nameMode.Load())
 }
 
 // ToggleMPLS 在显示 MPLS (0) 和隐藏 MPLS (1) 之间切换。
 func (u *mtrUI) ToggleMPLS() {
 	for {
-		old := atomic.LoadInt32(&u.disableMPLS)
-		next := int32(1) - old // 0→1, 1→0
-		if atomic.CompareAndSwapInt32(&u.disableMPLS, old, next) {
+		old := u.disableMPLS.Load()
+		if u.disableMPLS.CompareAndSwap(old, !old) {
 			return
 		}
 	}
@@ -139,7 +138,7 @@ func (u *mtrUI) ToggleMPLS() {
 
 // IsMPLSDisabled 返回当前是否隐藏 MPLS 显示。
 func (u *mtrUI) IsMPLSDisabled() bool {
-	return atomic.LoadInt32(&u.disableMPLS) != 0
+	return u.disableMPLS.Load()
 }
 
 // ---------------------------------------------------------------------------
@@ -410,11 +409,11 @@ func (u *mtrUI) ReadKeysLoop(ctx context.Context) {
 				}
 				return
 			case mtrActionPause:
-				atomic.StoreInt32(&u.paused, 1)
+				u.paused.Store(true)
 			case mtrActionResume:
-				atomic.StoreInt32(&u.paused, 0)
+				u.paused.Store(false)
 			case mtrActionRestart:
-				atomic.StoreInt32(&u.restartReq, 1)
+				u.restartReq.Store(true)
 			case mtrActionDisplayMode:
 				u.CycleDisplayMode()
 			case mtrActionNameToggle:
@@ -433,7 +432,7 @@ func (u *mtrUI) ReadKeysLoop(ctx context.Context) {
 // ConsumeRestartRequest 原子读取并清除重置请求标志。
 // 返回 true 表示请求了重置统计。
 func (u *mtrUI) ConsumeRestartRequest() bool {
-	return atomic.SwapInt32(&u.restartReq, 0) == 1
+	return u.restartReq.Swap(false)
 }
 
 // ParseMTRKey 将单字节解析为操作名称（用于测试）。

--- a/docs/performance/go127-safe-runtime.md
+++ b/docs/performance/go127-safe-runtime.md
@@ -1,0 +1,179 @@
+# Go 1.27 安全运行时现代化证据
+
+## 范围与结论
+
+本轮只迁移已能证明语义等价的运行时接口：
+
+- MTR/TUI 并发状态从函数式 atomic API 迁移到 typed atomic，并显式初始化
+  `-1` sentinel。
+- speed test 的普通传输 worker 使用 `WaitGroup.Go`。
+- 已覆盖测试的集合、排序、查找和地址拼接改用 `slices`、`cmp`、
+  `sync.Map.Clear` 和 `net.JoinHostPort`。
+- packet size 与 MTR echo ID 的非安全随机改用 `math/rand/v2`。
+
+CLI、JSON、TTY、协议报文、导出 API 和三 flavor 边界不变。平衡复测未发现
+显著性能回退，分配指标不变，满足 PR-1 的合并门槛。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `5e58ef2b0bdc3c5668a8378abf37716c5b5bb56c` |
+| benchmark head | `fcd1336c43f36de61c3fa05fbccf3b04880f9f1b` |
+| sentinel review follow-up | `8d36dc74060089e575ab1c1741494de249717169` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每次 1 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+| 压缩工具 | UPX 5.2.1，`-9` |
+
+benchmark head 之后只统一了生产与测试的 sentinel 构造 helper 并增加本报告，
+没有修改被测热点；性能工作流会在 PR exact head 上重新生成 Linux
+cross-reference artifact。
+
+## 调用链变化
+
+### MTR/TUI 状态
+
+`atomic.Load/Store/Add/Swap/CompareAndSwap*` 改为字段自身的 typed atomic 方法。
+`knownFinalTTL` 与 `roundFinalTTL` 仍以 `-1` 表示未知，并在构造函数中显式
+`Store(-1)`。相关结构始终通过指针使用，`go vet -copylocks` 未发现复制已使用
+atomic 的路径。
+
+### 普通 worker
+
+speed test transfer 的 `Add(1) -> go -> defer Done()` 改为 `WaitGroup.Go`。
+协议收发、WebSocket 和 MTR 生命周期没有迁移；这些路径分别留给 PR-6A、
+PR-6B 和 PR-6C。
+
+### 标准库集合接口
+
+- speed test 延迟样本使用 `slices.Sort`。
+- candidate 使用 `slices.SortStableFunc` 与 `cmp.Compare`，继续保持健康状态优先、
+  RTT 升序和相同 RTT 的输入顺序。
+- `StringInSlice` 使用 `slices.Contains`。
+- Geo cache 清理使用 `sync.Map.Clear`。
+- WebSocket 地址使用 `net.JoinHostPort`，覆盖 IPv4、IPv6、已加括号 IPv6、zone
+  和空 host。
+
+### 非安全随机
+
+packet size 使用 `rand/v2.IntN`，MTR echo ID 使用 `rand/v2.IntN` 并继续保留
+进程 ID 低 8 位。范围测试各执行 1000 次。raw socket 结构、TCP/UDP/ICMP
+报文和 QUIC payload 均未修改。
+
+## `go fix` 审计
+
+每个 analyzer 在 parent 临时工作树中独立运行并逐项核对 diff：
+
+- 接受：MTR/TUI 的 `atomictypes` 子集、transfer worker 的 `waitgroupgo` 子集。
+- 手工采用：有明确测试的 `slices`、`cmp`、`Map.Clear`、`JoinHostPort` 和
+  `rand/v2` 子集。
+- 拒绝：协议收发、wshandle 和 renderer 的 `waitgroupgo`；全仓 `any`；会改变
+  JSON 省略规则的 `omitzero`；无调用者 legacy server aggregator 的
+  `mapsloop`；其余跨主题或格式噪声建议。
+
+## Benchmark
+
+第一轮按 parent -> head 各运行 10 次；系统负载变化使未修改的 decoder 同时
+出现约 5% 到 14% 的回退、MTU decoder 同时出现约 7% 到 8% 的改善。随后按
+head -> parent 反向各补 10 次。合并后的关键结果如下：
+
+| Benchmark | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| MTR Update 64x4 | 92.97 us | 95.23 us | `~` |
+| MTR Clone 64x4 | 43.37 us | 42.75 us | `~` |
+| MTR Snapshot 64x4 | 31.41 us | 32.12 us | `~` |
+| MTR preview clone/update 64x4 | 80.40 us | 86.35 us | `~` |
+| Geo cache hit | 7.373 ns | 7.273 ns | `~` |
+| Geo cache miss | 4.887 ns | 4.593 ns | -6.03% |
+| WebSocket JSON marshal | 555.1 ns | 540.9 ns | -2.55% |
+| WebSocket JSON unmarshal | 2.664 us | 2.646 us | `~` |
+| Geo HTTP multi-client concurrent | 81.37 us | 83.73 us | `~` |
+| nali span scan | 4.789 us | 4.843 us | `~` |
+
+`~` 表示 benchstat 未确认显著差异。所有 allocs/op 均与 parent 相同。
+
+合并结果仍把未修改的 GeoFeed IPv6 miss 判为 `+5.42%`，并把四个未修改的
+协议 decoder 判为 `+2.35%` 到 `+5.30%`。因此对这些异常项在同一个工作树、
+同一路径中切换精确 SHA，按 AB/BA 各半交替运行 10 次：
+
+| 复测项 | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| GeoFeed IPv6 miss | 13.87 us | 14.00 us | `~` |
+| ICMPv4 decoder | 87.06 ns | 87.34 ns | `~` |
+| ICMPv6 decoder | 90.95 ns | 90.59 ns | `~` |
+| TCPv4 decoder | 16.57 ns | 16.55 ns | `~` |
+| TCPv6 decoder | 16.35 ns | 16.44 ns | `~` |
+| UDPv4 decoder | 82.65 ns | 82.95 ns | `~` |
+| UDPv6 decoder | 84.33 ns | 84.19 ns | `~` |
+
+同路径 decoder 几何均值变化为 `+0.09%`，无显著差异；全套结果中的异常来自
+运行顺序、系统负载和不同工作树测试二进制布局，不能归因于 PR-1。
+
+## Profile
+
+`BenchmarkMTRAggregatorSnapshot64TTL4Paths` 分别采集 30 秒 CPU 与 heap
+profile：
+
+| 指标 | parent | head |
+| --- | ---: | ---: |
+| benchmark | 27.562 us | 27.641 us |
+| 分配 | 106,544 B/op | 106,544 B/op |
+| 分配次数 | 458 allocs/op | 458 allocs/op |
+| `snapshotLocked` CPU cumulative | 26.97% | 27.88% |
+| `snapshotLocked` alloc space | 90.38% | 90.43% |
+| `buildMTRHopStat` alloc space | 7.67% | 7.62% |
+
+热点结构未改变；`snapshotLocked` 与 `buildMTRHopStat` 仍是 PR-5 的优化目标。
+
+## 产物大小
+
+构建参数为 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`。
+
+### Darwin arm64，未压缩
+
+| Flavor | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 29,994,386 B | 30,010,914 B | +0.055% |
+| nexttrace-tiny | 10,901,186 B | 10,934,226 B | +0.303% |
+| ntr | 10,901,186 B | 10,934,226 B | +0.303% |
+
+### Linux arm64，未压缩 / UPX `-9`
+
+| Flavor | parent | head | 未压缩变化 | UPX 变化 |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 29,622,396 / 9,682,520 B | 29,622,396 / 9,686,344 B | 0.000% | +0.039% |
+| nexttrace-tiny | 10,813,564 / 4,063,688 B | 10,879,100 / 4,068,364 B | +0.606% | +0.115% |
+| ntr | 10,813,564 / 4,063,672 B | 10,879,100 / 4,068,476 B | +0.606% | +0.118% |
+
+tiny/ntr 的大小增长与本轮新增 `rand/v2` 依赖同时出现；现有测量没有把依赖、
+符号布局等因素分离，因此不作单一因果归因。full 的 Linux 未压缩产物不变，
+没有跨 flavor 引入 WebUI/MCP 依赖。
+
+## 验证
+
+parent 与 head 在 `nojsonv2` 下的 `go test -count=1 ./...` 分别为 36.08 秒和
+35.74 秒。
+head 还通过：
+
+- 默认 JSON 与 `nojsonv2` 的完整测试。
+- `go test -race -count=1 ./...`。
+- `go build ./...`、`go vet ./...`、`go vet -copylocks ./cmd ./trace`。
+- full、tiny、ntr 的 tagged 测试和构建。
+- Linux amd64、Windows amd64、Darwin arm64 构建。
+- Web 前端 15 项 Node 测试。
+- `go mod verify`、空的 `go mod tidy -diff`。
+- `golangci-lint v2.13.2 --new-from-rev origin/main`，0 个新增问题。
+- Darwin release-style 产物的 `LC_BUILD_VERSION minos 13.0`。
+
+## 风险与回退
+
+`math/rand/v2` 会改变非安全随机序列，但 packet size 范围和 echo ID 位布局保持
+不变，随机序列本身不是公共合同。typed atomic 不能复制；当前目标结构只通过
+指针使用，并由 copylocks 检查约束。
+
+如需回退，可按逆序撤销三个实现提交；无需迁移配置、缓存、JSON 或持久数据。
+本地原始 benchmark、profile 和二进制不入库，PR 性能工作流会保存 Linux
+cross-reference artifact。

--- a/internal/speedtest/latency/latency.go
+++ b/internal/speedtest/latency/latency.go
@@ -3,7 +3,7 @@ package latency
 import (
 	"context"
 	"math"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 )
@@ -131,7 +131,7 @@ func Compute(samples []float64) Stats {
 	}
 
 	sorted := append([]float64(nil), samples...)
-	sort.Float64s(sorted)
+	slices.Sort(sorted)
 	minV := sorted[0]
 	maxV := sorted[n-1]
 

--- a/internal/speedtest/runner/runner.go
+++ b/internal/speedtest/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,7 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -302,16 +303,7 @@ func discoverCandidates(ctx context.Context, cfg *speedconfig.Config, p provider
 		seen[key] = true
 		out.Candidates = append(out.Candidates, buildCandidate(ctx, cfg, p, host, key, "dns"))
 	}
-	sort.SliceStable(out.Candidates, func(i, j int) bool {
-		li, lj := out.Candidates[i], out.Candidates[j]
-		if li.Status == "ok" && lj.Status != "ok" {
-			return true
-		}
-		if li.Status != "ok" && lj.Status == "ok" {
-			return false
-		}
-		return li.RTTMs < lj.RTTMs
-	})
+	sortCandidates(out.Candidates)
 	for _, cand := range out.Candidates {
 		if cand.Status == "ok" {
 			out.Selected = cand
@@ -326,6 +318,18 @@ func discoverCandidates(ctx context.Context, cfg *speedconfig.Config, p provider
 		})
 	}
 	return out, nil
+}
+
+func sortCandidates(candidates []candidate) {
+	slices.SortStableFunc(candidates, func(a, b candidate) int {
+		if a.Status == "ok" && b.Status != "ok" {
+			return -1
+		}
+		if a.Status != "ok" && b.Status == "ok" {
+			return 1
+		}
+		return cmp.Compare(a.RTTMs, b.RTTMs)
+	})
 }
 
 func buildCandidate(ctx context.Context, cfg *speedconfig.Config, p provider.Provider, host, ip, source string) candidate {

--- a/internal/speedtest/runner/runner_test.go
+++ b/internal/speedtest/runner/runner_test.go
@@ -19,6 +19,24 @@ import (
 	"github.com/nxtrace/NTrace-core/internal/speedtest/result"
 )
 
+func TestSortCandidatesKeepsHealthyRTTAndStableOrder(t *testing.T) {
+	candidates := []candidate{
+		{IP: "192.0.2.1", Status: "degraded", RTTMs: 20},
+		{IP: "192.0.2.2", Status: "ok", RTTMs: 10},
+		{IP: "192.0.2.3", Status: "ok", RTTMs: 10},
+		{IP: "192.0.2.4", Status: "degraded", RTTMs: 5},
+	}
+
+	sortCandidates(candidates)
+
+	want := []string{"192.0.2.2", "192.0.2.3", "192.0.2.4", "192.0.2.1"}
+	for i, ip := range want {
+		if candidates[i].IP != ip {
+			t.Fatalf("Candidates[%d].IP = %q, want %q", i, candidates[i].IP, ip)
+		}
+	}
+}
+
 func TestResolveLocalBindIPPrefersExplicitSource(t *testing.T) {
 	ip, err := resolveLocalBindIP(net.ParseIP("1.1.1.1"), "127.0.0.1", "missing0")
 	if err != nil {

--- a/internal/speedtest/transfer/transfer.go
+++ b/internal/speedtest/transfer/transfer.go
@@ -73,9 +73,7 @@ func Run(
 	}()
 
 	for i := 0; i < threads; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			var fault bool
 			if dir == Download {
 				_, fault = doDownload(ctx2, client, spec, timeout, &totalBytes)
@@ -85,7 +83,7 @@ func Run(
 			if fault {
 				faultCount.Add(1)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/trace/cache.go
+++ b/trace/cache.go
@@ -1,8 +1,5 @@
 package trace
 
 func ClearCaches() {
-	geoCache.Range(func(key, value any) bool {
-		geoCache.Delete(key)
-		return true
-	})
+	geoCache.Clear()
 }

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/nxtrace/NTrace-core/ipgeo"
 )
 
+func TestClearCachesRemovesAllEntries(t *testing.T) {
+	geoCache.Store("198.51.100.1", &ipgeo.IPGeoData{IP: "198.51.100.1"})
+	geoCache.Store("2001:db8::1", &ipgeo.IPGeoData{IP: "2001:db8::1"})
+
+	ClearCaches()
+
+	if _, ok := geoCache.Load("198.51.100.1"); ok {
+		t.Fatal("IPv4 cache entry remained after ClearCaches")
+	}
+	if _, ok := geoCache.Load("2001:db8::1"); ok {
+		t.Fatal("IPv6 cache entry remained after ClearCaches")
+	}
+}
+
 func TestLookupIPGeoCachesResults(t *testing.T) {
 	ClearCaches()
 	t.Cleanup(ClearCaches)

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -272,7 +272,7 @@ type mtrICMPEngine struct {
 	ipVer  int
 
 	// 单调递增序列号，避免跨轮 seq 冲突
-	seqCounter uint32
+	seqCounter atomic.Uint32
 
 	// per-round 探针/响应匹配
 	mu       sync.Mutex
@@ -281,12 +281,12 @@ type mtrICMPEngine struct {
 	notifyCh chan struct{}
 
 	// 当前轮次 ID，用于丢弃过期响应
-	roundID uint32
+	roundID atomic.Uint32
 
 	// 已知目的地 TTL（-1 = 未知），跨轮保留以减少无效探测
-	knownFinalTTL int32
+	knownFinalTTL atomic.Int32
 	// 当前轮次内发现的目的地 TTL（-1 = 本轮未发现）
-	roundFinalTTL int32
+	roundFinalTTL atomic.Int32
 
 	// 流式预览状态（peekPartialResult 使用，受 mu 保护）
 	curTtlSeq       map[int]int
@@ -341,13 +341,15 @@ func newMTRICMPEngine(config Config) (*mtrICMPEngine, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	echoID := (r.Intn(256) << 8) | (os.Getpid() & 0xFF)
 
-	return &mtrICMPEngine{
-		config:        config,
-		ipVer:         ipVer,
-		echoID:        echoID,
-		srcIP:         srcIP,
-		knownFinalTTL: -1,
-	}, nil
+	engine := &mtrICMPEngine{
+		config: config,
+		ipVer:  ipVer,
+		echoID: echoID,
+		srcIP:  srcIP,
+	}
+	engine.knownFinalTTL.Store(-1)
+	engine.roundFinalTTL.Store(-1)
+	return engine, nil
 }
 
 // start 创建持久 ICMP 套接字及监听协程。ctx 生命周期控制整个引擎。
@@ -386,7 +388,7 @@ func (e *mtrICMPEngine) close() {
 
 // resetFinalTTL 清除已知目的地 TTL 缓存（r 键重置统计时调用）。
 func (e *mtrICMPEngine) resetFinalTTL() {
-	atomic.StoreInt32(&e.knownFinalTTL, -1)
+	e.knownFinalTTL.Store(-1)
 }
 
 // peekPartialResult 返回当前轮次已收到的部分探测结果（用于流式预览）。
@@ -402,7 +404,7 @@ func (e *mtrICMPEngine) peekPartialResult() *Result {
 	}
 
 	// 若已检测到目的地，缩小预览范围
-	if rf := atomic.LoadInt32(&e.roundFinalTTL); rf > 0 && int(rf) < effectiveMax {
+	if rf := e.roundFinalTTL.Load(); rf > 0 && int(rf) < effectiveMax {
 		effectiveMax = int(rf)
 	}
 
@@ -452,7 +454,7 @@ func (e *mtrICMPEngine) rotateEngine(ctx context.Context) error {
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	e.echoID = (r.Intn(256) << 8) | (os.Getpid() & 0xFF)
-	atomic.StoreUint32(&e.seqCounter, 0)
+	e.seqCounter.Store(0)
 
 	e.spec = internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, e.echoID, e.srcIP, e.config.DstIP)
 	applyICMPSourceDevice(e.spec, e.config.OSType, e.config.SourceDevice)
@@ -508,7 +510,7 @@ func (e *mtrICMPEngine) onICMP(msg internal.ReceivedMessage, finish time.Time, s
 }
 
 func (e *mtrICMPEngine) shouldDiscardProbeReplyLocked(seq int, start mtrProbeMeta, finish time.Time) bool {
-	if start.roundID != atomic.LoadUint32(&e.roundID) {
+	if start.roundID != e.roundID.Load() {
 		e.discardProbeLocked(seq)
 		return true
 	}
@@ -577,9 +579,9 @@ func (e *mtrICMPEngine) updateRoundFinalTTL(ttl int32) {
 	if ttl < 0 {
 		return
 	}
-	curFinal := atomic.LoadInt32(&e.roundFinalTTL)
+	curFinal := e.roundFinalTTL.Load()
 	if curFinal < 0 || ttl < curFinal {
-		atomic.StoreInt32(&e.roundFinalTTL, ttl)
+		e.roundFinalTTL.Store(ttl)
 	}
 }
 
@@ -666,8 +668,8 @@ func (e *mtrICMPEngine) prepareProbeRound(ctx context.Context) mtrProbeRoundStat
 	if beginHop <= 0 {
 		beginHop = 1
 	}
-	curRound := atomic.AddUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, -1)
+	curRound := e.roundID.Add(1)
+	e.roundFinalTTL.Store(-1)
 	e.resetProbeRoundMaps()
 	e.drainNotifySignal()
 
@@ -705,14 +707,14 @@ func (e *mtrICMPEngine) drainNotifySignal() {
 }
 
 func (e *mtrICMPEngine) rotateProbeEngineIfNeeded(ctx context.Context, probeCount int) error {
-	if !seqWillWrap(atomic.LoadUint32(&e.seqCounter), probeCount) {
+	if !seqWillWrap(e.seqCounter.Load(), probeCount) {
 		return nil
 	}
 	return e.rotateEngine(ctx)
 }
 
 func (e *mtrICMPEngine) effectiveProbeRoundMax(maxHops int) int {
-	if kf := atomic.LoadInt32(&e.knownFinalTTL); kf > 0 && int(kf) < maxHops {
+	if kf := e.knownFinalTTL.Load(); kf > 0 && int(kf) < maxHops {
 		return int(kf)
 	}
 	return maxHops
@@ -754,7 +756,7 @@ func (e *mtrICMPEngine) sendProbeSweep(ctx context.Context, round mtrProbeRoundS
 }
 
 func (e *mtrICMPEngine) sendProbeForTTL(ctx context.Context, ttl int, roundID uint32) (bool, error) {
-	seq := int(atomic.AddUint32(&e.seqCounter, 1) & 0xFFFF)
+	seq := int(e.seqCounter.Add(1) & 0xFFFF)
 
 	// Pre-register the seq so onICMP can match it even for very short RTT replies.
 	preStart := time.Now()
@@ -830,16 +832,16 @@ func (e *mtrICMPEngine) finalizeProbeRound(effectiveMax int) int {
 }
 
 func (e *mtrICMPEngine) updateKnownFinalTTLFromRound() {
-	if rf := atomic.LoadInt32(&e.roundFinalTTL); rf > 0 {
-		kf := atomic.LoadInt32(&e.knownFinalTTL)
+	if rf := e.roundFinalTTL.Load(); rf > 0 {
+		kf := e.knownFinalTTL.Load()
 		if kf < 0 || rf < kf {
-			atomic.StoreInt32(&e.knownFinalTTL, rf)
+			e.knownFinalTTL.Store(rf)
 		}
 	}
 }
 
 func (e *mtrICMPEngine) roundFinalMax(effectiveMax int) int {
-	if rf := atomic.LoadInt32(&e.roundFinalTTL); rf > 0 && int(rf) < effectiveMax {
+	if rf := e.roundFinalTTL.Load(); rf > 0 && int(rf) < effectiveMax {
 		return int(rf)
 	}
 	return effectiveMax
@@ -916,16 +918,16 @@ func (p *mtrFallbackProber) close() {}
 func (e *mtrICMPEngine) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, error) {
 	// Serialize seq allocation + rotation check across concurrent ProbeTTL calls.
 	e.sendMu.Lock()
-	if seqWillWrap(atomic.LoadUint32(&e.seqCounter), 1) {
+	if seqWillWrap(e.seqCounter.Load(), 1) {
 		if err := e.rotateEngine(ctx); err != nil {
 			e.sendMu.Unlock()
 			return mtrProbeResult{TTL: ttl}, fmt.Errorf("echoID rotation: %w", err)
 		}
 	}
-	seq := int(atomic.AddUint32(&e.seqCounter, 1) & 0xFFFF)
+	seq := int(e.seqCounter.Add(1) & 0xFFFF)
 	e.sendMu.Unlock()
 
-	curRound := atomic.LoadUint32(&e.roundID)
+	curRound := e.roundID.Load()
 	done := make(chan struct{})
 
 	// Pre-register before sending so onICMP can match even very short RTT replies.
@@ -1006,7 +1008,7 @@ func (e *mtrICMPEngine) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, 
 // knownFinalTTL. In-flight ProbeTTL calls get notified and return immediately.
 func (e *mtrICMPEngine) Reset() error {
 	e.resetFinalTTL()
-	atomic.AddUint32(&e.roundID, 1)
+	e.roundID.Add(1)
 
 	e.mu.Lock()
 	for seq, ch := range e.probeNotify {

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -3,7 +3,7 @@ package trace
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"sync"
@@ -338,18 +338,19 @@ func newMTRICMPEngine(config Config) (*mtrICMPEngine, error) {
 		return nil, fmt.Errorf("cannot determine local IP for MTR ICMP")
 	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	echoID := (r.Intn(256) << 8) | (os.Getpid() & 0xFF)
-
 	engine := &mtrICMPEngine{
 		config: config,
 		ipVer:  ipVer,
-		echoID: echoID,
+		echoID: newMTREchoID(),
 		srcIP:  srcIP,
 	}
 	engine.knownFinalTTL.Store(-1)
 	engine.roundFinalTTL.Store(-1)
 	return engine, nil
+}
+
+func newMTREchoID() int {
+	return (rand.IntN(256) << 8) | (os.Getpid() & 0xFF)
 }
 
 // start 创建持久 ICMP 套接字及监听协程。ctx 生命周期控制整个引擎。
@@ -452,8 +453,7 @@ func seqWillWrap(seqCounter uint32, probeCount int) bool {
 func (e *mtrICMPEngine) rotateEngine(ctx context.Context) error {
 	e.spec.Close()
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	e.echoID = (r.Intn(256) << 8) | (os.Getpid() & 0xFF)
+	e.echoID = newMTREchoID()
 	e.seqCounter.Store(0)
 
 	e.spec = internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, e.echoID, e.srcIP, e.config.DstIP)

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -338,6 +338,10 @@ func newMTRICMPEngine(config Config) (*mtrICMPEngine, error) {
 		return nil, fmt.Errorf("cannot determine local IP for MTR ICMP")
 	}
 
+	return newMTRICMPEngineState(config, ipVer, srcIP), nil
+}
+
+func newMTRICMPEngineState(config Config, ipVer int, srcIP net.IP) *mtrICMPEngine {
 	engine := &mtrICMPEngine{
 		config: config,
 		ipVer:  ipVer,
@@ -346,7 +350,7 @@ func newMTRICMPEngine(config Config) (*mtrICMPEngine, error) {
 	}
 	engine.knownFinalTTL.Store(-1)
 	engine.roundFinalTTL.Store(-1)
-	return engine, nil
+	return engine
 }
 
 func newMTREchoID() int {

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -435,19 +435,15 @@ func newTestICMPEngine(timeout time.Duration) *mtrICMPEngine {
 	if timeout <= 0 {
 		timeout = 2 * time.Second
 	}
-	engine := &mtrICMPEngine{
-		config:   Config{Timeout: timeout},
-		notifyCh: make(chan struct{}, 1),
-		sentAt:   make(map[int]mtrProbeMeta),
-		replied:  make(map[int]*mtrProbeReply),
-	}
-	engine.knownFinalTTL.Store(-1)
-	engine.roundFinalTTL.Store(-1)
+	engine := newMTRICMPEngineState(Config{Timeout: timeout}, 4, net.IPv4zero)
+	engine.notifyCh = make(chan struct{}, 1)
+	engine.sentAt = make(map[int]mtrProbeMeta)
+	engine.replied = make(map[int]*mtrProbeReply)
 	return engine
 }
 
-func TestNewTestICMPEngineInitialFinalTTL(t *testing.T) {
-	engine := newTestICMPEngine(time.Second)
+func TestNewMTRICMPEngineStateInitialFinalTTL(t *testing.T) {
+	engine := newMTRICMPEngineState(Config{Timeout: time.Second}, 4, net.IPv4zero)
 	if got := engine.knownFinalTTL.Load(); got != -1 {
 		t.Fatalf("knownFinalTTL = %d, want -1", got)
 	}

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -434,18 +434,31 @@ func newTestICMPEngine(timeout time.Duration) *mtrICMPEngine {
 	if timeout <= 0 {
 		timeout = 2 * time.Second
 	}
-	return &mtrICMPEngine{
+	engine := &mtrICMPEngine{
 		config:   Config{Timeout: timeout},
 		notifyCh: make(chan struct{}, 1),
 		sentAt:   make(map[int]mtrProbeMeta),
 		replied:  make(map[int]*mtrProbeReply),
+	}
+	engine.knownFinalTTL.Store(-1)
+	engine.roundFinalTTL.Store(-1)
+	return engine
+}
+
+func TestNewTestICMPEngineInitialFinalTTL(t *testing.T) {
+	engine := newTestICMPEngine(time.Second)
+	if got := engine.knownFinalTTL.Load(); got != -1 {
+		t.Fatalf("knownFinalTTL = %d, want -1", got)
+	}
+	if got := engine.roundFinalTTL.Load(); got != -1 {
+		t.Fatalf("roundFinalTTL = %d, want -1", got)
 	}
 }
 
 // TestOnICMP_NormalReply 正常回包应被接受。
 func TestOnICMP_NormalReply(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 1)
+	e.roundID.Store(1)
 
 	now := time.Now()
 	seq := 42
@@ -465,7 +478,7 @@ func TestOnICMP_NormalReply(t *testing.T) {
 // TestOnICMP_StaleRoundReply 旧轮次回包（roundID 不匹配）应被丢弃。
 func TestOnICMP_StaleRoundReply(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 5)
+	e.roundID.Store(5)
 
 	now := time.Now()
 	seq := 100
@@ -496,7 +509,7 @@ func TestOnICMP_StaleRoundReply(t *testing.T) {
 func TestOnICMP_SeqWrapStaleReply(t *testing.T) {
 	timeout := 2 * time.Second
 	e := newTestICMPEngine(timeout)
-	atomic.StoreUint32(&e.roundID, 2000)
+	e.roundID.Store(2000)
 
 	// 模拟新轮次刚刚发送 seq=100（1ms 前）
 	newSendTime := time.Now()
@@ -525,7 +538,7 @@ func TestOnICMP_SeqWrapStaleReply(t *testing.T) {
 // TestOnICMP_NegativeRTT 时间倒退（finish < start）的回包应被丢弃。
 func TestOnICMP_NegativeRTT(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 1)
+	e.roundID.Store(1)
 
 	now := time.Now()
 	seq := 200
@@ -545,7 +558,7 @@ func TestOnICMP_NegativeRTT(t *testing.T) {
 func TestOnICMP_ExactTimeoutBoundary(t *testing.T) {
 	timeout := 2 * time.Second
 	e := newTestICMPEngine(timeout)
-	atomic.StoreUint32(&e.roundID, 1)
+	e.roundID.Store(1)
 
 	now := time.Now()
 	seq := 300
@@ -564,7 +577,7 @@ func TestOnICMP_ExactTimeoutBoundary(t *testing.T) {
 // TestOnICMP_UnknownSeq 未知 seq 的回包应被静默忽略。
 func TestOnICMP_UnknownSeq(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 1)
+	e.roundID.Store(1)
 
 	peer := &net.IPAddr{IP: net.ParseIP("10.0.0.4")}
 	e.onICMP(internal.ReceivedMessage{Peer: peer}, time.Now(), 999)
@@ -646,9 +659,9 @@ func TestProbeRound_BeginHopExceedsMaxHops(t *testing.T) {
 	e.config.BeginHop = 10
 	e.config.MaxHops = 5
 	// seqCounter 接近边界 — 若 probeCount 保护缺失会触发 rotateEngine（此处无 spec 会 panic）
-	atomic.StoreUint32(&e.seqCounter, 0xFFF0)
+	e.seqCounter.Store(0xFFF0)
 
-	seqBefore := atomic.LoadUint32(&e.seqCounter)
+	seqBefore := e.seqCounter.Load()
 
 	res, err := e.probeRound(context.Background())
 	if err != nil {
@@ -668,8 +681,8 @@ func TestProbeRound_BeginHopExceedsMaxHops(t *testing.T) {
 	}
 
 	// 未发送任何探针，seqCounter 应不变
-	if atomic.LoadUint32(&e.seqCounter) != seqBefore {
-		t.Errorf("seqCounter should not change, was %d now %d", seqBefore, atomic.LoadUint32(&e.seqCounter))
+	if e.seqCounter.Load() != seqBefore {
+		t.Errorf("seqCounter should not change, was %d now %d", seqBefore, e.seqCounter.Load())
 	}
 }
 
@@ -747,11 +760,11 @@ func TestMTRLoop_RestartStatistics(t *testing.T) {
 // TestResetClearsKnownFinalTTL 验证 resetFinalTTL 清除已知目的地 TTL 缓存。
 func TestResetClearsKnownFinalTTL(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreInt32(&e.knownFinalTTL, 5)
+	e.knownFinalTTL.Store(5)
 
 	e.resetFinalTTL()
 
-	if got := atomic.LoadInt32(&e.knownFinalTTL); got != -1 {
+	if got := e.knownFinalTTL.Load(); got != -1 {
 		t.Errorf("expected knownFinalTTL=-1 after reset, got %d", got)
 	}
 }
@@ -764,9 +777,9 @@ func TestResetClearsKnownFinalTTL(t *testing.T) {
 func TestOnICMP_DetectsDestination(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
 	e.config.DstIP = net.ParseIP("8.8.8.8")
-	atomic.StoreUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, -1)
-	atomic.StoreInt32(&e.knownFinalTTL, -1)
+	e.roundID.Store(1)
+	e.roundFinalTTL.Store(-1)
+	e.knownFinalTTL.Store(-1)
 
 	now := time.Now()
 	seq := 42
@@ -778,7 +791,7 @@ func TestOnICMP_DetectsDestination(t *testing.T) {
 		ICMP: internal.ICMPResponse{Kind: internal.ICMPResponseEchoReply, Description: "ICMP Echo Reply"},
 	}, now.Add(15*time.Millisecond), seq)
 
-	if got := atomic.LoadInt32(&e.roundFinalTTL); got != 5 {
+	if got := e.roundFinalTTL.Load(); got != 5 {
 		t.Errorf("expected roundFinalTTL=5, got %d", got)
 	}
 }
@@ -787,8 +800,8 @@ func TestOnICMP_DetectsDestination(t *testing.T) {
 func TestOnICMP_NonDestinationDoesNotSetFinal(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
 	e.config.DstIP = net.ParseIP("8.8.8.8")
-	atomic.StoreUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, -1)
+	e.roundID.Store(1)
+	e.roundFinalTTL.Store(-1)
 
 	now := time.Now()
 	seq := 42
@@ -798,7 +811,7 @@ func TestOnICMP_NonDestinationDoesNotSetFinal(t *testing.T) {
 	peer := &net.IPAddr{IP: net.ParseIP("10.0.0.1")}
 	e.onICMP(internal.ReceivedMessage{Peer: peer}, now.Add(10*time.Millisecond), seq)
 
-	if got := atomic.LoadInt32(&e.roundFinalTTL); got != -1 {
+	if got := e.roundFinalTTL.Load(); got != -1 {
 		t.Errorf("expected roundFinalTTL=-1 for non-destination, got %d", got)
 	}
 }
@@ -817,8 +830,8 @@ func TestPeekPartialResult_EmptyBeforeRound(t *testing.T) {
 
 func TestPeekPartialResult_PartialReplies(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, -1)
+	e.roundID.Store(1)
+	e.roundFinalTTL.Store(-1)
 
 	// 模拟 probeRound 已初始化 peek 状态
 	e.curBeginHop = 1
@@ -854,8 +867,8 @@ func TestPeekPartialResult_PartialReplies(t *testing.T) {
 
 func TestPeekPartialResult_UnsentTTLsAreNil(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, -1)
+	e.roundID.Store(1)
+	e.roundFinalTTL.Store(-1)
 
 	// 模拟发送进行到一半：TTL 1-2 已发送，TTL 3-5 尚未
 	e.curBeginHop = 1
@@ -894,8 +907,8 @@ func TestPeekPartialResult_UnsentTTLsAreNil(t *testing.T) {
 
 func TestPeekPartialResult_TrimsByRoundFinalTTL(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
-	atomic.StoreUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, 2) // 本轮已检测到目的地在 TTL 2
+	e.roundID.Store(1)
+	e.roundFinalTTL.Store(2) // 本轮已检测到目的地在 TTL 2
 
 	e.curBeginHop = 1
 	e.curEffectiveMax = 5
@@ -1083,9 +1096,9 @@ func TestMTRLoopRoundPathReopensProvisionalEdgeAndKeepsHigherStats(t *testing.T)
 func TestMTRICMPEngineCarriesTransitAndUnreachableResponses(t *testing.T) {
 	e := newTestICMPEngine(2 * time.Second)
 	e.config.DstIP = net.ParseIP("203.0.113.10")
-	atomic.StoreUint32(&e.roundID, 1)
-	atomic.StoreInt32(&e.roundFinalTTL, -1)
-	atomic.StoreInt32(&e.knownFinalTTL, -1)
+	e.roundID.Store(1)
+	e.roundFinalTTL.Store(-1)
+	e.knownFinalTTL.Store(-1)
 	e.curBeginHop = 1
 	e.curEffectiveMax = 3
 	e.curTtlSeq = map[int]int{2: 20, 3: 30}
@@ -1099,7 +1112,7 @@ func TestMTRICMPEngineCarriesTransitAndUnreachableResponses(t *testing.T) {
 	if got := e.replied[20].response; got == nil || got.Kind != MTRResponseTransit {
 		t.Fatalf("target-IP Time Exceeded response = %#v, want transit", got)
 	}
-	if got := atomic.LoadInt32(&e.roundFinalTTL); got != -1 {
+	if got := e.roundFinalTTL.Load(); got != -1 {
 		t.Fatalf("target-IP transit set round final TTL to %d", got)
 	}
 
@@ -1111,7 +1124,7 @@ func TestMTRICMPEngineCarriesTransitAndUnreachableResponses(t *testing.T) {
 	if got := e.replied[30].response; got == nil || got.Kind != MTRResponseUnreachable || got.Marker != "!H" {
 		t.Fatalf("unreachable response = %#v, want unreachable !H", got)
 	}
-	if got := atomic.LoadInt32(&e.roundFinalTTL); got != -1 {
+	if got := e.roundFinalTTL.Load(); got != -1 {
 		t.Fatalf("provisional unreachable set sticky round final TTL to %d", got)
 	}
 

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -647,6 +648,19 @@ func TestSeqWillWrap_NegativeProbes(t *testing.T) {
 	// beginHop > maxHops → probeCount 为负，不应回卷
 	if seqWillWrap(0xFFFF, -5) {
 		t.Fatal("negative probeCount should never trigger wraparound")
+	}
+}
+
+func TestNewMTREchoIDPreservesProcessByte(t *testing.T) {
+	wantLow := os.Getpid() & 0xFF
+	for range 1000 {
+		got := newMTREchoID()
+		if got < 0 || got > 0xFFFF {
+			t.Fatalf("newMTREchoID() = %d, want uint16 range", got)
+		}
+		if got&0xFF != wantLow {
+			t.Fatalf("newMTREchoID() low byte = %d, want process byte %d", got&0xFF, wantLow)
+		}
 	}
 }
 

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -52,7 +52,7 @@ type mtrSchedulerRuntime struct {
 	maxInFlightHop       int
 	states               []mtrHopState
 	generation           uint64
-	knownFinalTTL        int32
+	knownFinalTTL        atomic.Int32
 	pathTracker          *mtrPathTracker
 	inFlight             int
 	resultCh             chan mtrCompletedProbe
@@ -151,7 +151,6 @@ func newMTRSchedulerRuntime(
 		maxConsecErrs:        maxConsecErrs,
 		maxInFlightHop:       maxInFlightHop,
 		states:               make([]mtrHopState, maxHops+1),
-		knownFinalTTL:        -1,
 		resultCh:             make(chan mtrCompletedProbe, parallelism*2),
 		metadataCh:           make(chan mtrMetadataResult, parallelism*2),
 		metadataGeoSlots:     make(chan struct{}, mtrAsyncMetadataGeoConcurrency),
@@ -164,6 +163,7 @@ func newMTRSchedulerRuntime(
 		metadataGeoRetryAt:   make(map[string]time.Time),
 		metadataHostRetryAt:  make(map[string]time.Time),
 	}
+	rt.knownFinalTTL.Store(-1)
 	rt.pathTracker = newMTRPathTracker(cfg.MaxPerHop > 0, maxHops, cfg.OnPathEnd)
 	return rt, nil
 }
@@ -206,7 +206,7 @@ func (rt *mtrSchedulerRuntime) run() error {
 }
 
 func (rt *mtrSchedulerRuntime) effectiveMax() int {
-	kf := atomic.LoadInt32(&rt.knownFinalTTL)
+	kf := rt.knownFinalTTL.Load()
 	if kf > 0 && int(kf) < rt.maxHops {
 		return int(kf)
 	}
@@ -705,7 +705,7 @@ func (rt *mtrSchedulerRuntime) observeProbeResponse(ttl int, response *MTRProbeR
 	if pathEnd != nil {
 		boundary = pathEnd.Hop
 	}
-	atomic.StoreInt32(&rt.knownFinalTTL, int32(boundary))
+	rt.knownFinalTTL.Store(int32(boundary))
 	for hop := rt.beginHop; hop <= rt.maxHops; hop++ {
 		rt.states[hop].disabled = boundary > 0 && hop > boundary
 	}
@@ -820,7 +820,7 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	clear(rt.metadataHostAttempts)
 	clear(rt.metadataGeoRetryAt)
 	clear(rt.metadataHostRetryAt)
-	atomic.StoreInt32(&rt.knownFinalTTL, -1)
+	rt.knownFinalTTL.Store(-1)
 	rt.pathTracker.reset()
 	rt.agg.Reset()
 	_ = rt.prober.Reset()

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -87,6 +87,9 @@ func TestScheduler_ResultBuildersUseBoundedHopCount(t *testing.T) {
 			if rt.maxHops != test.want {
 				t.Fatalf("rt.maxHops = %d, want %d", rt.maxHops, test.want)
 			}
+			if got := rt.knownFinalTTL.Load(); got != -1 {
+				t.Fatalf("knownFinalTTL = %d, want -1", got)
+			}
 
 			if got := len(rt.timeoutProbeResult(test.want).Hops); got != test.want {
 				t.Fatalf("timeoutProbeResult hop len = %d, want %d", got, test.want)

--- a/trace/packet_size.go
+++ b/trace/packet_size.go
@@ -2,7 +2,7 @@ package trace
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 
 	"github.com/nxtrace/NTrace-core/util"
@@ -83,7 +83,7 @@ func resolveProbePayloadSize(method Method, dstIP net.IP, maxPayloadSize int, ra
 	if !randomPerProbe || maxPayloadSize <= minPayload {
 		return maxPayloadSize
 	}
-	return minPayload + rand.Intn(maxPayloadSize-minPayload+1)
+	return minPayload + rand.IntN(maxPayloadSize-minPayload+1)
 }
 
 func packetSizeFamilyLabel(dstIP net.IP) string {

--- a/trace/packet_size_test.go
+++ b/trace/packet_size_test.go
@@ -89,3 +89,30 @@ func TestDefaultPacketSizeMatchesMinimum(t *testing.T) {
 		t.Fatalf("DefaultPacketSize(TCPTrace, %v) = %d, want 64", ip, got)
 	}
 }
+
+func TestResolveProbePayloadSizeRange(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         Method
+		ip             net.IP
+		maxPayloadSize int
+		minWant        int
+		maxWant        int
+		random         bool
+	}{
+		{name: "fixed IPv4 ICMP", method: ICMPTrace, ip: net.ParseIP("192.0.2.1"), maxPayloadSize: 24, minWant: 24, maxWant: 24},
+		{name: "random IPv4 ICMP", method: ICMPTrace, ip: net.ParseIP("192.0.2.1"), maxPayloadSize: 24, minWant: 0, maxWant: 24, random: true},
+		{name: "random IPv6 UDP", method: UDPTrace, ip: net.ParseIP("2001:db8::1"), maxPayloadSize: 16, minWant: 2, maxWant: 16, random: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for range 1000 {
+				got := resolveProbePayloadSize(tt.method, tt.ip, tt.maxPayloadSize, tt.random)
+				if got < tt.minWant || got > tt.maxWant {
+					t.Fatalf("resolveProbePayloadSize() = %d, want range [%d, %d]", got, tt.minWant, tt.maxWant)
+				}
+			}
+		})
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -589,12 +590,7 @@ func GetPowProvider() string {
 }
 
 func StringInSlice(val string, list []string) bool {
-	for _, v := range list {
-		if v == val {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, val)
 }
 
 func HideIPPart(ip string) string {

--- a/wshandle/client.go
+++ b/wshandle/client.go
@@ -23,10 +23,7 @@ import (
 func formatHostPort(addr, port string) string {
 	clean := strings.TrimSpace(addr)
 	clean = strings.Trim(clean, "[]")
-	if strings.Contains(clean, ":") {
-		return "[" + clean + "]:" + port
-	}
-	return clean + ":" + port
+	return net.JoinHostPort(clean, port)
 }
 
 type wsWriteJob struct {

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -17,6 +17,29 @@ import (
 	"github.com/nxtrace/NTrace-core/util"
 )
 
+func TestFormatHostPort(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		port string
+		want string
+	}{
+		{name: "IPv4", addr: " 192.0.2.1 ", port: "443", want: "192.0.2.1:443"},
+		{name: "IPv6", addr: "2001:db8::1", port: "443", want: "[2001:db8::1]:443"},
+		{name: "bracketed IPv6", addr: "[2001:db8::1]", port: "443", want: "[2001:db8::1]:443"},
+		{name: "IPv6 zone", addr: "fe80::1%en0", port: "443", want: "[fe80::1%en0]:443"},
+		{name: "empty host", addr: "", port: "443", want: ":443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatHostPort(tt.addr, tt.port); got != tt.want {
+				t.Fatalf("formatHostPort(%q, %q) = %q, want %q", tt.addr, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
 func newStartedTestWsConn() *WsConn {
 	return newStartedTestWsConnWithContext(context.Background())
 }


### PR DESCRIPTION
## 问题

Go 1.27.1 已提供 typed atomics、`WaitGroup.Go`、`slices`、`cmp`、
`sync.Map.Clear`、`net.JoinHostPort` 和 `math/rand/v2`。仓库仍在部分已覆盖路径
使用旧式并发、集合和非安全随机接口，增加了状态 sentinel 被零值吞没、地址拼接
分支和人工 worker 记账的维护成本。

## 前后调用链

| 路径 | 调整前 | 调整后 |
| --- | --- | --- |
| MTR/TUI 状态 | `atomic.Load/Store/Add/Swap/CAS*` 操作裸整数 | 字段使用 `atomic.Bool/Int32/Uint32`，构造时显式写入 `-1` sentinel |
| speed transfer | `Add -> go -> defer Done` | `WaitGroup.Go` |
| 排序与查找 | 手写循环、`sort.Float64s`、`sort.SliceStable` | `slices.Contains/Sort/SortStableFunc` 与 `cmp.Compare` |
| Geo cache 清理 | `Range + Delete` | `sync.Map.Clear` |
| WS host/port | 手工判断 IPv6 并加括号 | `net.JoinHostPort` |
| 非安全随机 | `math/rand` 与按时间建 source | `math/rand/v2.IntN` |

协议收发、wshandle 生命周期和 MTR worker 生命周期没有迁移，分别留给后续
PR-6A、PR-6B、PR-6C。

## 变更

- typed atomic 仅覆盖已确认的 MTR engine、scheduler 和 TUI 状态；生产与测试
  共用 sentinel 构造 helper，避免测试只验证自身初始化。
- `WaitGroup.Go` 仅用于无返回错误、无特殊 panic/取消语义的 speed transfer worker。
- 保持 candidate 的健康状态优先、RTT 升序和相同 RTT 稳定顺序。
- packet size 与 MTR echo ID 改用 `rand/v2`；echo ID 继续保留 PID 低 8 位。
- raw socket 结构、ICMP/TCP/UDP/QUIC 报文布局均未修改。
- 逐 analyzer 审计 `go fix`；拒绝会跨越后续生命周期 PR、改变 JSON 省略规则、
  扩大全仓 `any` 或触及 legacy 无调用者代码的建议。
- 新增可读性能报告：`docs/performance/go127-safe-runtime.md`。

## 兼容性

- 不修改导出 API、CLI flag、退出码、stdout/stderr、JSON schema、MTR 统计、
  TTY/ANSI、协议包布局或 flavor 依赖边界。
- `rand/v2` 会改变非安全随机序列；packet size 合法范围与 echo ID 位布局不变，
  随机序列本身不是公共合同。
- typed atomic 目标结构只通过指针使用；copylocks 检查无复制路径。

## 测试

本地 exact head `d0b94db29a2a5b2ba90c6cade8dd42c1ba72fa47` 已通过：

- `go test -count=1 ./...`
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`
- `go build ./...`
- `go vet ./...`
- `go vet -copylocks ./cmd ./trace`
- `go test -count=1 -tags flavor_tiny ./cmd ./server`
- `go test -count=1 -tags flavor_ntr ./cmd ./server`
- full、tiny、ntr 的 `nojsonv2` 构建
- Linux amd64、Windows amd64、Darwin arm64 构建
- `node --test server/web/assets/*.test.cjs`：15/15
- `go mod verify`
- `go mod tidy -diff`：无差异
- `golangci-lint v2.13.2 run --new-from-rev origin/main`：0 issues
- Darwin release-style 产物：Go 1.27.1、`nojsonv2`、`LC_BUILD_VERSION minos 13.0`

parent/head 的完整 `nojsonv2` 测试耗时为 36.08 秒 / 35.74 秒。

## Race

- `go test -race -count=1 ./...`：通过。

## Benchstat

环境：Apple M5、Go 1.27.1、`GOMAXPROCS=10`、AC 供电、相同工具版本。
parent 为 `5e58ef2b0bdc3c5668a8378abf37716c5b5bb56c`，benchmark head 为
`fcd1336c43f36de61c3fa05fbccf3b04880f9f1b`。

- 全套按 parent -> head 与 head -> parent 两个顺序各 10 次，合并 `n=20`。
- MTR Update/Clone/Snapshot/Preview、Geo cache hit、WS unmarshal、Geo HTTP
  multi-client concurrent 和 nali 均无显著回退；全部 allocs/op 不变。
- 全套中未修改的 GeoFeed IPv6 miss 和协议 decoder 仍受工作树路径与运行顺序
  干扰；在同一工作树切换精确 SHA，以 AB/BA 各半交替复测 `n=10` 后全部不显著，
  decoder 几何均值变化 `+0.09%`。

详细表格和噪声处理见 `docs/performance/go127-safe-runtime.md`。Linux 数据由本
PR 的 Performance Evidence workflow 作为无阈值交叉参考保存。

## Profile

`BenchmarkMTRAggregatorSnapshot64TTL4Paths` 各采集 30 秒 CPU/heap profile：

- 27.562 us -> 27.641 us。
- 两侧均为 106,544 B/op、458 allocs/op。
- `snapshotLocked` CPU cumulative 为 26.97% -> 27.88%，alloc space 为
  90.38% -> 90.43%；热点结构不变，留给 PR-5。

## 产物大小

相同 stripped 参数下：

- Darwin arm64：full `+0.055%`，tiny/ntr 各 `+0.303%`。
- Linux arm64 未压缩：full `0.000%`，tiny/ntr 各 `+0.606%`。
- Linux arm64 UPX 5.2.1 `-9`：full `+0.039%`，tiny `+0.115%`，ntr `+0.118%`。

tiny/ntr 增长与新增 `rand/v2` 依赖同时出现，未隔离链接布局等因素，因此不作
单一因果归因。没有跨 flavor 引入 WebUI/MCP 依赖。

## 平台风险

- Darwin 最低版本继续使用已锁定的 macOS 13.0，没有扩大或降低范围。
- Windows/Linux 仅受平台无关的标准库接口替换影响，现有交叉构建通过。
- rand/v2 不用于安全 token、认证、raw 包布局或 QUIC payload。

## 回退方案

按下列 commit 的逆序 revert 即可；没有配置、缓存、JSON 或持久数据迁移。

## Commit 列表

- `112932e546efcb01b231c180b33e85e638dcbad0 refactor(mtr): 使用 typed atomic 管理并发状态`
- `83d906bb31c8ea29c8f76361867e2eb292c3d5e2 refactor(runtime): 采用 Go 1.27 标准库并发与集合接口`
- `fcd1336c43f36de61c3fa05fbccf3b04880f9f1b refactor(trace): 将非安全随机切换到 rand/v2`
- `8d36dc74060089e575ab1c1741494de249717169 refactor(mtr): 统一生产与测试的 atomic 哨兵初始化`
- `d0b94db29a2a5b2ba90c6cade8dd42c1ba72fa47 docs(perf): 记录安全运行时现代化证据`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化 IPv4、IPv6（含区域标识）地址与端口的格式化处理。
  - 优化测速候选节点排序，健康节点优先，并保持相同延迟下的稳定顺序。
  - 改进缓存清理、MTR 状态管理及探测数据处理，提升运行稳定性与维护性。

- **测试**
  - 扩展测速排序、缓存清理、探测负载范围、MTR 状态及地址格式化测试，增强边界场景覆盖。

- **文档**
  - 新增 Go 运行时现代化迁移及验证说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->