### PR TITLE
perf(geo): 复用 HTTP Transport 并合并 token 刷新

### DIFF
--- a/docs/performance/go127-geo-http-transport.md
+++ b/docs/performance/go127-geo-http-transport.md
@@ -1,0 +1,186 @@
+# Go 1.27 Geo HTTP Transport 复用证据
+
+## 范围与结论
+
+本轮只调整 Geo HTTP 连接复用、DNS 策略快照、NextTrace API v4 Transport
+生命周期和 IPDB.One token 刷新：
+
+- 普通 provider 按不可变 `{DoT resolver, fallback}` 策略共享 Transport；默认策略
+  使用 `sync.OnceValue`，非默认策略使用最多 32 项的 FIFO 池。
+- NextTrace API v4 使用独立的策略 Transport 池；timeout 和 token 不进入 key，也不再
+  修改普通 provider 的共享实例。
+- IPDB.One 的首次及过期 token 刷新使用 singleflight 合并；每个查询仍受调用者的
+  原始总预算约束。
+
+既有 `NewGeoHTTPClient` 保持签名及独立、可配置 Transport 语义；新增的
+`NewGeoHTTPClientWithPolicy` 也返回独立 Transport，内建 provider 则显式改用新增的
+共享接口。CLI、REST/WS、MCP、JSON、显式错误语义和三 flavor 边界不变；不把底层
+context/http 超时包装文本作为稳定合同。
+
+相对 parent，生产路径的 client 构造从 7 次分配降为 1 次；在最终 exact head 内，
+共享构造器相对兼容独立构造器从 6 次降为 1 次，构造耗时下降 90.25%。四 client
+并发请求未检出显著耗时差异，同时少一次分配。连接计数测试确认 100 次顺序请求
+最多建立 3 个连接，100 轮、每轮 4 个并发请求最多建立 8 个连接。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `284282979f88f81a62a8d987189b8711174d02d5` |
+| full-suite benchmark head | `407d84394397f0aa21ed7b05ab611afdb2e3ba75` |
+| shared-path profile head | `407d84394397f0aa21ed7b05ab611afdb2e3ba75` |
+| final focused head | `dfd0fb645eb30c102662fb66a36609568c26a77e` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每组 10 次，每次 1 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+| 压缩工具 | UPX 5.2.1，`-9` |
+
+`dfd0fb6` 恢复既有 `NewGeoHTTPClient` 的动态 DNS 与 Dialer timeout 语义，并
+增加回归测试；它把 DefaultTransport clone 逻辑等价抽成 helper，但未改变共享
+策略、连接池或 benchmark 语义。
+
+## 调用链变化
+
+### 普通 provider
+
+此前每次查询执行：
+
+`provider -> NewGeoHTTPClient -> DefaultTransport.Clone -> 独立连接池`
+
+现在内建 provider 执行：
+
+`provider -> NewSharedGeoHTTPClient -> policy pool -> 共享不可变 Transport`
+
+Transport 仍从 `http.DefaultTransport` 克隆，保留 proxy、TLS、HTTP/2 和标准连接池
+行为。Dialer 不固化业务 timeout，使用 request context 作为总预算；DNS 返回的 IP
+按原顺序尝试，TLS SNI 仍为 URL host。默认 Transport 的隐式每 host 空闲连接上限
+扩为 32，避免四个短生命周期 client 并发时反复关闭连接；显式自定义值不改写。
+
+默认策略只构造一次。非默认策略的 FIFO 命中不移动顺序，超过 32 项时淘汰最早
+插入项，并在锁外关闭其空闲连接。
+
+### NextTrace API v4
+
+NextTrace API v4 现在按 endpoint、不可变 DNS policy 和完整 proxy policy 复用独立
+Transport。token 与 timeout 不进入 key；每次调用只创建轻量 client，timeout 由
+request context 控制，`http.Client.Timeout` 只作兼容兜底。
+
+环境代理快照包含 `HTTP_PROXY`、`HTTPS_PROXY`、`NO_PROXY` 及 CGI 状态；代理函数
+仍对每次请求和重定向 URL 重新求值。显式 `NEXTTRACE_PROXY` 固定使用指定代理。
+FastIP 仅用于初始 endpoint 的直连场景；失败时回到该请求捕获的 DNS policy
+Dialer，不读取后来变化的全局 resolver。TLS SNI 保持 endpoint host。
+
+### Geo DNS scope
+
+`GeoDNSPolicy` 是规范化、可比较的值快照。空 resolver scope 与非空 scope 使用同一
+串行化和恢复路径；相同 resolver 允许安全嵌套，不同并发 scope 不再互相污染。
+
+### IPDB.One token
+
+首次与过期 token 刷新使用共享 singleflight。32 个同预算并发调用只进行一次认证；
+错误不缓存，token 有效期仍为 30 秒。flight 继承发起者的绝对 deadline，但不因其
+手动 cancel 中断其他 waiter；较长预算 waiter 若加入一个较短 deadline 的 flight，
+可在短 flight 超时后于自身剩余预算内重新竞争。认证与随后查询始终共享原始总预算。
+
+## Benchmark
+
+生产 provider 已从兼容构造器切换到共享构造器。下表在同一个 exact head、同一轮
+运行中，把共享 benchmark 重命名为兼容路径后交给 benchstat 比较：
+
+| Benchmark | 独立 Transport | 共享 Transport | 变化 |
+| --- | ---: | ---: | ---: |
+| client construct | 174.00 ns | 16.96 ns | -90.25% |
+| multi-client sequential | 29.42 us | 29.46 us | `~` |
+| multi-client concurrent | 72.16 us | 71.60 us | `~` |
+| construct B/op | 1,232 B | 48 B | -96.10% |
+| construct allocs/op | 6 | 1 | -83.33% |
+| concurrent B/op | 24.35 KiB | 24.37 KiB | +0.12% |
+| concurrent allocs/op | 293 | 292 | -0.34% |
+
+`~` 表示 benchstat 未确认显著差异。顺序和并发请求均未检出显著差异；并发路径
+约 0.12% 的 B/op 增量同时伴随一次分配减少。
+
+parent 与 head 的全套 benchmark 按顺序各运行 10 次。未修改的 GeoFeed、nali、
+WebSocket、协议 decoder 和 MTU decoder 同时出现方向不一致的 3% 到 13% 波动，
+而分配数全部不变，因此这些未修改路径不作 PR-2 归因。最终 `dfd0fb6` focused
+复测还直接比较既有独立构造器：parent 到 head 的 construct 为 228.8 ns ->
+174.0 ns（-23.93%）、1,680 B -> 1,232 B（-26.67%）、7 -> 6 allocs；
+multi-client sequential 为 29.55 us -> 29.42 us，concurrent 为 71.52 us ->
+72.16 us，两项均无显著差异。既有 API 的请求性能未检出显著回退，构造开销降低。
+
+## Profile
+
+`MultiClientConcurrent` 分别以 `-benchtime=30s` 采集 CPU 与 heap profile：
+
+| 指标 | parent 独立 Transport | head 共享 Transport |
+| --- | ---: | ---: |
+| benchmark | 75.991 us | 74.517 us |
+| 分配 | 24,899 B/op | 24,926 B/op |
+| 分配次数 | 293 allocs/op | 292 allocs/op |
+
+CPU profile 两侧结构一致：`syscall.rawsyscalln` 分别占 42.09% 与 42.51%，
+`pthread_cond_wait` 15.34% 与 15.43%，`kevent` 13.75% 与 13.31%。heap profile
+中 `readMIMEHeader` 分别占 16.30% 与 16.40%，`NewRequestWithContext` 占
+5.66% 与 5.75%，Transport `getConn` 占 5.68% 与 5.31%。两侧累计 alloc space
+不直接比较；每次迭代分配和热点比例未出现结构性回退。
+
+## 产物大小
+
+产物使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`；Darwin 另加
+`-macos=13.0`。本轮不改变 flavor 依赖边界。
+
+### Darwin arm64，未压缩
+
+| Flavor | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,010,818 B | 30,010,850 B | +32 B / +0.000107% |
+| nexttrace-tiny | 10,934,146 B | 10,934,162 B | +16 B / +0.000146% |
+| ntr | 10,934,146 B | 10,934,162 B | +16 B / +0.000146% |
+
+### Linux arm64，未压缩 / UPX `-9`
+
+| Flavor | parent | head | 未压缩变化 | UPX 变化 |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 29,622,396 / 9,686,712 B | 29,687,932 / 9,693,332 B | +0.221% | +0.068% |
+| nexttrace-tiny | 10,879,100 / 4,068,500 B | 10,879,100 / 4,074,040 B | 0.000% | +0.136% |
+| ntr | 10,879,100 / 4,068,396 B | 10,879,100 / 4,073,952 B | 0.000% | +0.137% |
+
+Linux full 增加约 64 KiB，tiny/ntr 未压缩产物未观察到体积增加；现有数据不对
+链接器裁剪和代码布局作单一因果归因。三种 flavor 的现有依赖边界未扩大。压缩大小
+会受符号和代码布局影响，不单独作为运行时回退判据。
+
+## 验证
+
+除完整包测试外，新增回归覆盖：
+
+- 100 次顺序请求，以及 100 轮、每轮 4 个并发请求的连接复用上限。
+- 坏/好地址 fallback 顺序、TLS SNI、HTTP proxy 子进程和真实 HTTPS CONNECT。
+- 重定向逐 URL 代理判定、`NO_PROXY`、完整代理配置 identity 和显式代理。
+- dial、response header、body read 的 request cancellation。
+- 32 项 FIFO、命中不刷新顺序、淘汰后关闭空闲连接。
+- 空 resolver scope、相同策略嵌套、不同并发 scope 以及 race。
+- NextTrace API v4 并发 Transport cache 和 FastIP fallback。
+- IPDB.One 首次/过期 32 并发 singleflight、错误重试、TTL 和长短预算竞争。
+
+head 通过默认 JSON 与 `nojsonv2` 完整测试、race、build、vet、full/tiny/ntr、
+Web 前端 Node 测试、module verify/tidy diff，以及 Linux、Windows、Darwin 现有
+构建矩阵。Darwin release-style 三 flavor 的 `LC_BUILD_VERSION` 继续为
+`minos 13.0`。
+
+相同 `nojsonv2` 完整测试的墙钟耗时为 parent 19.67 秒、head 25.63 秒；head 的
+默认 JSON 完整测试为 19.53 秒，race 为 23.35 秒。单次测试耗时只用于保存 exact
+head 门禁成本，不作性能结论。
+
+## 平台风险与回退
+
+共享 Transport 会延长空闲连接和 DNS 策略对象的生命周期。普通非默认策略池与
+NextTrace API v4 策略池各有 32 项硬上限，默认策略另由 `OnceValue` 持有；淘汰会
+主动关闭空闲连接。request context 仍是总预算；预算未耗尽且所有地址均失败时返回
+最后一个连接错误，预算耗尽时返回 context 错误。代理、HTTP/2、TLS 和系统证书
+行为继承标准 Transport。
+
+如需回退，可按逆序撤销五个实现提交；旧导出 API 未删除或改签名，无需迁移配置、
+缓存、JSON 或持久数据。原始 benchmark、profile 和二进制留作 CI/local artifact，
+不提交仓库。

--- a/ipgeo/chunzhen.go
+++ b/ipgeo/chunzhen.go
@@ -14,11 +14,12 @@ import (
 
 func Chunzhen(ip string, timeout time.Duration, _ string, _ bool) (*IPGeoData, error) {
 	url := util.GetEnvDefault("NEXTTRACE_CHUNZHENURL", "http://127.0.0.1:2060") + "?ip=" + ip
-	client := util.NewGeoHTTPClient(timeout)
-	req, err := http.NewRequest("GET", url, nil)
+	client := util.NewSharedGeoHTTPClient(timeout)
+	req, cancel, err := newGeoRequest(http.MethodGet, url, timeout)
 	if err != nil {
 		return &IPGeoData{}, fmt.Errorf("chunzhen: failed to create request: %w", err)
 	}
+	defer cancel()
 	content, err := client.Do(req)
 	if err != nil {
 		log.Println("纯真 请求超时(2s)，请切换其他API使用")

--- a/ipgeo/http_request.go
+++ b/ipgeo/http_request.go
@@ -1,0 +1,26 @@
+package ipgeo
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+func newGeoRequest(method, url string, timeout time.Duration) (*http.Request, context.CancelFunc, error) {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	return req, cancel, nil
+}

--- a/ipgeo/http_request_test.go
+++ b/ipgeo/http_request_test.go
@@ -1,0 +1,49 @@
+package ipgeo
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewGeoRequestAppliesTimeoutToContext(t *testing.T) {
+	const timeout = 5 * time.Second
+	started := time.Now()
+	req, cancel, err := newGeoRequest(http.MethodGet, "https://example.com/geo", timeout)
+	if err != nil {
+		t.Fatalf("newGeoRequest() error = %v", err)
+	}
+	defer cancel()
+
+	deadline, ok := req.Context().Deadline()
+	if !ok {
+		t.Fatal("request context has no deadline")
+	}
+	if remaining := deadline.Sub(started); remaining < timeout-time.Second || remaining > timeout+time.Second {
+		t.Fatalf("request deadline remaining = %v, want approximately %v", remaining, timeout)
+	}
+
+	cancel()
+	select {
+	case <-req.Context().Done():
+		if req.Context().Err() != context.Canceled {
+			t.Fatalf("request context error = %v, want context.Canceled", req.Context().Err())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request context was not canceled")
+	}
+}
+
+func TestNewGeoRequestWithoutPositiveTimeoutHasNoDeadline(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		req, cancel, err := newGeoRequest(http.MethodGet, "https://example.com/geo", timeout)
+		if err != nil {
+			t.Fatalf("newGeoRequest(%v) error = %v", timeout, err)
+		}
+		cancel()
+		if _, ok := req.Context().Deadline(); ok {
+			t.Fatalf("newGeoRequest(%v) unexpectedly set a deadline", timeout)
+		}
+	}
+}

--- a/ipgeo/ipapicom.go
+++ b/ipgeo/ipapicom.go
@@ -17,11 +17,12 @@ import (
 
 func IPApiCom(ip string, timeout time.Duration, _ string, _ bool) (*IPGeoData, error) {
 	url := token.BaseOrDefault("http://ip-api.com/json/") + ip + "?fields=status,message,country,regionName,city,isp,district,as,lat,lon"
-	client := util.NewGeoHTTPClient(timeout)
-	req, err := http.NewRequest("GET", url, nil)
+	client := util.NewSharedGeoHTTPClient(timeout)
+	req, cancel, err := newGeoRequest(http.MethodGet, url, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("ip-api.com: failed to create request: %w", err)
 	}
+	defer cancel()
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0")
 	content, err := client.Do(req)
 	if err != nil {

--- a/ipgeo/ipdbone.go
+++ b/ipgeo/ipdbone.go
@@ -1,6 +1,7 @@
 package ipgeo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,9 +11,15 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/nxtrace/NTrace-core/config"
 	"github.com/nxtrace/NTrace-core/util"
+)
+
+const (
+	ipdbOneDefaultTimeout = 3 * time.Second
+	ipdbOneTokenTTL       = 30 * time.Second
 )
 
 // LangMap shows language mapping for IPDB.One API
@@ -66,41 +73,70 @@ func (c *IPDBOneTokenCache) SetToken(token string, expiresIn time.Duration) {
 
 // IPDBOneClient handles communication with IPDB.One API
 type IPDBOneClient struct {
-	config     *IPDBOneConfig
-	tokenCache *IPDBOneTokenCache
-	tokenInit  *sync.Once
-	httpClient *http.Client
+	config          *IPDBOneConfig
+	tokenCache      *IPDBOneTokenCache
+	tokenGroup      *singleflight.Group
+	geoDNSPolicy    util.GeoDNSPolicy
+	tokenHTTPClient *http.Client
+	httpClient      *http.Client
+}
+
+type ipdbOneTokenFlightDeadlineError struct {
+	err      error
+	deadline time.Time
+}
+
+func (e *ipdbOneTokenFlightDeadlineError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ipdbOneTokenFlightDeadlineError) Unwrap() error {
+	return e.err
 }
 
 // NewIPDBOneClient creates a new client for IPDB.One with default configuration
 func NewIPDBOneClient() *IPDBOneClient {
+	policy := util.CurrentGeoDNSPolicy()
+	httpClient := util.NewSharedGeoHTTPClientWithPolicy(ipdbOneDefaultTimeout, policy)
 	return &IPDBOneClient{
-		config:     GetDefaultConfig(),
-		tokenCache: &IPDBOneTokenCache{},
-		tokenInit:  &sync.Once{},
-		httpClient: util.NewGeoHTTPClient(3 * time.Second),
+		config:          GetDefaultConfig(),
+		tokenCache:      &IPDBOneTokenCache{},
+		tokenGroup:      &singleflight.Group{},
+		geoDNSPolicy:    policy,
+		tokenHTTPClient: util.NewSharedGeoHTTPClientWithPolicy(0, policy),
+		httpClient:      httpClient,
 	}
 }
 
 func (c *IPDBOneClient) cloneWithTimeout(timeout time.Duration) *IPDBOneClient {
-	if c == nil || timeout <= 0 {
+	if c == nil {
 		return c
 	}
+	policy := util.CurrentGeoDNSPolicy()
+	if timeout <= 0 {
+		timeout = c.httpClient.Timeout
+	}
+	tokenHTTPClient := c.tokenHTTPClient
+	if policy != c.geoDNSPolicy {
+		tokenHTTPClient = util.NewSharedGeoHTTPClientWithPolicy(0, policy)
+	}
 	return &IPDBOneClient{
-		config:     c.config,
-		tokenCache: c.tokenCache,
-		tokenInit:  c.tokenInit,
-		httpClient: util.NewGeoHTTPClient(timeout),
+		config:          c.config,
+		tokenCache:      c.tokenCache,
+		tokenGroup:      c.tokenGroup,
+		geoDNSPolicy:    policy,
+		tokenHTTPClient: tokenHTTPClient,
+		httpClient:      util.NewSharedGeoHTTPClientWithPolicy(timeout, policy),
 	}
 }
 
 // fetchToken requests a new authentication token from the API
-func (c *IPDBOneClient) fetchToken() error {
+func (c *IPDBOneClient) fetchToken(ctx context.Context) (string, error) {
 	authURL := c.config.BaseURL + "/auth/requestToken/query"
 
-	req, err := http.NewRequest("GET", authURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -108,65 +144,106 @@ func (c *IPDBOneClient) fetchToken() error {
 	req.Header.Set("x-api-id", c.config.ApiID)
 	req.Header.Set("x-api-key", c.config.ApiKey)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.tokenHTTPClient.Do(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	statusCode := gjson.Get(string(body), "code").Int()
 	statusMessage := gjson.Get(string(body), "message").String()
 
 	if statusCode != 200 {
-		return errors.New("failed to authenticate: " + statusMessage)
+		return "", errors.New("failed to authenticate: " + statusMessage)
 	}
 
 	token := gjson.Get(string(body), "data.token").String()
 	if token == "" {
-		return errors.New("authentication failed: empty token received")
+		return "", errors.New("authentication failed: empty token received")
 	}
 
 	// Cache token with a 30-second expiration
-	c.tokenCache.SetToken(token, 30*time.Second)
-	return nil
+	c.tokenCache.SetToken(token, ipdbOneTokenTTL)
+	return token, nil
 }
 
 // ensureToken makes sure a valid token is available, fetching a new one if needed
-func (c *IPDBOneClient) ensureToken() error {
-	var initErr error
-
+func (c *IPDBOneClient) ensureToken(ctx context.Context) (string, error) {
 	// Ensure API credentials are set
 	if c.config.ApiID == "" || c.config.ApiKey == "" {
-		return errors.New("api id or api key is not set")
+		return "", errors.New("api id or api key is not set")
 	}
 
-	// Initialize token the first time this is called
-	c.tokenInit.Do(func() {
-		initErr = c.fetchToken()
-	})
-
-	if initErr != nil {
-		return initErr
+	if token := c.tokenCache.GetToken(); token != "" {
+		return token, nil
 	}
 
-	// If token expired or not available, get a new one
-	if c.tokenCache.GetToken() == "" {
-		return c.fetchToken()
-	}
+	for {
+		resultCh := c.tokenGroup.DoChan("token", func() (any, error) {
+			fetchCtx, cancel := c.tokenFlightContext(ctx)
+			defer cancel()
+			token, err := c.fetchTokenIfNeeded(fetchCtx)
+			if err != nil && errors.Is(fetchCtx.Err(), context.DeadlineExceeded) {
+				deadline, _ := fetchCtx.Deadline()
+				return "", &ipdbOneTokenFlightDeadlineError{err: err, deadline: deadline}
+			}
+			return token, err
+		})
 
-	return nil
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case result := <-resultCh:
+			if result.Err != nil {
+				if c.shouldRetryTokenFlight(ctx, result.Err) {
+					continue
+				}
+				return "", result.Err
+			}
+			return result.Val.(string), nil
+		}
+	}
+}
+
+func (c *IPDBOneClient) fetchTokenIfNeeded(ctx context.Context) (string, error) {
+	if token := c.tokenCache.GetToken(); token != "" {
+		return token, nil
+	}
+	return c.fetchToken(ctx)
+}
+
+func (c *IPDBOneClient) tokenFlightContext(waiter context.Context) (context.Context, context.CancelFunc) {
+	if deadline, ok := waiter.Deadline(); ok {
+		return context.WithDeadline(context.WithoutCancel(waiter), deadline)
+	}
+	return context.WithTimeout(context.WithoutCancel(waiter), ipdbOneDefaultTimeout)
+}
+
+func (c *IPDBOneClient) shouldRetryTokenFlight(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	var flightErr *ipdbOneTokenFlightDeadlineError
+	if !errors.As(err, &flightErr) {
+		return false
+	}
+	deadline, ok := ctx.Deadline()
+	return ok && deadline.After(flightErr.deadline)
 }
 
 // LookupIP queries the IP information from IPDB.One
 func (c *IPDBOneClient) LookupIP(ip string, lang string) (*IPGeoData, error) {
+	ctx, cancel := c.timeoutContext()
+	defer cancel()
 
 	// Ensure we have a valid token
-	if err := c.ensureToken(); err != nil {
+	token, err := c.ensureToken(ctx)
+	if err != nil {
 		return &IPGeoData{}, fmt.Errorf("ipdbone auth: %w", err)
 	}
 
@@ -179,14 +256,14 @@ func (c *IPDBOneClient) LookupIP(ip string, lang string) (*IPGeoData, error) {
 	// Query the IP information
 	queryURL := c.config.BaseURL + "/query/" + ip + "?lang=" + langCode
 
-	req, err := http.NewRequest("GET", queryURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "NextTrace/"+config.Version)
-	req.Header.Set("Authorization", "Bearer "+c.tokenCache.GetToken())
+	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -205,6 +282,13 @@ func (c *IPDBOneClient) LookupIP(ip string, lang string) (*IPGeoData, error) {
 	}
 
 	return parseIPDBOneResponse(ip, body)
+}
+
+func (c *IPDBOneClient) timeoutContext() (context.Context, context.CancelFunc) {
+	if timeout := c.httpClient.Timeout; timeout > 0 {
+		return context.WithTimeout(context.Background(), timeout)
+	}
+	return context.WithCancel(context.Background())
 }
 
 // parseIPDBOneResponse converts the API response to an IPGeoData struct
@@ -269,9 +353,6 @@ var defaultClient = NewIPDBOneClient()
 
 // IPDBOne looks up IP information from IPDB.One (maintains backward compatibility)
 func IPDBOne(ip string, timeout time.Duration, lang string, _ bool) (*IPGeoData, error) {
-	client := defaultClient
-	if timeout > 0 {
-		client = defaultClient.cloneWithTimeout(timeout)
-	}
+	client := defaultClient.cloneWithTimeout(timeout)
 	return client.LookupIP(ip, lang)
 }

--- a/ipgeo/ipdbone.go
+++ b/ipgeo/ipdbone.go
@@ -56,7 +56,7 @@ func (c *IPDBOneTokenCache) GetToken() string {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
-	if c.token == "" || time.Now().After(c.expiresAt) {
+	if c.token == "" || !time.Now().Before(c.expiresAt) {
 		return ""
 	}
 	return c.token

--- a/ipgeo/ipdbone_test.go
+++ b/ipgeo/ipdbone_test.go
@@ -1,0 +1,421 @@
+package ipgeo
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type ipdbOneRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f ipdbOneRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type ipdbOneTokenResult struct {
+	token string
+	err   error
+}
+
+func newIPDBOneTestClient(timeout time.Duration, transport http.RoundTripper) *IPDBOneClient {
+	client := NewIPDBOneClient()
+	client.config = &IPDBOneConfig{
+		BaseURL: "https://ipdb-one.test",
+		ApiID:   "api-id",
+		ApiKey:  "api-key",
+	}
+	client.tokenHTTPClient = &http.Client{Transport: transport}
+	client.httpClient = &http.Client{Transport: transport, Timeout: timeout}
+	return client
+}
+
+func ipdbOneJSONResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func startIPDBOneTokenBatch(client *IPDBOneClient, count int) <-chan []ipdbOneTokenResult {
+	done := make(chan []ipdbOneTokenResult, 1)
+	start := make(chan struct{})
+	results := make([]ipdbOneTokenResult, count)
+	var workers sync.WaitGroup
+	workers.Add(count)
+	for i := range count {
+		go func() {
+			defer workers.Done()
+			<-start
+			results[i].token, results[i].err = client.ensureToken(context.Background())
+		}()
+	}
+	close(start)
+	go func() {
+		workers.Wait()
+		done <- results
+	}()
+	return done
+}
+
+func waitIPDBOneTokenBatch(t *testing.T, done <-chan []ipdbOneTokenResult) []ipdbOneTokenResult {
+	t.Helper()
+	select {
+	case results := <-done:
+		return results
+	case <-time.After(2 * time.Second):
+		t.Fatal("token batch did not complete")
+		return nil
+	}
+}
+
+func TestIPDBOneTokenFetchSingleflight(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		expiredSeed bool
+	}{
+		{name: "first fetch"},
+		{name: "expired refresh", expiredSeed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var authCalls atomic.Int32
+			authStarted := make(chan struct{}, 1)
+			releaseAuth := make(chan struct{})
+			client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				authCalls.Add(1)
+				select {
+				case authStarted <- struct{}{}:
+				default:
+				}
+				<-releaseAuth
+				return ipdbOneJSONResponse(req, `{"code":200,"data":{"token":"shared-token"}}`), nil
+			}))
+			if tc.expiredSeed {
+				client.tokenCache.SetToken("expired-token", -time.Second)
+			}
+
+			done := startIPDBOneTokenBatch(client, 32)
+			select {
+			case <-authStarted:
+			case <-time.After(time.Second):
+				t.Fatal("authentication request did not start")
+			}
+			time.Sleep(20 * time.Millisecond)
+			close(releaseAuth)
+
+			for i, result := range waitIPDBOneTokenBatch(t, done) {
+				if result.err != nil || result.token != "shared-token" {
+					t.Fatalf("result[%d] = (%q, %v), want shared-token, nil", i, result.token, result.err)
+				}
+			}
+			if got := authCalls.Load(); got != 1 {
+				t.Fatalf("authentication requests = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestIPDBOneTokenFetchErrorIsSharedAndRetryable(t *testing.T) {
+	var (
+		authCalls atomic.Int32
+		retryOK   atomic.Bool
+	)
+	authStarted := make(chan struct{}, 1)
+	releaseAuth := make(chan struct{})
+	client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		authCalls.Add(1)
+		if retryOK.Load() {
+			return ipdbOneJSONResponse(req, `{"code":200,"data":{"token":"retry-token"}}`), nil
+		}
+		select {
+		case authStarted <- struct{}{}:
+		default:
+		}
+		<-releaseAuth
+		return ipdbOneJSONResponse(req, `{"code":500,"message":"temporary auth failure"}`), nil
+	}))
+
+	done := startIPDBOneTokenBatch(client, 24)
+	select {
+	case <-authStarted:
+	case <-time.After(time.Second):
+		t.Fatal("authentication request did not start")
+	}
+	time.Sleep(20 * time.Millisecond)
+	close(releaseAuth)
+
+	results := waitIPDBOneTokenBatch(t, done)
+	firstErr := results[0].err
+	if firstErr == nil || firstErr.Error() != "failed to authenticate: temporary auth failure" {
+		t.Fatalf("first error = %v", firstErr)
+	}
+	for i, result := range results {
+		if result.token != "" || result.err != firstErr {
+			t.Fatalf("result[%d] = (%q, %v), want the original shared error %v", i, result.token, result.err, firstErr)
+		}
+	}
+	if got := authCalls.Load(); got != 1 {
+		t.Fatalf("authentication requests after failed batch = %d, want 1", got)
+	}
+	if token := client.tokenCache.GetToken(); token != "" {
+		t.Fatalf("cached token after failure = %q, want empty", token)
+	}
+
+	retryOK.Store(true)
+	token, err := client.ensureToken(context.Background())
+	if err != nil || token != "retry-token" {
+		t.Fatalf("retry = (%q, %v), want retry-token, nil", token, err)
+	}
+	if got := authCalls.Load(); got != 2 {
+		t.Fatalf("authentication requests after retry = %d, want 2", got)
+	}
+}
+
+func TestIPDBOneTokenFetchRejectsEmptyToken(t *testing.T) {
+	client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return ipdbOneJSONResponse(req, `{"code":200,"data":{"token":""}}`), nil
+	}))
+
+	token, err := client.ensureToken(context.Background())
+	if token != "" || err == nil || err.Error() != "authentication failed: empty token received" {
+		t.Fatalf("ensureToken() = (%q, %v), want empty token error", token, err)
+	}
+	if cached := client.tokenCache.GetToken(); cached != "" {
+		t.Fatalf("cached token = %q, want empty", cached)
+	}
+}
+
+func TestIPDBOneTokenCacheExpiration(t *testing.T) {
+	cache := &IPDBOneTokenCache{}
+	cache.SetToken("valid-token", time.Second)
+	if got := cache.GetToken(); got != "valid-token" {
+		t.Fatalf("valid cached token = %q, want valid-token", got)
+	}
+
+	cache.SetToken("expired-token", 0)
+	if got := cache.GetToken(); got != "" {
+		t.Fatalf("zero-TTL cached token = %q, want empty", got)
+	}
+}
+
+func TestIPDBOneTokenFlightRechecksCache(t *testing.T) {
+	var requests atomic.Int32
+	client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return nil, errors.New("unexpected request")
+	}))
+	client.tokenCache.SetToken("cached-by-peer", time.Second)
+
+	token, err := client.fetchTokenIfNeeded(context.Background())
+	if err != nil || token != "cached-by-peer" {
+		t.Fatalf("fetchTokenIfNeeded() = (%q, %v), want cached-by-peer, nil", token, err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("requests = %d, want 0", got)
+	}
+}
+
+func TestIPDBOneTokenRequiresCredentials(t *testing.T) {
+	var requests atomic.Int32
+	client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return nil, errors.New("unexpected request")
+	}))
+	client.config.ApiID = ""
+
+	token, err := client.ensureToken(context.Background())
+	if token != "" || err == nil || err.Error() != "api id or api key is not set" {
+		t.Fatalf("ensureToken() = (%q, %v), want missing credentials error", token, err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("requests = %d, want 0", got)
+	}
+}
+
+func TestIPDBOneTokenWaiterCancellationDoesNotCancelSharedFetch(t *testing.T) {
+	var authCalls atomic.Int32
+	authStarted := make(chan struct{}, 1)
+	releaseAuth := make(chan struct{})
+	client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		authCalls.Add(1)
+		select {
+		case authStarted <- struct{}{}:
+		default:
+		}
+		select {
+		case <-releaseAuth:
+			return ipdbOneJSONResponse(req, `{"code":200,"data":{"token":"shared-token"}}`), nil
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}))
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan ipdbOneTokenResult, 1)
+	go func() {
+		token, err := client.ensureToken(leaderCtx)
+		leaderDone <- ipdbOneTokenResult{token: token, err: err}
+	}()
+	select {
+	case <-authStarted:
+	case <-time.After(time.Second):
+		t.Fatal("authentication request did not start")
+	}
+
+	waiterDone := make(chan ipdbOneTokenResult, 1)
+	go func() {
+		token, err := client.ensureToken(context.Background())
+		waiterDone <- ipdbOneTokenResult{token: token, err: err}
+	}()
+	time.Sleep(10 * time.Millisecond)
+	cancelLeader()
+
+	select {
+	case result := <-leaderDone:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("canceled leader error = %v, want context.Canceled", result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled leader did not return")
+	}
+
+	close(releaseAuth)
+	select {
+	case result := <-waiterDone:
+		if result.err != nil || result.token != "shared-token" {
+			t.Fatalf("waiter = (%q, %v), want shared-token, nil", result.token, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waiter did not receive shared token")
+	}
+	if got := authCalls.Load(); got != 1 {
+		t.Fatalf("authentication requests = %d, want 1", got)
+	}
+}
+
+func TestIPDBOneTokenFlightDoesNotInheritShortWaiterTimeout(t *testing.T) {
+	var authCalls atomic.Int32
+	authStarted := make(chan struct{}, 1)
+	client := newIPDBOneTestClient(time.Second, ipdbOneRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		authCalls.Add(1)
+		select {
+		case authStarted <- struct{}{}:
+		default:
+		}
+		timer := time.NewTimer(150 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return ipdbOneJSONResponse(req, `{"code":200,"data":{"token":"shared-token"}}`), nil
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}))
+	shortClient := client.cloneWithTimeout(50 * time.Millisecond)
+	longClient := client.cloneWithTimeout(time.Second)
+
+	shortCtx, cancelShort := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelShort()
+	shortDone := make(chan ipdbOneTokenResult, 1)
+	go func() {
+		token, err := shortClient.ensureToken(shortCtx)
+		shortDone <- ipdbOneTokenResult{token: token, err: err}
+	}()
+	select {
+	case <-authStarted:
+	case <-time.After(time.Second):
+		t.Fatal("authentication request did not start")
+	}
+
+	longCtx, cancelLong := context.WithTimeout(context.Background(), time.Second)
+	defer cancelLong()
+	longDone := make(chan ipdbOneTokenResult, 1)
+	go func() {
+		token, err := longClient.ensureToken(longCtx)
+		longDone <- ipdbOneTokenResult{token: token, err: err}
+	}()
+
+	select {
+	case result := <-shortDone:
+		if !errors.Is(result.err, context.DeadlineExceeded) {
+			t.Fatalf("short waiter error = %v, want context deadline exceeded", result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("short waiter did not honor its timeout")
+	}
+	select {
+	case result := <-longDone:
+		if result.err != nil || result.token != "shared-token" {
+			t.Fatalf("long waiter = (%q, %v), want shared-token, nil", result.token, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("long waiter inherited the short timeout")
+	}
+	if got := authCalls.Load(); got != 2 {
+		t.Fatalf("authentication requests = %d, want 2 after the short flight expires and the long waiter retries", got)
+	}
+}
+
+func TestIPDBOneCloneSharesTokenState(t *testing.T) {
+	client := NewIPDBOneClient()
+	clone := client.cloneWithTimeout(5 * time.Second)
+	if clone.tokenCache != client.tokenCache {
+		t.Fatal("clone does not share token cache")
+	}
+	if clone.tokenGroup != client.tokenGroup {
+		t.Fatal("clone does not share token singleflight group")
+	}
+	if clone.tokenHTTPClient != client.tokenHTTPClient {
+		t.Fatal("clone does not share the stable token HTTP client")
+	}
+	client.tokenCache.SetToken("cached-token", 30*time.Second)
+	if got := clone.tokenCache.GetToken(); got != "cached-token" {
+		t.Fatalf("clone cached token = %q, want cached-token", got)
+	}
+}
+
+func TestIPDBOneLookupUsesTokenAndTotalTimeoutContext(t *testing.T) {
+	const timeout = 2 * time.Second
+	var (
+		queryAuthorization string
+		authDeadline       time.Time
+		queryDeadline      time.Time
+	)
+	client := newIPDBOneTestClient(timeout, ipdbOneRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/auth/requestToken/query":
+			authDeadline, _ = req.Context().Deadline()
+			return ipdbOneJSONResponse(req, `{"code":200,"data":{"token":"request-token"}}`), nil
+		case "/query/1.1.1.1":
+			queryAuthorization = req.Header.Get("Authorization")
+			queryDeadline, _ = req.Context().Deadline()
+			return ipdbOneJSONResponse(req, `{"code":200,"data":{"geo":{"country":"US"}}}`), nil
+		default:
+			return nil, errors.New("unexpected IPDB.One request path: " + req.URL.Path)
+		}
+	}))
+
+	result, err := client.LookupIP("1.1.1.1", "en")
+	if err != nil {
+		t.Fatalf("LookupIP() error = %v", err)
+	}
+	if result.Country != "US" {
+		t.Fatalf("LookupIP() country = %q, want US", result.Country)
+	}
+	if queryAuthorization != "Bearer request-token" {
+		t.Fatalf("Authorization = %q, want Bearer request-token", queryAuthorization)
+	}
+	if authDeadline.IsZero() || queryDeadline.IsZero() {
+		t.Fatalf("request deadlines = (%v, %v), want both set", authDeadline, queryDeadline)
+	}
+	if !authDeadline.Equal(queryDeadline) {
+		t.Fatalf("auth deadline = %v, query deadline = %v; want one total budget", authDeadline, queryDeadline)
+	}
+}

--- a/ipgeo/ipgeo.go
+++ b/ipgeo/ipgeo.go
@@ -80,7 +80,7 @@ func GetSource(s string) Source {
 func GetSourceWithGeoDNS(s string, dotServer string) Source {
 	base := GetSource(s)
 	dotServer = strings.TrimSpace(strings.ToLower(dotServer))
-	if base == nil || dotServer == "" {
+	if base == nil {
 		return base
 	}
 	return func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {

--- a/ipgeo/ipgeo_test.go
+++ b/ipgeo/ipgeo_test.go
@@ -1,10 +1,12 @@
 package ipgeo
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -93,6 +95,7 @@ func TestGetSourceUsesNextTraceAPIV4WhenTokenConfigured(t *testing.T) {
 }
 
 func TestDeprecatedNextTraceAPIWrappers(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
 	isolateNextTraceAPIV4TokenFiles(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "")
 	assert.Equal(
@@ -111,11 +114,9 @@ func TestDeprecatedNextTraceAPIWrappers(t *testing.T) {
 	assert.EqualError(t, gotErr, wantErr.Error())
 
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
 	t.Cleanup(func() {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -123,12 +124,7 @@ func TestDeprecatedNextTraceAPIWrappers(t *testing.T) {
 	}))
 	defer srv.Close()
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
-		client := srv.Client()
-		client.Timeout = timeout
-		return client
-	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	wantV4, err := NextTraceAPIV4GeoIP("198.51.100.1", time.Second, "en", false)
 	require.NoError(t, err)
@@ -159,4 +155,80 @@ func TestDisableGeoIP(t *testing.T) {
 	res, err := disableGeoIP("1.1.1.1", time.Second, "en", false)
 	require.NoError(t, err)
 	assert.Equal(t, &IPGeoData{}, res)
+}
+
+func TestGetSourceWithGeoDNSEmptyResolverUsesIsolatedScope(t *testing.T) {
+	util.SetGeoDNSResolver("google")
+	util.SetGeoDNSFallback(false)
+	defer func() {
+		util.SetGeoDNSResolver("")
+		util.SetGeoDNSFallback(true)
+	}()
+
+	dotEntered := make(chan struct{})
+	releaseDot := make(chan struct{})
+	dotDone := make(chan struct{})
+	go func() {
+		defer close(dotDone)
+		_, _ = util.WithGeoDNSResolver("cloudflare", func() (struct{}, error) {
+			close(dotEntered)
+			<-releaseDot
+			return struct{}{}, nil
+		})
+	}()
+	<-dotEntered
+
+	sourceStarted := make(chan struct{})
+	sourceDone := make(chan error, 1)
+	go observeEmptyGeoSourceScope(GetSourceWithGeoDNS("disable-geoip", ""), sourceStarted, sourceDone)
+	<-sourceStarted
+
+	blocked, completed, earlyErr := waitForGeoSourceScopeBlock(sourceDone)
+	if completed {
+		close(releaseDot)
+		<-dotDone
+		t.Fatalf("empty-resolver source bypassed active scope: %v", earlyErr)
+	}
+	if !blocked {
+		close(releaseDot)
+		<-dotDone
+		t.Fatal("empty-resolver source never reached the active scope lock")
+	}
+
+	close(releaseDot)
+	<-dotDone
+	select {
+	case err := <-sourceDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("empty-resolver source did not resume after active scope exited")
+	}
+}
+
+//go:noinline
+func observeEmptyGeoSourceScope(source Source, started chan<- struct{}, result chan<- error) {
+	close(started)
+	_, err := source("1.1.1.1", time.Second, "en", false)
+	result <- err
+}
+
+func waitForGeoSourceScopeBlock(result <-chan error) (blocked bool, completed bool, err error) {
+	deadline := time.Now().Add(2 * time.Second)
+	stack := make([]byte, 1<<20)
+	for time.Now().Before(deadline) {
+		select {
+		case err = <-result:
+			return false, true, err
+		default:
+		}
+		n := runtime.Stack(stack, true)
+		for _, goroutine := range bytes.Split(stack[:n], []byte("\n\n")) {
+			if bytes.Contains(goroutine, []byte("observeEmptyGeoSourceScope")) &&
+				bytes.Contains(goroutine, []byte("[sync.Mutex.Lock")) {
+				return true, false, nil
+			}
+		}
+		runtime.Gosched()
+	}
+	return false, false, nil
 }

--- a/ipgeo/ipgeo_test.go
+++ b/ipgeo/ipgeo_test.go
@@ -183,7 +183,7 @@ func TestGetSourceWithGeoDNSEmptyResolverUsesIsolatedScope(t *testing.T) {
 	go observeEmptyGeoSourceScope(GetSourceWithGeoDNS("disable-geoip", ""), sourceStarted, sourceDone)
 	<-sourceStarted
 
-	blocked, completed, earlyErr := waitForGeoSourceScopeBlock(sourceDone)
+	blocked, completed, earlyErr := waitForGeoSourceScopeBlock(t, sourceDone)
 	if completed {
 		close(releaseDot)
 		<-dotDone
@@ -212,7 +212,9 @@ func observeEmptyGeoSourceScope(source Source, started chan<- struct{}, result c
 	result <- err
 }
 
-func waitForGeoSourceScopeBlock(result <-chan error) (blocked bool, completed bool, err error) {
+func waitForGeoSourceScopeBlock(t *testing.T, result <-chan error) (blocked bool, completed bool, err error) {
+	t.Helper()
+	const maxStackDumpSize = 16 << 20
 	deadline := time.Now().Add(2 * time.Second)
 	stack := make([]byte, 1<<20)
 	for time.Now().Before(deadline) {
@@ -222,6 +224,14 @@ func waitForGeoSourceScopeBlock(result <-chan error) (blocked bool, completed bo
 		default:
 		}
 		n := runtime.Stack(stack, true)
+		for n == len(stack) {
+			if len(stack) >= maxStackDumpSize {
+				t.Errorf("goroutine stack dump exceeded %d bytes", maxStackDumpSize)
+				return false, false, err
+			}
+			stack = make([]byte, min(len(stack)*2, maxStackDumpSize))
+			n = runtime.Stack(stack, true)
+		}
 		for _, goroutine := range bytes.Split(stack[:n], []byte("\n\n")) {
 			if bytes.Contains(goroutine, []byte("observeEmptyGeoSourceScope")) &&
 				bytes.Contains(goroutine, []byte("[sync.Mutex.Lock")) {

--- a/ipgeo/ipinfo.go
+++ b/ipgeo/ipinfo.go
@@ -2,6 +2,7 @@ package ipgeo
 
 import (
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -13,9 +14,13 @@ import (
 
 func IPInfo(ip string, timeout time.Duration, _ string, _ bool) (*IPGeoData, error) {
 	url := token.BaseOrDefault("http://ipinfo.io/") + ip + "?token=" + token.ipinfo
-	client := util.NewGeoHTTPClient(timeout)
-	resp, err := client.Get(url)
-	//resp, err := http.Get("https://ipinfo.io/" + ip + "?token=" + token.ipinfo)
+	client := util.NewSharedGeoHTTPClient(timeout)
+	req, cancel, err := newGeoRequest(http.MethodGet, url, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/ipgeo/ipinsight.go
+++ b/ipgeo/ipinsight.go
@@ -2,6 +2,7 @@ package ipgeo
 
 import (
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -10,8 +11,13 @@ import (
 )
 
 func IPInSight(ip string, timeout time.Duration, _ string, _ bool) (*IPGeoData, error) {
-	client := util.NewGeoHTTPClient(timeout)
-	resp, err := client.Get(token.BaseOrDefault("https://api.ipinsight.io/ip/") + ip + "?token=" + token.ipinsight)
+	client := util.NewSharedGeoHTTPClient(timeout)
+	req, cancel, err := newGeoRequest(http.MethodGet, token.BaseOrDefault("https://api.ipinsight.io/ip/")+ip+"?token="+token.ipinsight, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/ipgeo/ipsb.go
+++ b/ipgeo/ipsb.go
@@ -14,11 +14,12 @@ import (
 
 func IPSB(ip string, timeout time.Duration, _ string, _ bool) (*IPGeoData, error) {
 	url := token.BaseOrDefault("https://api.ip.sb/geoip/") + ip
-	client := util.NewGeoHTTPClient(timeout)
-	req, err := http.NewRequest("GET", url, nil)
+	client := util.NewSharedGeoHTTPClient(timeout)
+	req, cancel, err := newGeoRequest(http.MethodGet, url, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("ip.sb: failed to create request: %w", err)
 	}
+	defer cancel()
 	// 设置 UA，ip.sb 默认禁止 go-client User-Agent 的 api 请求
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0")
 	content, err := client.Do(req)

--- a/ipgeo/nexttrace_api_v4.go
+++ b/ipgeo/nexttrace_api_v4.go
@@ -33,23 +33,28 @@ const (
 )
 
 var (
-	nextTraceAPIV4GeoEndpoint      = "https://api.nxtrace.org/v4/ipGeo"
-	nextTraceAPIV4RetryDelays      = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
-	nextTraceAPIV4ClientCache      = make(map[nextTraceAPIV4ClientCacheKey]*NextTraceAPIV4Client)
-	nextTraceAPIV4ClientCacheOrder []nextTraceAPIV4ClientCacheKey
-	nextTraceAPIV4ClientCacheMu    sync.RWMutex
+	nextTraceAPIV4GeoEndpoint         = "https://api.nxtrace.org/v4/ipGeo"
+	nextTraceAPIV4RetryDelays         = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	nextTraceAPIV4TransportCache      = make(map[nextTraceAPIV4TransportCacheKey]*http.Transport)
+	nextTraceAPIV4TransportCacheOrder []nextTraceAPIV4TransportCacheKey
+	nextTraceAPIV4TransportCacheMu    sync.RWMutex
 )
 
-type nextTraceAPIV4HTTPClientFactoryFunc func(endpoint string, timeout time.Duration) *http.Client
+type nextTraceAPIV4TransportFactoryFunc func(endpoint string, policy util.GeoDNSPolicy, proxy nextTraceAPIV4ProxyPolicy) *http.Transport
 
-var nextTraceAPIV4HTTPClientFactory nextTraceAPIV4HTTPClientFactoryFunc = newNextTraceAPIV4HTTPClient
+var nextTraceAPIV4TransportFactory nextTraceAPIV4TransportFactoryFunc = newNextTraceAPIV4Transport
+var nextTraceAPIV4CloseIdleConnections = (*http.Transport).CloseIdleConnections
 var nextTraceAPIV4FastIPFn = util.GetFastIPWithContext
 
-type nextTraceAPIV4ClientCacheKey struct {
-	endpoint       string
-	token          string
-	timeout        time.Duration
-	geoDNSResolver string
+type nextTraceAPIV4TransportCacheKey struct {
+	endpoint      string
+	geoDNSPolicy  util.GeoDNSPolicy
+	proxyIdentity string
+}
+
+type nextTraceAPIV4ProxyPolicy struct {
+	identity string
+	proxy    func(*http.Request) (*url.URL, error)
 }
 
 type NextTraceAPIV4Quota struct {
@@ -71,7 +76,7 @@ type NextTraceAPIV4Client struct {
 func NewNextTraceAPIV4Client(endpoint string, token string, httpClient *http.Client) *NextTraceAPIV4Client {
 	endpoint = normalizeNextTraceAPIV4Endpoint(endpoint)
 	if httpClient == nil {
-		httpClient = nextTraceAPIV4HTTPClientFactory(endpoint, nextTraceAPIV4MinTimeout)
+		httpClient = defaultNextTraceAPIV4HTTPClient(endpoint, nextTraceAPIV4MinTimeout)
 	}
 	return &NextTraceAPIV4Client{
 		endpoint:   endpoint,
@@ -99,8 +104,11 @@ func NextTraceAPIV4GeoIP(ip string, timeout time.Duration, lang string, maptrace
 	timeout = normalizeNextTraceAPIV4Timeout(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	_ = prepareNextTraceAPIV4FastIP(ctx, nextTraceAPIV4GeoEndpoint, false)
-	client := cachedNextTraceAPIV4Client(nextTraceAPIV4GeoEndpoint, util.GetNextTraceAPIV4Token(), timeout)
+	endpoint := normalizeNextTraceAPIV4Endpoint(nextTraceAPIV4GeoEndpoint)
+	policy := util.CurrentGeoDNSPolicy()
+	proxy := captureNextTraceAPIV4Proxy(endpoint)
+	_ = prepareNextTraceAPIV4FastIPWithProxy(ctx, endpoint, false, proxy)
+	client := newNextTraceAPIV4ClientForPolicy(endpoint, util.GetNextTraceAPIV4Token(), timeout, policy, proxy)
 	geo, _, err := client.Lookup(ctx, ip)
 	return geo, err
 }
@@ -117,66 +125,84 @@ func LeoIPNextTraceAPIV4HTTP(ip string, timeout time.Duration, lang string, mapt
 	return NextTraceAPIV4GeoIP(ip, timeout, lang, maptrace)
 }
 
-func cachedNextTraceAPIV4Client(endpoint string, token string, timeout time.Duration) *NextTraceAPIV4Client {
-	endpoint = normalizeNextTraceAPIV4Endpoint(endpoint)
-	token = strings.TrimSpace(token)
-	timeout = normalizeNextTraceAPIV4Timeout(timeout)
-
-	key := nextTraceAPIV4ClientCacheKey{
-		endpoint:       endpoint,
-		token:          token,
-		timeout:        timeout,
-		geoDNSResolver: util.CurrentGeoDNSResolver(),
-	}
-
-	nextTraceAPIV4ClientCacheMu.RLock()
-	if client := nextTraceAPIV4ClientCache[key]; client != nil {
-		nextTraceAPIV4ClientCacheMu.RUnlock()
-		return client
-	}
-	nextTraceAPIV4ClientCacheMu.RUnlock()
-
-	nextTraceAPIV4ClientCacheMu.Lock()
-	defer nextTraceAPIV4ClientCacheMu.Unlock()
-	if client := nextTraceAPIV4ClientCache[key]; client != nil {
-		return client
-	}
-
-	client := NewNextTraceAPIV4Client(endpoint, token, nextTraceAPIV4HTTPClientFactory(endpoint, timeout))
-	nextTraceAPIV4ClientCache[key] = client
-	nextTraceAPIV4ClientCacheOrder = append(nextTraceAPIV4ClientCacheOrder, key)
-	evictNextTraceAPIV4ClientCacheLocked()
-	return client
+func newNextTraceAPIV4ClientForPolicy(endpoint string, token string, timeout time.Duration, policy util.GeoDNSPolicy, proxy nextTraceAPIV4ProxyPolicy) *NextTraceAPIV4Client {
+	return NewNextTraceAPIV4Client(endpoint, token, newNextTraceAPIV4HTTPClient(endpoint, timeout, policy, proxy))
 }
 
-func evictNextTraceAPIV4ClientCacheLocked() {
-	evictCount := len(nextTraceAPIV4ClientCache) - nextTraceAPIV4CacheMaxSize
+func defaultNextTraceAPIV4HTTPClient(endpoint string, timeout time.Duration) *http.Client {
+	policy := util.CurrentGeoDNSPolicy()
+	proxy := captureNextTraceAPIV4Proxy(endpoint)
+	return newNextTraceAPIV4HTTPClient(endpoint, timeout, policy, proxy)
+}
+
+func newNextTraceAPIV4HTTPClient(endpoint string, timeout time.Duration, policy util.GeoDNSPolicy, proxy nextTraceAPIV4ProxyPolicy) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: cachedNextTraceAPIV4Transport(endpoint, policy, proxy),
+	}
+}
+
+func cachedNextTraceAPIV4Transport(endpoint string, policy util.GeoDNSPolicy, proxy nextTraceAPIV4ProxyPolicy) *http.Transport {
+	policy = util.NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())
+	key := nextTraceAPIV4TransportCacheKey{
+		endpoint:      normalizeNextTraceAPIV4Endpoint(endpoint),
+		geoDNSPolicy:  policy,
+		proxyIdentity: proxy.identity,
+	}
+
+	nextTraceAPIV4TransportCacheMu.RLock()
+	if transport := nextTraceAPIV4TransportCache[key]; transport != nil {
+		nextTraceAPIV4TransportCacheMu.RUnlock()
+		return transport
+	}
+	nextTraceAPIV4TransportCacheMu.RUnlock()
+
+	nextTraceAPIV4TransportCacheMu.Lock()
+	if transport := nextTraceAPIV4TransportCache[key]; transport != nil {
+		nextTraceAPIV4TransportCacheMu.Unlock()
+		return transport
+	}
+
+	transport := nextTraceAPIV4TransportFactory(key.endpoint, policy, proxy)
+	nextTraceAPIV4TransportCache[key] = transport
+	nextTraceAPIV4TransportCacheOrder = append(nextTraceAPIV4TransportCacheOrder, key)
+	evicted := evictNextTraceAPIV4TransportCacheLocked()
+	nextTraceAPIV4TransportCacheMu.Unlock()
+	closeNextTraceAPIV4TransportIdleConnections(evicted)
+	return transport
+}
+
+func evictNextTraceAPIV4TransportCacheLocked() []*http.Transport {
+	evictCount := len(nextTraceAPIV4TransportCache) - nextTraceAPIV4CacheMaxSize
 	if evictCount <= 0 {
-		return
+		return nil
 	}
-	if evictCount > len(nextTraceAPIV4ClientCacheOrder) {
-		evictCount = len(nextTraceAPIV4ClientCacheOrder)
+	if evictCount > len(nextTraceAPIV4TransportCacheOrder) {
+		evictCount = len(nextTraceAPIV4TransportCacheOrder)
 	}
 
-	evictedKeys := append([]nextTraceAPIV4ClientCacheKey(nil), nextTraceAPIV4ClientCacheOrder[:evictCount]...)
-	copy(nextTraceAPIV4ClientCacheOrder, nextTraceAPIV4ClientCacheOrder[evictCount:])
-	for i := len(nextTraceAPIV4ClientCacheOrder) - evictCount; i < len(nextTraceAPIV4ClientCacheOrder); i++ {
-		nextTraceAPIV4ClientCacheOrder[i] = nextTraceAPIV4ClientCacheKey{}
+	evictedKeys := append([]nextTraceAPIV4TransportCacheKey(nil), nextTraceAPIV4TransportCacheOrder[:evictCount]...)
+	copy(nextTraceAPIV4TransportCacheOrder, nextTraceAPIV4TransportCacheOrder[evictCount:])
+	for i := len(nextTraceAPIV4TransportCacheOrder) - evictCount; i < len(nextTraceAPIV4TransportCacheOrder); i++ {
+		nextTraceAPIV4TransportCacheOrder[i] = nextTraceAPIV4TransportCacheKey{}
 	}
-	nextTraceAPIV4ClientCacheOrder = nextTraceAPIV4ClientCacheOrder[:len(nextTraceAPIV4ClientCacheOrder)-evictCount]
+	nextTraceAPIV4TransportCacheOrder = nextTraceAPIV4TransportCacheOrder[:len(nextTraceAPIV4TransportCacheOrder)-evictCount]
 
+	evicted := make([]*http.Transport, 0, len(evictedKeys))
 	for _, key := range evictedKeys {
-		client := nextTraceAPIV4ClientCache[key]
-		delete(nextTraceAPIV4ClientCache, key)
-		closeNextTraceAPIV4ClientIdleConnections(client)
+		transport := nextTraceAPIV4TransportCache[key]
+		delete(nextTraceAPIV4TransportCache, key)
+		if transport != nil {
+			evicted = append(evicted, transport)
+		}
 	}
+	return evicted
 }
 
-func closeNextTraceAPIV4ClientIdleConnections(client *NextTraceAPIV4Client) {
-	if client == nil || client.httpClient == nil {
-		return
+func closeNextTraceAPIV4TransportIdleConnections(transports []*http.Transport) {
+	for _, transport := range transports {
+		nextTraceAPIV4CloseIdleConnections(transport)
 	}
-	client.httpClient.CloseIdleConnections()
 }
 
 func normalizeNextTraceAPIV4Endpoint(endpoint string) string {
@@ -192,8 +218,12 @@ func PrepareNextTraceAPIV4FastIP(ctx context.Context, enableOutput bool) error {
 }
 
 func prepareNextTraceAPIV4FastIP(ctx context.Context, endpoint string, enableOutput bool) error {
+	return prepareNextTraceAPIV4FastIPWithProxy(ctx, endpoint, enableOutput, captureNextTraceAPIV4Proxy(endpoint))
+}
+
+func prepareNextTraceAPIV4FastIPWithProxy(ctx context.Context, endpoint string, enableOutput bool, proxy nextTraceAPIV4ProxyPolicy) error {
 	host, port, ok := nextTraceAPIV4APIEndpointHostPort(endpoint)
-	if !ok || nextTraceAPIV4ProxyConfigured(endpoint) {
+	if !ok || nextTraceAPIV4ProxyApplies(proxy, endpoint) {
 		return nil
 	}
 	if ctx == nil {
@@ -205,15 +235,40 @@ func prepareNextTraceAPIV4FastIP(ctx context.Context, endpoint string, enableOut
 	return err
 }
 
-func nextTraceAPIV4ProxyConfigured(endpoint string) bool {
-	if util.GetProxy() != nil {
-		return true
+func captureNextTraceAPIV4Proxy(_ string) nextTraceAPIV4ProxyPolicy {
+	if proxyURL := util.GetProxy(); proxyURL != nil {
+		cloned := *proxyURL
+		return nextTraceAPIV4ProxyPolicy{
+			identity: "explicit:" + proxyURL.String(),
+			proxy:    http.ProxyURL(&cloned),
+		}
+	}
+
+	config := httpproxy.FromEnvironment()
+	proxyForURL := config.ProxyFunc()
+	return nextTraceAPIV4ProxyPolicy{
+		identity: strings.Join([]string{
+			"environment",
+			config.HTTPProxy,
+			config.HTTPSProxy,
+			config.NoProxy,
+			strconv.FormatBool(config.CGI),
+		}, "\x00"),
+		proxy: func(req *http.Request) (*url.URL, error) {
+			return proxyForURL(req.URL)
+		},
+	}
+}
+
+func nextTraceAPIV4ProxyApplies(policy nextTraceAPIV4ProxyPolicy, endpoint string) bool {
+	if policy.proxy == nil {
+		return false
 	}
 	u, err := url.Parse(normalizeNextTraceAPIV4Endpoint(endpoint))
 	if err != nil {
-		return false
+		return true
 	}
-	proxyURL, err := httpproxy.FromEnvironment().ProxyFunc()(u)
+	proxyURL, err := policy.proxy(&http.Request{URL: u})
 	return err != nil || proxyURL != nil
 }
 
@@ -240,67 +295,46 @@ func nextTraceAPIV4APIEndpointHostPort(endpoint string) (string, string, bool) {
 	return nextTraceAPIV4APIHost, port, true
 }
 
-func newNextTraceAPIV4HTTPClient(endpoint string, timeout time.Duration) *http.Client {
-	client := util.NewGeoHTTPClient(timeout)
+func newNextTraceAPIV4Transport(endpoint string, policy util.GeoDNSPolicy, proxy nextTraceAPIV4ProxyPolicy) *http.Transport {
+	baseClient := util.NewSharedGeoHTTPClientWithPolicy(0, policy)
+	transport := &http.Transport{}
+	if base, ok := baseClient.Transport.(*http.Transport); ok && base != nil {
+		transport = base.Clone()
+	} else if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
+		transport = base.Clone()
+	}
+
+	transport.Proxy = proxy.proxy
+
 	host, port, ok := nextTraceAPIV4APIEndpointHostPort(endpoint)
-	if !ok {
-		return client
-	}
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok || transport == nil {
-		return client
+	if !ok || nextTraceAPIV4ProxyApplies(proxy, endpoint) {
+		return transport
 	}
 
-	if proxyURL := util.GetProxy(); proxyURL != nil {
-		transport.Proxy = http.ProxyURL(proxyURL)
-		return client
+	fallbackDial := transport.DialContext
+	if fallbackDial == nil {
+		fallbackDial = (&net.Dialer{KeepAlive: 30 * time.Second}).DialContext
 	}
-	if nextTraceAPIV4ProxyConfigured(endpoint) {
-		return client
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   timeout,
-		KeepAlive: 30 * time.Second,
-	}
+	fastIPDialer := &net.Dialer{KeepAlive: 30 * time.Second}
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return dialNextTraceAPIV4(ctx, dialer, network, addr, host, port)
+		return dialNextTraceAPIV4(ctx, fastIPDialer, fallbackDial, network, addr, host, port)
 	}
-	return client
+	return transport
 }
 
-func dialNextTraceAPIV4(ctx context.Context, dialer *net.Dialer, network string, addr string, apiHost string, apiPort string) (net.Conn, error) {
+func dialNextTraceAPIV4(ctx context.Context, fastIPDialer *net.Dialer, fallbackDial func(context.Context, string, string) (net.Conn, error), network string, addr string, apiHost string, apiPort string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return dialer.DialContext(ctx, network, addr)
+		return fallbackDial(ctx, network, addr)
 	}
 	if strings.EqualFold(host, apiHost) && port == apiPort {
 		if fastIP := strings.Trim(util.GetFastIPCache(), "[]"); fastIP != "" {
-			if conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(fastIP, port)); dialErr == nil {
+			if conn, dialErr := fastIPDialer.DialContext(ctx, network, net.JoinHostPort(fastIP, port)); dialErr == nil {
 				return conn, nil
 			}
 		}
 	}
-	return dialGeoResolved(ctx, dialer, network, host, port)
-}
-
-func dialGeoResolved(ctx context.Context, dialer *net.Dialer, network string, host string, port string) (net.Conn, error) {
-	ips, err := util.LookupHostForGeo(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-	var lastErr error
-	for _, ip := range ips {
-		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-		if dialErr == nil {
-			return conn, nil
-		}
-		lastErr = dialErr
-	}
-	if lastErr == nil {
-		return nil, fmt.Errorf("geo DNS returned no IPs for host %q", host)
-	}
-	return nil, lastErr
+	return fallbackDial(ctx, network, addr)
 }
 
 func (c *NextTraceAPIV4Client) Lookup(ctx context.Context, ip string) (*IPGeoData, NextTraceAPIV4Quota, error) {
@@ -310,6 +344,8 @@ func (c *NextTraceAPIV4Client) Lookup(ctx context.Context, ip string) (*IPGeoDat
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	ctx, cancel := c.totalLookupContext(ctx)
+	defer cancel()
 	var lastErr error
 	for attempt := 0; attempt < nextTraceAPIV4MaxAttempts; attempt++ {
 		geo, quota, err := c.lookupOnce(ctx, ip)
@@ -328,10 +364,7 @@ func (c *NextTraceAPIV4Client) Lookup(ctx context.Context, ip string) (*IPGeoDat
 }
 
 func (c *NextTraceAPIV4Client) lookupOnce(ctx context.Context, ip string) (*IPGeoData, NextTraceAPIV4Quota, error) {
-	attemptCtx, cancel := c.lookupAttemptContext(ctx)
-	defer cancel()
-
-	req, err := c.newLookupRequest(attemptCtx, ip)
+	req, err := c.newLookupRequest(ctx, ip)
 	if err != nil {
 		return nil, NextTraceAPIV4Quota{}, err
 	}
@@ -363,7 +396,7 @@ func (c *NextTraceAPIV4Client) lookupOnce(ctx context.Context, ip string) (*IPGe
 	return geo, parseNextTraceAPIV4Quota(resp.Header), nil
 }
 
-func (c *NextTraceAPIV4Client) lookupAttemptContext(ctx context.Context) (context.Context, context.CancelFunc) {
+func (c *NextTraceAPIV4Client) totalLookupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if c.httpClient == nil || c.httpClient.Timeout <= 0 {
 		return ctx, func() {}
 	}

--- a/ipgeo/nexttrace_api_v4_test.go
+++ b/ipgeo/nexttrace_api_v4_test.go
@@ -25,24 +25,6 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-type closeIdleRoundTripper struct {
-	closed *int32
-}
-
-func (rt *closeIdleRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-		Header:     make(http.Header),
-		Body:       io.NopCloser(strings.NewReader(`{"ip":"` + req.URL.Query().Get("ip") + `"}`)),
-		Request:    req,
-	}, nil
-}
-
-func (rt *closeIdleRoundTripper) CloseIdleConnections() {
-	atomic.AddInt32(rt.closed, 1)
-}
-
 func withNextTraceAPIV4RetryDelays(t *testing.T, delays ...time.Duration) {
 	t.Helper()
 	old := nextTraceAPIV4RetryDelays
@@ -52,89 +34,59 @@ func withNextTraceAPIV4RetryDelays(t *testing.T, delays ...time.Duration) {
 	})
 }
 
-func resetNextTraceAPIV4ClientCache() {
-	nextTraceAPIV4ClientCacheMu.Lock()
-	defer nextTraceAPIV4ClientCacheMu.Unlock()
-	for _, client := range nextTraceAPIV4ClientCache {
-		closeNextTraceAPIV4ClientIdleConnections(client)
+func resetNextTraceAPIV4TransportCache() {
+	nextTraceAPIV4TransportCacheMu.Lock()
+	transports := make([]*http.Transport, 0, len(nextTraceAPIV4TransportCache))
+	for _, transport := range nextTraceAPIV4TransportCache {
+		transports = append(transports, transport)
 	}
-	nextTraceAPIV4ClientCache = make(map[nextTraceAPIV4ClientCacheKey]*NextTraceAPIV4Client)
-	nextTraceAPIV4ClientCacheOrder = nil
+	nextTraceAPIV4TransportCache = make(map[nextTraceAPIV4TransportCacheKey]*http.Transport)
+	nextTraceAPIV4TransportCacheOrder = nil
+	nextTraceAPIV4TransportCacheMu.Unlock()
+	closeNextTraceAPIV4TransportIdleConnections(transports)
 }
 
-func nextTraceAPIV4ClientCacheLen() int {
-	nextTraceAPIV4ClientCacheMu.RLock()
-	defer nextTraceAPIV4ClientCacheMu.RUnlock()
-	return len(nextTraceAPIV4ClientCache)
-}
-
-func isolateNextTraceAPIV4ProxyEnv(t *testing.T) {
-	t.Helper()
-	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"} {
-		t.Setenv(key, "")
-	}
+func nextTraceAPIV4TransportCacheLen() int {
+	nextTraceAPIV4TransportCacheMu.RLock()
+	defer nextTraceAPIV4TransportCacheMu.RUnlock()
+	return len(nextTraceAPIV4TransportCache)
 }
 
 func TestNextTraceAPIV4GeoIPNormalizesTimeout(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
 	t.Cleanup(func() {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = w.Write([]byte(`{"ip":"1.1.1.1"}`))
 	}))
 	defer srv.Close()
 	nextTraceAPIV4GeoEndpoint = srv.URL
+	resetNextTraceAPIV4TransportCache()
 
-	tests := []struct {
-		name    string
-		timeout time.Duration
-		want    time.Duration
-	}{
-		{name: "below minimum", timeout: time.Second, want: 2 * time.Second},
-		{name: "zero", timeout: 0, want: 2 * time.Second},
-		{name: "above minimum", timeout: 3 * time.Second, want: 3 * time.Second},
+	geo, err := NextTraceAPIV4GeoIP("1.1.1.1", time.Millisecond, "cn", false)
+	if err != nil {
+		t.Fatalf("NextTraceAPIV4GeoIP() error = %v", err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetNextTraceAPIV4ClientCache()
-			var got time.Duration
-			nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
-				got = timeout
-				client := srv.Client()
-				client.Timeout = timeout
-				return client
-			}
-			geo, err := NextTraceAPIV4GeoIP("1.1.1.1", tt.timeout, "cn", false)
-			if err != nil {
-				t.Fatalf("NextTraceAPIV4GeoIP() error = %v", err)
-			}
-			if geo.IP != "1.1.1.1" {
-				t.Fatalf("IP = %q, want 1.1.1.1", geo.IP)
-			}
-			if got != tt.want {
-				t.Fatalf("timeout = %s, want %s", got, tt.want)
-			}
-		})
+	if geo.IP != "1.1.1.1" {
+		t.Fatalf("IP = %q, want 1.1.1.1", geo.IP)
 	}
 }
 
 func TestNextTraceAPIV4GeoIPUsesTimeoutAsTotalBudget(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	withNextTraceAPIV4RetryDelays(t, 3*time.Second, 3*time.Second)
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
 	t.Cleanup(func() {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	attempts := 0
@@ -145,12 +97,7 @@ func TestNextTraceAPIV4GeoIPUsesTimeoutAsTotalBudget(t *testing.T) {
 	}))
 	defer srv.Close()
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
-		client := srv.Client()
-		client.Timeout = timeout
-		return client
-	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	start := time.Now()
 	_, err := NextTraceAPIV4GeoIP("1.1.1.1", 2*time.Second, "cn", false)
@@ -170,19 +117,28 @@ func TestNextTraceAPIV4GeoIPSharesTimeoutWithFastIPPrewarm(t *testing.T) {
 	isolateNextTraceAPIV4ProxyEnv(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
 	oldFastIPFn := nextTraceAPIV4FastIPFn
 	oldProxy := util.EnvProxyURL
+	oldCache := util.GetFastIPCache()
+	oldMeta := util.GetFastIPMetaCache()
 	t.Cleanup(func() {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
 		nextTraceAPIV4FastIPFn = oldFastIPFn
 		util.EnvProxyURL = oldProxy
-		resetNextTraceAPIV4ClientCache()
+		util.SetFastIPCacheState(oldCache, oldMeta)
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	util.EnvProxyURL = ""
-	nextTraceAPIV4GeoEndpoint = "https://" + nextTraceAPIV4APIHost + nextTraceAPIV4GeoPath
+	util.SetFastIPCacheState("", util.FastIPMeta{})
+	requestStarted := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestStarted <- struct{}{}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+	port := strconv.Itoa(srv.Listener.Addr().(*net.TCPAddr).Port)
+	nextTraceAPIV4GeoEndpoint = "http://" + nextTraceAPIV4APIHost + ":" + port + nextTraceAPIV4GeoPath
 	nextTraceAPIV4FastIPFn = func(ctx context.Context, _ string, _ string, enableOutput bool) (string, error) {
 		if enableOutput {
 			t.Fatal("FastIP enableOutput = true, want false for lookup fallback")
@@ -190,55 +146,44 @@ func TestNextTraceAPIV4GeoIPSharesTimeoutWithFastIPPrewarm(t *testing.T) {
 		if _, ok := ctx.Deadline(); !ok {
 			t.Fatal("FastIP context has no deadline")
 		}
-		time.Sleep(200 * time.Millisecond)
+		timer := time.NewTimer(750 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+		util.SetFastIPCacheState("127.0.0.1", util.FastIPMeta{IP: "127.0.0.1"})
 		return "127.0.0.1", nil
 	}
 
 	timeout := 2 * time.Second
-	var lookupRemaining time.Duration
-	nextTraceAPIV4HTTPClientFactory = func(_ string, gotTimeout time.Duration) *http.Client {
-		if gotTimeout != timeout {
-			t.Fatalf("client timeout = %s, want %s", gotTimeout, timeout)
-		}
-		return &http.Client{
-			Timeout: gotTimeout,
-			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				deadline, ok := req.Context().Deadline()
-				if !ok {
-					t.Fatal("lookup context has no deadline")
-				}
-				lookupRemaining = time.Until(deadline)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Status:     "200 OK",
-					Header:     make(http.Header),
-					Body:       io.NopCloser(strings.NewReader(`{"ip":"1.1.1.1"}`)),
-					Request:    req,
-				}, nil
-			}),
-		}
-	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
-	if _, err := NextTraceAPIV4GeoIP("1.1.1.1", timeout, "cn", false); err != nil {
-		t.Fatalf("NextTraceAPIV4GeoIP() error = %v", err)
+	start := time.Now()
+	if _, err := NextTraceAPIV4GeoIP("1.1.1.1", timeout, "cn", false); err == nil {
+		t.Fatal("NextTraceAPIV4GeoIP() error = nil, want deadline error")
 	}
-	if lookupRemaining >= timeout-100*time.Millisecond {
-		t.Fatalf("lookup remaining timeout = %s, want FastIP prewarm charged to same budget", lookupRemaining)
+	elapsed := time.Since(start)
+	if elapsed < 1700*time.Millisecond || elapsed > 2700*time.Millisecond {
+		t.Fatalf("elapsed = %s, want one shared %s budget including FastIP", elapsed, timeout)
+	}
+	select {
+	case <-requestStarted:
+	default:
+		t.Fatal("lookup did not start after FastIP prewarm")
 	}
 }
 
-func TestNextTraceAPIV4GeoIPReusesCachedClientAndConnection(t *testing.T) {
+func TestNextTraceAPIV4GeoIPReusesTransportAndConnection(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
 	t.Cleanup(func() {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 
-	var factoryCalls int32
 	var newConns int32
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -253,13 +198,7 @@ func TestNextTraceAPIV4GeoIPReusesCachedClientAndConnection(t *testing.T) {
 	defer srv.Close()
 
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
-		atomic.AddInt32(&factoryCalls, 1)
-		client := srv.Client()
-		client.Timeout = timeout
-		return client
-	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	for _, ip := range []string{"1.1.1.1", "8.8.8.8", "9.9.9.9"} {
 		geo, err := NextTraceAPIV4GeoIP(ip, 2*time.Second, "cn", false)
@@ -271,8 +210,8 @@ func TestNextTraceAPIV4GeoIPReusesCachedClientAndConnection(t *testing.T) {
 		}
 	}
 
-	if got := atomic.LoadInt32(&factoryCalls); got != 1 {
-		t.Fatalf("factory calls = %d, want 1 cached client", got)
+	if got := nextTraceAPIV4TransportCacheLen(); got != 1 {
+		t.Fatalf("transport cache size = %d, want 1", got)
 	}
 	if got := atomic.LoadInt32(&newConns); got != 1 {
 		t.Fatalf("new connections = %d, want 1 reused HTTP connection", got)
@@ -292,7 +231,7 @@ func TestNextTraceAPIV4GeoIPUsesFastIPForAPIEndpoint(t *testing.T) {
 		nextTraceAPIV4FastIPFn = oldFastIPFn
 		util.EnvProxyURL = oldProxy
 		util.SetFastIPCacheState(oldCache, oldMeta)
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	util.EnvProxyURL = ""
@@ -332,7 +271,7 @@ func TestNextTraceAPIV4GeoIPUsesFastIPForAPIEndpoint(t *testing.T) {
 		util.SetFastIPCacheState("127.0.0.1", util.FastIPMeta{IP: "127.0.0.1"})
 		return "127.0.0.1", nil
 	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	geo, err := NextTraceAPIV4GeoIP("1.1.1.1", 2*time.Second, "cn", false)
 	if err != nil {
@@ -343,6 +282,59 @@ func TestNextTraceAPIV4GeoIPUsesFastIPForAPIEndpoint(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&fastIPCalls); got != 1 {
 		t.Fatalf("FastIP calls = %d, want 1", got)
+	}
+}
+
+func TestNextTraceAPIV4FastIPDialPreservesTLSServerName(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldProxy := util.EnvProxyURL
+	oldCache := util.GetFastIPCache()
+	oldMeta := util.GetFastIPMetaCache()
+	t.Cleanup(func() {
+		util.EnvProxyURL = oldProxy
+		util.SetFastIPCacheState(oldCache, oldMeta)
+	})
+	util.EnvProxyURL = ""
+
+	sniCh := make(chan string, 1)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sniCh <- r.TLS.ServerName
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"ip":"1.1.1.1"}`))
+	}))
+	defer srv.Close()
+	listenerHost, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort() error = %v", err)
+	}
+	util.SetFastIPCacheState(listenerHost, util.FastIPMeta{IP: listenerHost})
+
+	endpoint := "https://" + net.JoinHostPort(nextTraceAPIV4APIHost, port) + nextTraceAPIV4GeoPath
+	policy := util.NewGeoDNSPolicy("", true)
+	transport := newNextTraceAPIV4Transport(endpoint, policy, nextTraceAPIV4ProxyPolicy{identity: "direct"})
+	tlsTransport, ok := srv.Client().Transport.(*http.Transport)
+	if !ok || tlsTransport.TLSClientConfig == nil {
+		t.Fatal("test server client has no TLS config")
+	}
+	transport.TLSClientConfig = tlsTransport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // The local test verifies SNI, not certificate trust.
+	defer transport.CloseIdleConnections()
+
+	client := NewNextTraceAPIV4Client(endpoint, "test-token", &http.Client{Timeout: 2 * time.Second, Transport: transport})
+	geo, _, err := client.Lookup(context.Background(), "1.1.1.1")
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if geo.IP != "1.1.1.1" {
+		t.Fatalf("IP = %q, want 1.1.1.1", geo.IP)
+	}
+	select {
+	case got := <-sniCh:
+		if got != nextTraceAPIV4APIHost {
+			t.Fatalf("TLS ServerName = %q, want %q", got, nextTraceAPIV4APIHost)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("TLS server did not observe a handshake")
 	}
 }
 
@@ -428,17 +420,51 @@ func TestDialNextTraceAPIV4FallsBackWhenCachedFastIPFails(t *testing.T) {
 
 	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
 	util.SetFastIPCacheState("127.0.0.2", util.FastIPMeta{IP: "127.0.0.2"})
-	conn, err := dialNextTraceAPIV4(context.Background(), &net.Dialer{Timeout: time.Second}, "tcp", net.JoinHostPort("127.0.0.1", port), "127.0.0.1", port)
+	dialer := &net.Dialer{Timeout: time.Second}
+	originalAddr := net.JoinHostPort("127.0.0.1", port)
+	var fallbackAddr string
+	fallbackDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		fallbackAddr = addr
+		return dialer.DialContext(ctx, network, addr)
+	}
+	conn, err := dialNextTraceAPIV4(context.Background(), dialer, fallbackDial, "tcp", originalAddr, "127.0.0.1", port)
 	if err != nil {
 		t.Fatalf("dialNextTraceAPIV4() error = %v", err)
 	}
 	_ = conn.Close()
+	if fallbackAddr != originalAddr {
+		t.Fatalf("fallback addr = %q, want captured policy dialer addr %q", fallbackAddr, originalAddr)
+	}
 
 	select {
 	case serverConn := <-accepted:
 		_ = serverConn.Close()
 	case <-time.After(time.Second):
 		t.Fatal("fallback dial did not reach original host listener")
+	}
+}
+
+func TestDialNextTraceAPIV4CancellationReachesFallback(t *testing.T) {
+	oldCache := util.GetFastIPCache()
+	oldMeta := util.GetFastIPMetaCache()
+	t.Cleanup(func() {
+		util.SetFastIPCacheState(oldCache, oldMeta)
+	})
+
+	util.SetFastIPCacheState("192.0.2.1", util.FastIPMeta{IP: "192.0.2.1"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var fallbackCalls int32
+	fallbackDial := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		atomic.AddInt32(&fallbackCalls, 1)
+		return nil, ctx.Err()
+	}
+	_, err := dialNextTraceAPIV4(ctx, &net.Dialer{}, fallbackDial, "tcp", "api.nxtrace.org:443", nextTraceAPIV4APIHost, nextTraceAPIV4DefaultPort)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("dialNextTraceAPIV4() error = %v, want context canceled", err)
+	}
+	if got := atomic.LoadInt32(&fallbackCalls); got != 1 {
+		t.Fatalf("fallback calls = %d, want 1", got)
 	}
 }
 
@@ -467,7 +493,7 @@ func TestPrepareNextTraceAPIV4FastIPSkipsStandardProxyEnv(t *testing.T) {
 	}
 }
 
-func TestNewNextTraceAPIV4HTTPClientSkipsFastIPDialForStandardProxyEnv(t *testing.T) {
+func TestNewNextTraceAPIV4TransportSkipsFastIPDialForStandardProxyEnv(t *testing.T) {
 	isolateNextTraceAPIV4ProxyEnv(t)
 	oldProxy := util.EnvProxyURL
 	t.Cleanup(func() {
@@ -476,19 +502,222 @@ func TestNewNextTraceAPIV4HTTPClientSkipsFastIPDialForStandardProxyEnv(t *testin
 
 	util.EnvProxyURL = ""
 	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:65535")
-	client := newNextTraceAPIV4HTTPClient(nextTraceAPIV4GeoEndpoint, time.Second)
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok || transport == nil || transport.DialContext == nil {
-		t.Fatalf("client transport = %#v, want http.Transport with DialContext", client.Transport)
+	policy := util.CurrentGeoDNSPolicy()
+	proxy := captureNextTraceAPIV4Proxy(nextTraceAPIV4GeoEndpoint)
+	transport := newNextTraceAPIV4Transport(nextTraceAPIV4GeoEndpoint, policy, proxy)
+	if transport == nil || transport.DialContext == nil {
+		t.Fatalf("transport = %#v, want http.Transport with DialContext", transport)
 	}
 	dialName := runtime.FuncForPC(reflect.ValueOf(transport.DialContext).Pointer()).Name()
-	if strings.Contains(dialName, "newNextTraceAPIV4HTTPClient") {
+	if strings.Contains(dialName, "newNextTraceAPIV4Transport") {
 		t.Fatalf("DialContext = %s, want util.NewGeoHTTPClient dialer when HTTPS_PROXY is set", dialName)
 	}
 }
 
+func TestNextTraceAPIV4EnvironmentProxyReevaluatesRedirectURL(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:18080")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:18443")
+	t.Setenv("NO_PROXY", "origin.example,bypass.example")
+
+	policy := captureNextTraceAPIV4Proxy("http://origin.example/v4/ipGeo")
+	tests := []struct {
+		name       string
+		requestURL string
+		wantProxy  string
+	}{
+		{name: "initial host bypasses proxy", requestURL: "http://origin.example/v4/ipGeo"},
+		{name: "https redirect uses https proxy", requestURL: "https://secure.example/v4/ipGeo", wantProxy: "http://127.0.0.1:18443"},
+		{name: "http redirect uses http proxy", requestURL: "http://plain.example/v4/ipGeo", wantProxy: "http://127.0.0.1:18080"},
+		{name: "redirected bypass host stays direct", requestURL: "https://bypass.example/v4/ipGeo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.requestURL, nil)
+			if err != nil {
+				t.Fatalf("NewRequest() error = %v", err)
+			}
+			proxyURL, err := policy.proxy(req)
+			if err != nil {
+				t.Fatalf("proxy() error = %v", err)
+			}
+			got := ""
+			if proxyURL != nil {
+				got = proxyURL.String()
+			}
+			if got != tt.wantProxy {
+				t.Fatalf("proxy for %s = %q, want %q", tt.requestURL, got, tt.wantProxy)
+			}
+		})
+	}
+}
+
+func TestNextTraceAPIV4ExplicitProxyRemainsFixedAcrossRedirects(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
+	const explicitProxy = "http://127.0.0.1:19090"
+	util.EnvProxyURL = explicitProxy
+
+	policy := captureNextTraceAPIV4Proxy("http://origin.example/v4/ipGeo")
+	for _, requestURL := range []string{
+		"http://origin.example/v4/ipGeo",
+		"https://redirected.example/v4/ipGeo",
+	} {
+		req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+		if err != nil {
+			t.Fatalf("NewRequest() error = %v", err)
+		}
+		proxyURL, err := policy.proxy(req)
+		if err != nil {
+			t.Fatalf("proxy() error = %v", err)
+		}
+		if proxyURL == nil || proxyURL.String() != explicitProxy {
+			t.Fatalf("proxy for %s = %v, want %s", requestURL, proxyURL, explicitProxy)
+		}
+	}
+}
+
+func TestPrepareNextTraceAPIV4FastIPEvaluatesOnlyInitialEndpoint(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:18443")
+	t.Setenv("NO_PROXY", nextTraceAPIV4APIHost)
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	t.Cleanup(func() {
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+	})
+
+	var calls int32
+	nextTraceAPIV4FastIPFn = func(context.Context, string, string, bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "127.0.0.1", nil
+	}
+	policy := captureNextTraceAPIV4Proxy(nextTraceAPIV4GeoEndpoint)
+	if err := prepareNextTraceAPIV4FastIPWithProxy(context.Background(), nextTraceAPIV4GeoEndpoint, false, policy); err != nil {
+		t.Fatalf("prepareNextTraceAPIV4FastIPWithProxy() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("FastIP calls = %d, want 1 for initial NO_PROXY endpoint", got)
+	}
+
+	redirectReq, err := http.NewRequest(http.MethodGet, "https://redirected.example/v4/ipGeo", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	proxyURL, err := policy.proxy(redirectReq)
+	if err != nil {
+		t.Fatalf("proxy() error = %v", err)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://127.0.0.1:18443" {
+		t.Fatalf("redirect proxy = %v, want captured HTTPS_PROXY", proxyURL)
+	}
+}
+
+func TestNextTraceAPIV4HTTPSProxyPreservesCONNECTHostAndTLSServerName(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
+
+	sniCh := make(chan string, 1)
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case sniCh <- r.TLS.ServerName:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"ip":"1.1.1.1"}`))
+	}))
+	defer target.Close()
+
+	connectHostCh := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "CONNECT required", http.StatusMethodNotAllowed)
+			return
+		}
+		select {
+		case connectHostCh <- r.Host:
+		default:
+		}
+		upstream, err := net.DialTimeout("tcp", target.Listener.Addr().String(), time.Second)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			_ = upstream.Close()
+			http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+			return
+		}
+		downstream, rw, err := hijacker.Hijack()
+		if err != nil {
+			_ = upstream.Close()
+			return
+		}
+		if _, err := rw.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+			_ = downstream.Close()
+			_ = upstream.Close()
+			return
+		}
+		if err := rw.Flush(); err != nil {
+			_ = downstream.Close()
+			_ = upstream.Close()
+			return
+		}
+		go func() {
+			_, _ = io.Copy(upstream, downstream)
+			_ = upstream.Close()
+		}()
+		go func() {
+			_, _ = io.Copy(downstream, upstream)
+			_ = downstream.Close()
+		}()
+	}))
+	defer proxyServer.Close()
+	t.Setenv("HTTPS_PROXY", proxyServer.URL)
+
+	_, port, err := net.SplitHostPort(target.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort() error = %v", err)
+	}
+	endpoint := "https://" + net.JoinHostPort(nextTraceAPIV4APIHost, port) + nextTraceAPIV4GeoPath
+	policy := util.NewGeoDNSPolicy("", true)
+	transport := newNextTraceAPIV4Transport(endpoint, policy, captureNextTraceAPIV4Proxy(endpoint))
+	tlsTransport, ok := target.Client().Transport.(*http.Transport)
+	if !ok || tlsTransport.TLSClientConfig == nil {
+		t.Fatal("test server client has no TLS config")
+	}
+	transport.TLSClientConfig = tlsTransport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // The local test verifies CONNECT and SNI, not certificate trust.
+	defer transport.CloseIdleConnections()
+
+	client := NewNextTraceAPIV4Client(endpoint, "test-token", &http.Client{Timeout: 2 * time.Second, Transport: transport})
+	geo, _, err := client.Lookup(context.Background(), "1.1.1.1")
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if geo.IP != "1.1.1.1" {
+		t.Fatalf("IP = %q, want 1.1.1.1", geo.IP)
+	}
+	wantConnectHost := net.JoinHostPort(nextTraceAPIV4APIHost, port)
+	select {
+	case got := <-connectHostCh:
+		if got != wantConnectHost {
+			t.Fatalf("CONNECT host = %q, want %q", got, wantConnectHost)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not observe CONNECT")
+	}
+	select {
+	case got := <-sniCh:
+		if got != nextTraceAPIV4APIHost {
+			t.Fatalf("TLS ServerName = %q, want %q", got, nextTraceAPIV4APIHost)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("TLS server did not observe a handshake")
+	}
+}
+
 func TestNextTraceAPIV4GeoIPSkipsFastIPForCustomEndpoint(t *testing.T) {
-	isolateNextTraceAPIV4ProxyEnv(t)
+	isolateNextTraceAPIV4ProxyState(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
 	oldFastIPFn := nextTraceAPIV4FastIPFn
@@ -498,7 +727,7 @@ func TestNextTraceAPIV4GeoIPSkipsFastIPForCustomEndpoint(t *testing.T) {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
 		nextTraceAPIV4FastIPFn = oldFastIPFn
 		util.SetFastIPCacheState(oldCache, oldMeta)
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	var fastIPCalls int32
@@ -512,7 +741,7 @@ func TestNextTraceAPIV4GeoIPSkipsFastIPForCustomEndpoint(t *testing.T) {
 	}))
 	defer srv.Close()
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	geo, err := NextTraceAPIV4GeoIP("8.8.8.8", 2*time.Second, "cn", false)
 	if err != nil {
@@ -536,7 +765,7 @@ func TestNextTraceAPIV4GeoIPUsesProxyInsteadOfFastIP(t *testing.T) {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
 		nextTraceAPIV4FastIPFn = oldFastIPFn
 		util.EnvProxyURL = oldProxy
-		resetNextTraceAPIV4ClientCache()
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	var proxyRequests int32
@@ -563,7 +792,7 @@ func TestNextTraceAPIV4GeoIPUsesProxyInsteadOfFastIP(t *testing.T) {
 	}
 	util.EnvProxyURL = proxy.URL
 	nextTraceAPIV4GeoEndpoint = "http://" + nextTraceAPIV4APIHost + ":65535" + nextTraceAPIV4GeoPath
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	geo, err := NextTraceAPIV4GeoIP("9.9.9.9", 2*time.Second, "cn", false)
 	if err != nil {
@@ -580,144 +809,211 @@ func TestNextTraceAPIV4GeoIPUsesProxyInsteadOfFastIP(t *testing.T) {
 	}
 }
 
-func TestNextTraceAPIV4GeoIPCacheKeyIncludesTokenAndTimeout(t *testing.T) {
-	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
+func TestNextTraceAPIV4ClientsShareTransportAcrossTokenAndTimeout(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldFactory := nextTraceAPIV4TransportFactory
 	t.Cleanup(func() {
-		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
-	})
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		_, _ = w.Write([]byte(`{"ip":"` + r.URL.Query().Get("ip") + `"}`))
-	}))
-	defer srv.Close()
-
-	var factoryCalls int32
-	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
-		atomic.AddInt32(&factoryCalls, 1)
-		client := srv.Client()
-		client.Timeout = timeout
-		return client
-	}
-	resetNextTraceAPIV4ClientCache()
-
-	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "token-a")
-	if _, err := NextTraceAPIV4GeoIP("1.1.1.1", 2*time.Second, "cn", false); err != nil {
-		t.Fatalf("first lookup error = %v", err)
-	}
-	if _, err := NextTraceAPIV4GeoIP("8.8.8.8", time.Second, "cn", false); err != nil {
-		t.Fatalf("same normalized timeout lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 1 {
-		t.Fatalf("factory calls after same key = %d, want 1", got)
-	}
-
-	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "token-b")
-	if _, err := NextTraceAPIV4GeoIP("9.9.9.9", 2*time.Second, "cn", false); err != nil {
-		t.Fatalf("token change lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 2 {
-		t.Fatalf("factory calls after token change = %d, want 2", got)
-	}
-
-	if _, err := NextTraceAPIV4GeoIP("1.0.0.1", 3*time.Second, "cn", false); err != nil {
-		t.Fatalf("timeout change lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 3 {
-		t.Fatalf("factory calls after timeout change = %d, want 3", got)
-	}
-}
-
-func TestNextTraceAPIV4GeoIPCacheKeyIncludesGeoDNSResolver(t *testing.T) {
-	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
-	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
-	oldResolver := util.CurrentGeoDNSResolver()
-	t.Cleanup(func() {
-		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		util.SetGeoDNSResolver(oldResolver)
-		resetNextTraceAPIV4ClientCache()
-	})
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		_, _ = w.Write([]byte(`{"ip":"` + r.URL.Query().Get("ip") + `"}`))
-	}))
-	defer srv.Close()
-
-	var factoryCalls int32
-	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
-		atomic.AddInt32(&factoryCalls, 1)
-		client := srv.Client()
-		client.Timeout = timeout
-		return client
-	}
-	util.SetGeoDNSResolver("")
-	resetNextTraceAPIV4ClientCache()
-
-	if _, err := NextTraceAPIV4GeoIP("1.1.1.1", 2*time.Second, "cn", false); err != nil {
-		t.Fatalf("default resolver lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 1 {
-		t.Fatalf("factory calls after default resolver = %d, want 1", got)
-	}
-
-	util.SetGeoDNSResolver("google")
-	if _, err := NextTraceAPIV4GeoIP("8.8.8.8", 2*time.Second, "cn", false); err != nil {
-		t.Fatalf("google resolver lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 2 {
-		t.Fatalf("factory calls after google resolver = %d, want 2", got)
-	}
-
-	util.SetGeoDNSResolver("cloudflare")
-	if _, err := NextTraceAPIV4GeoIP("9.9.9.9", 2*time.Second, "cn", false); err != nil {
-		t.Fatalf("cloudflare resolver lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 3 {
-		t.Fatalf("factory calls after cloudflare resolver = %d, want 3", got)
-	}
-
-	util.SetGeoDNSResolver("google")
-	if _, err := NextTraceAPIV4GeoIP("1.0.0.1", 2*time.Second, "cn", false); err != nil {
-		t.Fatalf("google resolver reuse lookup error = %v", err)
-	}
-	if got := atomic.LoadInt32(&factoryCalls); got != 3 {
-		t.Fatalf("factory calls after returning to google = %d, want 3", got)
-	}
-}
-
-func TestNextTraceAPIV4ClientCacheNormalizesEndpoint(t *testing.T) {
-	oldFactory := nextTraceAPIV4HTTPClientFactory
-	t.Cleanup(func() {
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
+		nextTraceAPIV4TransportFactory = oldFactory
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	var factoryCalls int32
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
 		atomic.AddInt32(&factoryCalls, 1)
-		return &http.Client{
-			Timeout: timeout,
-			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-				return nil, errors.New("unexpected request")
-			}),
-		}
+		return &http.Transport{}
 	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	endpoint := "https://api.example.test/v4/ipGeo"
-	client := cachedNextTraceAPIV4Client(" "+endpoint+" ", "test-token", 2*time.Second)
-	cached := cachedNextTraceAPIV4Client(endpoint, "test-token", 2*time.Second)
+	policy := util.CurrentGeoDNSPolicy()
+	proxy := captureNextTraceAPIV4Proxy(endpoint)
+	first := newNextTraceAPIV4ClientForPolicy(endpoint, "token-a", 2*time.Second, policy, proxy)
+	second := newNextTraceAPIV4ClientForPolicy(endpoint, "token-b", 3*time.Second, policy, proxy)
+	if first == second {
+		t.Fatal("clients were reused, want one lightweight client per construction")
+	}
+	if first.httpClient.Transport != second.httpClient.Transport {
+		t.Fatal("transport differs across token and timeout")
+	}
+	if first.token != "token-a" || second.token != "token-b" {
+		t.Fatalf("tokens = %q, %q, want per-client values", first.token, second.token)
+	}
+	if first.httpClient.Timeout != 2*time.Second || second.httpClient.Timeout != 3*time.Second {
+		t.Fatalf("timeouts = %s, %s, want per-client values", first.httpClient.Timeout, second.httpClient.Timeout)
+	}
+	if got := atomic.LoadInt32(&factoryCalls); got != 1 {
+		t.Fatalf("transport factory calls = %d, want 1", got)
+	}
+}
 
-	if client != cached {
-		t.Fatal("cached client differs for endpoint with surrounding spaces")
+func TestNextTraceAPIV4TransportKeyIncludesFullGeoDNSPolicy(t *testing.T) {
+	oldFactory := nextTraceAPIV4TransportFactory
+	t.Cleanup(func() {
+		nextTraceAPIV4TransportFactory = oldFactory
+		resetNextTraceAPIV4TransportCache()
+	})
+
+	var factoryCalls int32
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
+		atomic.AddInt32(&factoryCalls, 1)
+		return &http.Transport{}
+	}
+	resetNextTraceAPIV4TransportCache()
+
+	endpoint := "https://api.example.test/v4/ipGeo"
+	proxy := nextTraceAPIV4ProxyPolicy{identity: "direct"}
+	googleFallback := util.NewGeoDNSPolicy(" GOOGLE ", true)
+	googleStrict := util.NewGeoDNSPolicy("google", false)
+	cloudflareFallback := util.NewGeoDNSPolicy("cloudflare", true)
+
+	first := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, googleFallback, proxy)
+	strict := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, googleStrict, proxy)
+	cloudflare := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, cloudflareFallback, proxy)
+	reused := newNextTraceAPIV4ClientForPolicy(endpoint, "other-token", 3*time.Second, googleFallback, proxy)
+
+	if first.httpClient.Transport == strict.httpClient.Transport {
+		t.Fatal("fallback change reused transport")
+	}
+	if first.httpClient.Transport == cloudflare.httpClient.Transport {
+		t.Fatal("resolver change reused transport")
+	}
+	if first.httpClient.Transport != reused.httpClient.Transport {
+		t.Fatal("equivalent normalized policy did not reuse transport")
+	}
+	if got := atomic.LoadInt32(&factoryCalls); got != 3 {
+		t.Fatalf("transport factory calls = %d, want 3 policies", got)
+	}
+}
+
+func TestNextTraceAPIV4TransportKeyIncludesProxyIdentity(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldFactory := nextTraceAPIV4TransportFactory
+	oldProxy := util.EnvProxyURL
+	t.Cleanup(func() {
+		nextTraceAPIV4TransportFactory = oldFactory
+		util.EnvProxyURL = oldProxy
+		resetNextTraceAPIV4TransportCache()
+	})
+
+	var factoryCalls int32
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
+		atomic.AddInt32(&factoryCalls, 1)
+		return &http.Transport{}
+	}
+	resetNextTraceAPIV4TransportCache()
+
+	endpoint := "https://api.example.test/v4/ipGeo"
+	policy := util.NewGeoDNSPolicy("", true)
+	util.EnvProxyURL = ""
+	direct := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+	util.EnvProxyURL = "http://127.0.0.1:10001"
+	proxyOne := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+	util.EnvProxyURL = "http://127.0.0.1:10002"
+	proxyTwo := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+	util.EnvProxyURL = "http://127.0.0.1:10001"
+	proxyOneAgain := newNextTraceAPIV4ClientForPolicy(endpoint, "other-token", 3*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+
+	if direct.httpClient.Transport == proxyOne.httpClient.Transport {
+		t.Fatal("direct and proxied requests reused transport")
+	}
+	if proxyOne.httpClient.Transport == proxyTwo.httpClient.Transport {
+		t.Fatal("different proxies reused transport")
+	}
+	if proxyOne.httpClient.Transport != proxyOneAgain.httpClient.Transport {
+		t.Fatal("same proxy identity did not reuse transport")
+	}
+	if got := atomic.LoadInt32(&factoryCalls); got != 3 {
+		t.Fatalf("transport factory calls = %d, want 3 proxy identities", got)
+	}
+}
+
+func TestNextTraceAPIV4TransportKeyIncludesFullEnvironmentProxyConfig(t *testing.T) {
+	isolateNextTraceAPIV4ProxyState(t)
+	oldFactory := nextTraceAPIV4TransportFactory
+	t.Cleanup(func() {
+		nextTraceAPIV4TransportFactory = oldFactory
+		resetNextTraceAPIV4TransportCache()
+	})
+
+	var factoryCalls int32
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
+		atomic.AddInt32(&factoryCalls, 1)
+		return &http.Transport{}
+	}
+	resetNextTraceAPIV4TransportCache()
+
+	endpoint := "https://api.example.test/v4/ipGeo"
+	policy := util.NewGeoDNSPolicy("", true)
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:18443")
+	t.Setenv("NO_PROXY", "api.example.test")
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:18080")
+	first := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:18081")
+	second := newNextTraceAPIV4ClientForPolicy(endpoint, "token", 2*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:18080")
+	firstAgain := newNextTraceAPIV4ClientForPolicy(endpoint, "other-token", 3*time.Second, policy, captureNextTraceAPIV4Proxy(endpoint))
+
+	if first.httpClient.Transport == second.httpClient.Transport {
+		t.Fatal("different environment proxy configurations reused transport")
+	}
+	if first.httpClient.Transport != firstAgain.httpClient.Transport {
+		t.Fatal("same environment proxy configuration did not reuse transport")
+	}
+	if got := atomic.LoadInt32(&factoryCalls); got != 2 {
+		t.Fatalf("transport factory calls = %d, want 2 configurations", got)
+	}
+}
+
+func TestNewNextTraceAPIV4TransportClonesSharedPolicyTransport(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldProxy := util.EnvProxyURL
+	t.Cleanup(func() {
+		util.EnvProxyURL = oldProxy
+	})
+	util.EnvProxyURL = ""
+
+	policy := util.NewGeoDNSPolicy("", true)
+	shared, ok := util.NewSharedGeoHTTPClientWithPolicy(0, policy).Transport.(*http.Transport)
+	if !ok || shared == nil {
+		t.Fatal("shared policy transport is not *http.Transport")
+	}
+	derived := newNextTraceAPIV4Transport("https://api.example.test/v4/ipGeo", policy, captureNextTraceAPIV4Proxy("https://api.example.test/v4/ipGeo"))
+	if derived == shared {
+		t.Fatal("v4 transport reused mutable shared policy transport")
+	}
+	originalMaxIdle := shared.MaxIdleConns
+	derived.MaxIdleConns = originalMaxIdle + 1
+	if shared.MaxIdleConns != originalMaxIdle {
+		t.Fatal("mutating v4 transport changed shared policy transport")
+	}
+}
+
+func TestNextTraceAPIV4TransportCacheNormalizesEndpoint(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldFactory := nextTraceAPIV4TransportFactory
+	t.Cleanup(func() {
+		nextTraceAPIV4TransportFactory = oldFactory
+		resetNextTraceAPIV4TransportCache()
+	})
+
+	var factoryCalls int32
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
+		atomic.AddInt32(&factoryCalls, 1)
+		return &http.Transport{}
+	}
+	resetNextTraceAPIV4TransportCache()
+
+	endpoint := "https://api.example.test/v4/ipGeo"
+	policy := util.CurrentGeoDNSPolicy()
+	proxy := captureNextTraceAPIV4Proxy(endpoint)
+	client := newNextTraceAPIV4ClientForPolicy(" "+endpoint+" ", "test-token", 2*time.Second, policy, proxy)
+	cached := newNextTraceAPIV4ClientForPolicy(endpoint, "test-token", 2*time.Second, policy, proxy)
+
+	if client == cached {
+		t.Fatal("client was reused, want lightweight client per construction")
+	}
+	if client.httpClient.Transport != cached.httpClient.Transport {
+		t.Fatal("transport differs for endpoint with surrounding spaces")
 	}
 	if got := atomic.LoadInt32(&factoryCalls); got != 1 {
 		t.Fatalf("factory calls = %d, want 1", got)
@@ -727,45 +1023,51 @@ func TestNextTraceAPIV4ClientCacheNormalizesEndpoint(t *testing.T) {
 	}
 }
 
-func TestNextTraceAPIV4ClientCacheEvictsOldestEntry(t *testing.T) {
-	oldFactory := nextTraceAPIV4HTTPClientFactory
-	oldResolver := util.CurrentGeoDNSResolver()
+func TestNextTraceAPIV4TransportCacheEvictsOldestEntry(t *testing.T) {
+	oldFactory := nextTraceAPIV4TransportFactory
+	oldCloseIdle := nextTraceAPIV4CloseIdleConnections
 	t.Cleanup(func() {
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		util.SetGeoDNSResolver(oldResolver)
-		resetNextTraceAPIV4ClientCache()
+		nextTraceAPIV4TransportFactory = oldFactory
+		nextTraceAPIV4CloseIdleConnections = oldCloseIdle
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	var factoryCalls int32
 	var closeIdleCalls int32
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
 		atomic.AddInt32(&factoryCalls, 1)
-		return &http.Client{
-			Timeout:   timeout,
-			Transport: &closeIdleRoundTripper{closed: &closeIdleCalls},
-		}
+		return &http.Transport{}
 	}
-	util.SetGeoDNSResolver("")
-	resetNextTraceAPIV4ClientCache()
+	nextTraceAPIV4CloseIdleConnections = func(*http.Transport) {
+		atomic.AddInt32(&closeIdleCalls, 1)
+	}
+	resetNextTraceAPIV4TransportCache()
 
-	endpoint := "https://api.example.test/v4/ipGeo"
-	timeout := 2 * time.Second
-	firstKey := nextTraceAPIV4ClientCacheKey{
-		endpoint: endpoint,
-		token:    "token-0",
-		timeout:  timeout,
+	policy := util.NewGeoDNSPolicy("", true)
+	proxy := nextTraceAPIV4ProxyPolicy{identity: "direct"}
+	firstEndpoint := "https://api-0.example.test/v4/ipGeo"
+	firstKey := nextTraceAPIV4TransportCacheKey{
+		endpoint:      firstEndpoint,
+		geoDNSPolicy:  policy,
+		proxyIdentity: proxy.identity,
 	}
-	firstClient := cachedNextTraceAPIV4Client(endpoint, "token-0", timeout)
-	for i := 1; i <= nextTraceAPIV4CacheMaxSize; i++ {
-		_ = cachedNextTraceAPIV4Client(endpoint, "token-"+strconv.Itoa(i), timeout)
+	firstTransport := cachedNextTraceAPIV4Transport(firstEndpoint, policy, proxy)
+	for i := 1; i < nextTraceAPIV4CacheMaxSize; i++ {
+		endpoint := "https://api-" + strconv.Itoa(i) + ".example.test/v4/ipGeo"
+		_ = cachedNextTraceAPIV4Transport(endpoint, policy, proxy)
 	}
+	if cachedNextTraceAPIV4Transport(firstEndpoint, policy, proxy) != firstTransport {
+		t.Fatal("cache hit did not reuse first transport")
+	}
+	lastEndpoint := "https://api-" + strconv.Itoa(nextTraceAPIV4CacheMaxSize) + ".example.test/v4/ipGeo"
+	_ = cachedNextTraceAPIV4Transport(lastEndpoint, policy, proxy)
 
-	if got := nextTraceAPIV4ClientCacheLen(); got != nextTraceAPIV4CacheMaxSize {
+	if got := nextTraceAPIV4TransportCacheLen(); got != nextTraceAPIV4CacheMaxSize {
 		t.Fatalf("cache size = %d, want %d", got, nextTraceAPIV4CacheMaxSize)
 	}
-	nextTraceAPIV4ClientCacheMu.RLock()
-	_, firstStillCached := nextTraceAPIV4ClientCache[firstKey]
-	nextTraceAPIV4ClientCacheMu.RUnlock()
+	nextTraceAPIV4TransportCacheMu.RLock()
+	_, firstStillCached := nextTraceAPIV4TransportCache[firstKey]
+	nextTraceAPIV4TransportCacheMu.RUnlock()
 	if firstStillCached {
 		t.Fatal("oldest cache entry still present after exceeding cache size")
 	}
@@ -773,11 +1075,11 @@ func TestNextTraceAPIV4ClientCacheEvictsOldestEntry(t *testing.T) {
 		t.Fatalf("CloseIdleConnections calls after first eviction = %d, want 1", got)
 	}
 
-	recreated := cachedNextTraceAPIV4Client(endpoint, "token-0", timeout)
-	if recreated == firstClient {
-		t.Fatal("evicted cache entry reused old client")
+	recreated := cachedNextTraceAPIV4Transport(firstEndpoint, policy, proxy)
+	if recreated == firstTransport {
+		t.Fatal("evicted cache entry reused old transport")
 	}
-	if got := nextTraceAPIV4ClientCacheLen(); got != nextTraceAPIV4CacheMaxSize {
+	if got := nextTraceAPIV4TransportCacheLen(); got != nextTraceAPIV4CacheMaxSize {
 		t.Fatalf("cache size after recreating evicted entry = %d, want %d", got, nextTraceAPIV4CacheMaxSize)
 	}
 	if got := atomic.LoadInt32(&factoryCalls); got != int32(nextTraceAPIV4CacheMaxSize+2) {
@@ -788,45 +1090,46 @@ func TestNextTraceAPIV4ClientCacheEvictsOldestEntry(t *testing.T) {
 	}
 }
 
-func TestNextTraceAPIV4ClientCacheEvictsMultipleOldestEntries(t *testing.T) {
-	t.Cleanup(resetNextTraceAPIV4ClientCache)
-	resetNextTraceAPIV4ClientCache()
+func TestNextTraceAPIV4TransportCacheEvictsMultipleOldestEntries(t *testing.T) {
+	oldCloseIdle := nextTraceAPIV4CloseIdleConnections
+	t.Cleanup(func() {
+		nextTraceAPIV4CloseIdleConnections = oldCloseIdle
+		resetNextTraceAPIV4TransportCache()
+	})
+	resetNextTraceAPIV4TransportCache()
 
 	var closeIdleCalls int32
-	endpoint := "https://api.example.test/v4/ipGeo"
-	timeout := 2 * time.Second
 	total := nextTraceAPIV4CacheMaxSize + 3
-	keys := make([]nextTraceAPIV4ClientCacheKey, 0, total)
+	keys := make([]nextTraceAPIV4TransportCacheKey, 0, total)
+	policy := util.NewGeoDNSPolicy("", true)
+	proxy := nextTraceAPIV4ProxyPolicy{identity: "direct"}
+	nextTraceAPIV4CloseIdleConnections = func(*http.Transport) {
+		atomic.AddInt32(&closeIdleCalls, 1)
+	}
 
-	nextTraceAPIV4ClientCacheMu.Lock()
+	nextTraceAPIV4TransportCacheMu.Lock()
 	for i := 0; i < total; i++ {
-		key := nextTraceAPIV4ClientCacheKey{
-			endpoint: endpoint,
-			token:    "token-" + strconv.Itoa(i),
-			timeout:  timeout,
+		key := nextTraceAPIV4TransportCacheKey{
+			endpoint:      "https://api-" + strconv.Itoa(i) + ".example.test/v4/ipGeo",
+			geoDNSPolicy:  policy,
+			proxyIdentity: proxy.identity,
 		}
 		keys = append(keys, key)
-		nextTraceAPIV4ClientCache[key] = &NextTraceAPIV4Client{
-			endpoint: endpoint,
-			token:    key.token,
-			httpClient: &http.Client{
-				Timeout:   timeout,
-				Transport: &closeIdleRoundTripper{closed: &closeIdleCalls},
-			},
-		}
-		nextTraceAPIV4ClientCacheOrder = append(nextTraceAPIV4ClientCacheOrder, key)
+		nextTraceAPIV4TransportCache[key] = &http.Transport{}
+		nextTraceAPIV4TransportCacheOrder = append(nextTraceAPIV4TransportCacheOrder, key)
 	}
-	evictNextTraceAPIV4ClientCacheLocked()
-	gotLen := len(nextTraceAPIV4ClientCache)
-	gotOrder := append([]nextTraceAPIV4ClientCacheKey(nil), nextTraceAPIV4ClientCacheOrder...)
+	evicted := evictNextTraceAPIV4TransportCacheLocked()
+	gotLen := len(nextTraceAPIV4TransportCache)
+	gotOrder := append([]nextTraceAPIV4TransportCacheKey(nil), nextTraceAPIV4TransportCacheOrder...)
 	evictedStillCached := false
 	for _, key := range keys[:3] {
-		if nextTraceAPIV4ClientCache[key] != nil {
+		if nextTraceAPIV4TransportCache[key] != nil {
 			evictedStillCached = true
 			break
 		}
 	}
-	nextTraceAPIV4ClientCacheMu.Unlock()
+	nextTraceAPIV4TransportCacheMu.Unlock()
+	closeNextTraceAPIV4TransportIdleConnections(evicted)
 
 	if gotLen != nextTraceAPIV4CacheMaxSize {
 		t.Fatalf("cache size = %d, want %d", gotLen, nextTraceAPIV4CacheMaxSize)
@@ -842,14 +1145,17 @@ func TestNextTraceAPIV4ClientCacheEvictsMultipleOldestEntries(t *testing.T) {
 	}
 }
 
-func TestNextTraceAPIV4GeoIPCachesClientConcurrently(t *testing.T) {
+func TestNextTraceAPIV4GeoIPCachesTransportConcurrently(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
-	oldFactory := nextTraceAPIV4HTTPClientFactory
+	oldFactory := nextTraceAPIV4TransportFactory
+	oldProxy := util.EnvProxyURL
 	t.Cleanup(func() {
 		nextTraceAPIV4GeoEndpoint = oldEndpoint
-		nextTraceAPIV4HTTPClientFactory = oldFactory
-		resetNextTraceAPIV4ClientCache()
+		nextTraceAPIV4TransportFactory = oldFactory
+		util.EnvProxyURL = oldProxy
+		resetNextTraceAPIV4TransportCache()
 	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -859,14 +1165,15 @@ func TestNextTraceAPIV4GeoIPCachesClientConcurrently(t *testing.T) {
 	defer srv.Close()
 
 	var factoryCalls int32
+	util.EnvProxyURL = ""
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
+	nextTraceAPIV4TransportFactory = func(string, util.GeoDNSPolicy, nextTraceAPIV4ProxyPolicy) *http.Transport {
 		atomic.AddInt32(&factoryCalls, 1)
-		client := srv.Client()
-		client.Timeout = timeout
-		return client
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.Proxy = nil
+		return transport
 	}
-	resetNextTraceAPIV4ClientCache()
+	resetNextTraceAPIV4TransportCache()
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 20)
@@ -886,7 +1193,7 @@ func TestNextTraceAPIV4GeoIPCachesClientConcurrently(t *testing.T) {
 		}
 	}
 	if got := atomic.LoadInt32(&factoryCalls); got != 1 {
-		t.Fatalf("factory calls = %d, want 1 cached client under concurrency", got)
+		t.Fatalf("transport factory calls = %d, want 1 under concurrency", got)
 	}
 }
 

--- a/ipgeo/proxy_test.go
+++ b/ipgeo/proxy_test.go
@@ -1,0 +1,24 @@
+package ipgeo
+
+import (
+	"testing"
+
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+func isolateNextTraceAPIV4ProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy", "REQUEST_METHOD"} {
+		t.Setenv(key, "")
+	}
+}
+
+func isolateNextTraceAPIV4ProxyState(t *testing.T) {
+	t.Helper()
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldProxy := util.EnvProxyURL
+	util.EnvProxyURL = ""
+	t.Cleanup(func() {
+		util.EnvProxyURL = oldProxy
+	})
+}

--- a/util/dns_resolver.go
+++ b/util/dns_resolver.go
@@ -17,22 +17,44 @@ import (
 // ──────────────────────────────────────────────────
 
 var (
-	geoDotServer string        // 当前 dot-server 选项（如 "dnssb"）
-	geoFallback  bool   = true // DoT 失败时是否回退系统 DNS
-	geoMu        sync.RWMutex
-	geoApplyMu   sync.Mutex
-	geoScopeMu   sync.Mutex
-	geoScopeDot  string
-	geoScopePrev struct {
-		dotServer string
-		fallback  bool
-	}
-	geoScopeDepth int
+	geoDotServer   string        // 当前 dot-server 选项（如 "dnssb"）
+	geoFallback    bool   = true // DoT 失败时是否回退系统 DNS
+	geoMu          sync.RWMutex
+	geoApplyMu     sync.Mutex
+	geoScopeMu     sync.Mutex
+	geoScopePolicy GeoDNSPolicy
+	geoScopePrev   GeoDNSPolicy
+	geoScopeDepth  int
 
 	// geoResolverOverride 允许测试注入自定义 resolver（仅测试用）。
 	// 非 nil 时 LookupHostForGeo 的 DoT 阶段使用该 resolver 替代 ResolverForDot 的结果。
 	geoResolverOverride *net.Resolver
 )
+
+// GeoDNSPolicy is an immutable, comparable Geo DNS configuration.
+// Use NewGeoDNSPolicy so resolver names are normalized before comparison or caching.
+type GeoDNSPolicy struct {
+	resolver string
+	fallback bool
+}
+
+// NewGeoDNSPolicy creates a normalized Geo DNS policy.
+func NewGeoDNSPolicy(resolver string, fallback bool) GeoDNSPolicy {
+	return GeoDNSPolicy{
+		resolver: normalizeGeoDNSResolver(resolver),
+		fallback: fallback,
+	}
+}
+
+// Resolver returns the normalized DoT resolver name.
+func (p GeoDNSPolicy) Resolver() string {
+	return p.resolver
+}
+
+// Fallback reports whether a failed DoT lookup falls back to the system resolver.
+func (p GeoDNSPolicy) Fallback() bool {
+	return p.fallback
+}
 
 func setGeoResolverOverride(resolver *net.Resolver) {
 	geoMu.Lock()
@@ -56,9 +78,7 @@ func SetGeoDNSResolver(dotServer string) {
 
 // CurrentGeoDNSResolver 返回当前生效的 Geo DNS resolver 名称（已规范化）。
 func CurrentGeoDNSResolver() string {
-	geoMu.RLock()
-	defer geoMu.RUnlock()
-	return geoDotServer
+	return CurrentGeoDNSPolicy().Resolver()
 }
 
 func normalizeGeoDNSResolver(dotServer string) string {
@@ -72,6 +92,21 @@ func SetGeoDNSFallback(enabled bool) {
 	geoFallback = enabled
 }
 
+// CurrentGeoDNSPolicy returns one consistent snapshot of the active Geo DNS policy.
+func CurrentGeoDNSPolicy() GeoDNSPolicy {
+	geoMu.RLock()
+	defer geoMu.RUnlock()
+	return NewGeoDNSPolicy(geoDotServer, geoFallback)
+}
+
+func setGeoDNSPolicy(policy GeoDNSPolicy) {
+	policy = NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())
+	geoMu.Lock()
+	geoDotServer = policy.Resolver()
+	geoFallback = policy.Fallback()
+	geoMu.Unlock()
+}
+
 // WithGeoDNSResolver 在 callback 生命周期内临时切换 Geo DNS resolver。
 // 该辅助会串行化不同 resolver 的切换与恢复，并允许相同 resolver 作用域安全嵌套。
 func WithGeoDNSResolver[T any](dotServer string, callback func() (T, error)) (T, error) {
@@ -80,12 +115,9 @@ func WithGeoDNSResolver[T any](dotServer string, callback func() (T, error)) (T,
 		return zero, nil
 	}
 	dotServer = normalizeGeoDNSResolver(dotServer)
-	if dotServer == "" {
-		return callback()
-	}
 
 	geoApplyMu.Lock()
-	if geoScopeDepth > 0 && geoScopeDot == dotServer {
+	if geoScopeDepth > 0 && geoScopePolicy.Resolver() == dotServer {
 		geoScopeDepth++
 		geoApplyMu.Unlock()
 		defer releaseGeoDNSResolverScope()
@@ -94,12 +126,12 @@ func WithGeoDNSResolver[T any](dotServer string, callback func() (T, error)) (T,
 	geoApplyMu.Unlock()
 
 	geoScopeMu.Lock()
-	prevDotServer, prevFallback := getGeoDNSConfig()
-	SetGeoDNSResolver(dotServer)
+	previous := CurrentGeoDNSPolicy()
+	policy := NewGeoDNSPolicy(dotServer, previous.Fallback())
+	setGeoDNSPolicy(policy)
 	geoApplyMu.Lock()
-	geoScopeDot = dotServer
-	geoScopePrev.dotServer = prevDotServer
-	geoScopePrev.fallback = prevFallback
+	geoScopePolicy = policy
+	geoScopePrev = previous
 	geoScopeDepth = 1
 	geoApplyMu.Unlock()
 	defer releaseGeoDNSResolverScope()
@@ -119,23 +151,19 @@ func releaseGeoDNSResolverScope() {
 		return
 	}
 
-	prevDotServer := geoScopePrev.dotServer
-	prevFallback := geoScopePrev.fallback
-	geoScopeDot = ""
-	geoScopePrev.dotServer = ""
-	geoScopePrev.fallback = true
+	previous := geoScopePrev
+	geoScopePolicy = GeoDNSPolicy{}
+	geoScopePrev = GeoDNSPolicy{}
 	geoApplyMu.Unlock()
 
-	SetGeoDNSResolver(prevDotServer)
-	SetGeoDNSFallback(prevFallback)
+	setGeoDNSPolicy(previous)
 	geoScopeMu.Unlock()
 }
 
 // getGeoDNSConfig 返回当前快照；并发安全。
 func getGeoDNSConfig() (dotServer string, fallback bool) {
-	geoMu.RLock()
-	defer geoMu.RUnlock()
-	return geoDotServer, geoFallback
+	policy := CurrentGeoDNSPolicy()
+	return policy.Resolver(), policy.Fallback()
 }
 
 // ResolverForDot 根据 dotServer 名字返回对应的 *net.Resolver。
@@ -164,15 +192,20 @@ func ResolverForDot(dotServer string) *net.Resolver {
 //  3. DoT 失败且 fallback=true 时，回退系统 DNS。
 //  4. 全部失败才返回 error。
 func LookupHostForGeo(ctx context.Context, host string) ([]net.IP, error) {
+	return LookupHostForGeoWithPolicy(ctx, host, CurrentGeoDNSPolicy())
+}
+
+// LookupHostForGeoWithPolicy resolves host with one immutable Geo DNS policy.
+func LookupHostForGeoWithPolicy(ctx context.Context, host string, policy GeoDNSPolicy) ([]net.IP, error) {
 	// ── 1. IP 字面量短路 ──
 	if ip := net.ParseIP(host); ip != nil {
 		return []net.IP{ip}, nil
 	}
 
-	dotServer, fallback := getGeoDNSConfig()
+	policy = NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())
 
 	// ── 2. DoT 解析 ──
-	r := ResolverForDot(dotServer)
+	r := ResolverForDot(policy.Resolver())
 	if override := getGeoResolverOverride(); override != nil {
 		r = override
 	}
@@ -182,7 +215,7 @@ func LookupHostForGeo(ctx context.Context, host string) ([]net.IP, error) {
 			return ips, nil
 		}
 		// DoT 失败，决定是否 fallback
-		if !fallback {
+		if !policy.Fallback() {
 			if err != nil {
 				return nil, err
 			}

--- a/util/dns_resolver_test.go
+++ b/util/dns_resolver_test.go
@@ -318,7 +318,7 @@ func TestWithGeoDNSResolver_EmptyScopeIsolatedFromConcurrentDoT(t *testing.T) {
 	go observeEmptyGeoResolverScope(emptyStarted, emptyDone, emptyPolicy)
 	<-emptyStarted
 
-	blocked, completed, got := waitForGeoResolverScopeBlock(emptyPolicy)
+	blocked, completed, got := waitForGeoResolverScopeBlock(t, emptyPolicy)
 	if completed {
 		close(releaseDot)
 		<-dotDone
@@ -361,7 +361,9 @@ func observeEmptyGeoResolverScope(started chan<- struct{}, done chan<- struct{},
 	})
 }
 
-func waitForGeoResolverScopeBlock(result <-chan geoResolverScopeObservation) (blocked bool, completed bool, got geoResolverScopeObservation) {
+func waitForGeoResolverScopeBlock(t *testing.T, result <-chan geoResolverScopeObservation) (blocked bool, completed bool, got geoResolverScopeObservation) {
+	t.Helper()
+	const maxStackDumpSize = 16 << 20
 	deadline := time.Now().Add(2 * time.Second)
 	stack := make([]byte, 1<<20)
 	for time.Now().Before(deadline) {
@@ -371,6 +373,14 @@ func waitForGeoResolverScopeBlock(result <-chan geoResolverScopeObservation) (bl
 		default:
 		}
 		n := runtime.Stack(stack, true)
+		for n == len(stack) {
+			if len(stack) >= maxStackDumpSize {
+				t.Errorf("goroutine stack dump exceeded %d bytes", maxStackDumpSize)
+				return false, false, got
+			}
+			stack = make([]byte, min(len(stack)*2, maxStackDumpSize))
+			n = runtime.Stack(stack, true)
+		}
 		for _, goroutine := range bytes.Split(stack[:n], []byte("\n\n")) {
 			if bytes.Contains(goroutine, []byte("observeEmptyGeoResolverScope")) &&
 				bytes.Contains(goroutine, []byte("[sync.Mutex.Lock")) {

--- a/util/dns_resolver_test.go
+++ b/util/dns_resolver_test.go
@@ -1,11 +1,18 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 )
+
+type geoResolverScopeObservation struct {
+	resolver string
+	fallback bool
+}
 
 // ── ResolverForDot 映射 ─────────────────────────────
 
@@ -26,6 +33,21 @@ func TestResolverMapping(t *testing.T) {
 		if r := ResolverForDot(name); r != nil {
 			t.Errorf("ResolverForDot(%q) = %v, want nil", name, r)
 		}
+	}
+}
+
+func TestGeoDNSPolicyNormalizesAndComparesByResolverAndFallback(t *testing.T) {
+	first := NewGeoDNSPolicy(" CloudFlare ", true)
+	second := NewGeoDNSPolicy("cloudflare", true)
+	withoutFallback := NewGeoDNSPolicy("cloudflare", false)
+	if first != second {
+		t.Fatalf("normalized policies differ: %#v != %#v", first, second)
+	}
+	if first == withoutFallback {
+		t.Fatalf("policies with different fallback behavior compare equal: %#v", first)
+	}
+	if first.Resolver() != "cloudflare" || !first.Fallback() {
+		t.Fatalf("policy = (%q, %t), want (%q, %t)", first.Resolver(), first.Fallback(), "cloudflare", true)
 	}
 }
 
@@ -266,5 +288,134 @@ func TestWithGeoDNSResolver_AllowsNestedSameResolver(t *testing.T) {
 	dot, fallback := getGeoDNSConfig()
 	if dot != "google" || fallback {
 		t.Fatalf("resolver restored to (%q, %t), want (%q, %t)", dot, fallback, "google", false)
+	}
+}
+
+func TestWithGeoDNSResolver_EmptyScopeIsolatedFromConcurrentDoT(t *testing.T) {
+	SetGeoDNSResolver("google")
+	SetGeoDNSFallback(false)
+	defer func() {
+		SetGeoDNSResolver("")
+		SetGeoDNSFallback(true)
+	}()
+
+	dotEntered := make(chan struct{})
+	releaseDot := make(chan struct{})
+	dotDone := make(chan struct{})
+	go func() {
+		defer close(dotDone)
+		_, _ = WithGeoDNSResolver("cloudflare", func() (struct{}, error) {
+			close(dotEntered)
+			<-releaseDot
+			return struct{}{}, nil
+		})
+	}()
+	<-dotEntered
+
+	emptyStarted := make(chan struct{})
+	emptyDone := make(chan struct{})
+	emptyPolicy := make(chan geoResolverScopeObservation, 1)
+	go observeEmptyGeoResolverScope(emptyStarted, emptyDone, emptyPolicy)
+	<-emptyStarted
+
+	blocked, completed, got := waitForGeoResolverScopeBlock(emptyPolicy)
+	if completed {
+		close(releaseDot)
+		<-dotDone
+		<-emptyDone
+		t.Fatalf("empty resolver scope entered active DoT scope and saw (%q, %t)", got.resolver, got.fallback)
+	}
+	if !blocked {
+		close(releaseDot)
+		<-dotDone
+		<-emptyDone
+		t.Fatal("empty resolver scope never reached the active scope lock")
+	}
+
+	close(releaseDot)
+	<-dotDone
+	select {
+	case got := <-emptyPolicy:
+		if got.resolver != "" || got.fallback {
+			t.Fatalf("empty scope saw (%q, %t), want (%q, %t)", got.resolver, got.fallback, "", false)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("empty resolver scope did not resume after DoT scope exited")
+	}
+	<-emptyDone
+
+	resolver, fallback := getGeoDNSConfig()
+	if resolver != "google" || fallback {
+		t.Fatalf("resolver restored to (%q, %t), want (%q, %t)", resolver, fallback, "google", false)
+	}
+}
+
+//go:noinline
+func observeEmptyGeoResolverScope(started chan<- struct{}, done chan<- struct{}, result chan<- geoResolverScopeObservation) {
+	defer close(done)
+	close(started)
+	_, _ = WithGeoDNSResolver("", func() (struct{}, error) {
+		resolver, fallback := getGeoDNSConfig()
+		result <- geoResolverScopeObservation{resolver: resolver, fallback: fallback}
+		return struct{}{}, nil
+	})
+}
+
+func waitForGeoResolverScopeBlock(result <-chan geoResolverScopeObservation) (blocked bool, completed bool, got geoResolverScopeObservation) {
+	deadline := time.Now().Add(2 * time.Second)
+	stack := make([]byte, 1<<20)
+	for time.Now().Before(deadline) {
+		select {
+		case got = <-result:
+			return false, true, got
+		default:
+		}
+		n := runtime.Stack(stack, true)
+		for _, goroutine := range bytes.Split(stack[:n], []byte("\n\n")) {
+			if bytes.Contains(goroutine, []byte("observeEmptyGeoResolverScope")) &&
+				bytes.Contains(goroutine, []byte("[sync.Mutex.Lock")) {
+				return true, false, got
+			}
+		}
+		runtime.Gosched()
+	}
+	return false, false, got
+}
+
+func TestWithGeoDNSResolver_AllowsNestedEmptyResolver(t *testing.T) {
+	SetGeoDNSResolver("google")
+	SetGeoDNSFallback(false)
+	defer func() {
+		SetGeoDNSResolver("")
+		SetGeoDNSFallback(true)
+	}()
+
+	done := make(chan struct{})
+	var (
+		outerResolver string
+		innerResolver string
+	)
+	go func() {
+		defer close(done)
+		_, _ = WithGeoDNSResolver("", func() (struct{}, error) {
+			outerResolver, _ = getGeoDNSConfig()
+			return WithGeoDNSResolver("", func() (struct{}, error) {
+				innerResolver, _ = getGeoDNSConfig()
+				return struct{}{}, nil
+			})
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("nested empty resolver scope deadlocked")
+	}
+	if outerResolver != "" || innerResolver != "" {
+		t.Fatalf("nested empty scopes saw (%q, %q), want empty resolvers", outerResolver, innerResolver)
+	}
+	resolver, fallback := getGeoDNSConfig()
+	if resolver != "google" || fallback {
+		t.Fatalf("resolver restored to (%q, %t), want (%q, %t)", resolver, fallback, "google", false)
 	}
 }

--- a/util/http_client_geo.go
+++ b/util/http_client_geo.go
@@ -71,9 +71,12 @@ func (p *geoHTTPTransportPool) transportFor(policy GeoDNSPolicy) *http.Transport
 }
 
 // NewGeoHTTPClient returns an independently configurable client whose Transport
-// captures the current Geo DNS policy.
+// follows the active Geo DNS policy when a connection is dialed.
 func NewGeoHTTPClient(timeout time.Duration) *http.Client {
-	return NewGeoHTTPClientWithPolicy(timeout, CurrentGeoDNSPolicy())
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: newGeoHTTPTransportForCurrentPolicy(timeout),
+	}
 }
 
 // NewGeoHTTPClientWithPolicy returns an independently configurable client for policy.
@@ -110,11 +113,31 @@ func newGeoHTTPTransport(policy GeoDNSPolicy) *http.Transport {
 	return newGeoHTTPTransportWithLookup(policy, LookupHostForGeoWithPolicy)
 }
 
-func newGeoHTTPTransportWithLookup(policy GeoDNSPolicy, lookup geoHostLookupFunc) *http.Transport {
-	transport := &http.Transport{}
-	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
-		transport = base.Clone()
+func newGeoHTTPTransportForCurrentPolicy(timeout time.Duration) *http.Transport {
+	transport := cloneDefaultGeoHTTPTransport()
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
 	}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return dialer.DialContext(ctx, network, addr)
+		}
+		ips, err := LookupHostForGeo(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("geo DNS returned no IPs for host %q", host)
+		}
+		return dialGeoAddresses(ctx, network, port, ips, dialer.DialContext)
+	}
+	return transport
+}
+
+func newGeoHTTPTransportWithLookup(policy GeoDNSPolicy, lookup geoHostLookupFunc) *http.Transport {
+	transport := cloneDefaultGeoHTTPTransport()
 	if transport.MaxIdleConnsPerHost == 0 {
 		transport.MaxIdleConnsPerHost = geoHTTPDefaultMaxIdleConnsPerHost
 	}
@@ -136,6 +159,13 @@ func newGeoHTTPTransportWithLookup(policy GeoDNSPolicy, lookup geoHostLookupFunc
 		return dialGeoAddresses(ctx, network, port, ips, dialer.DialContext)
 	}
 	return transport
+}
+
+func cloneDefaultGeoHTTPTransport() *http.Transport {
+	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
+		return base.Clone()
+	}
+	return &http.Transport{}
 }
 
 func dialGeoAddresses(ctx context.Context, network, port string, ips []net.IP, dial geoDialContextFunc) (net.Conn, error) {

--- a/util/http_client_geo.go
+++ b/util/http_client_geo.go
@@ -9,7 +9,10 @@ import (
 	"time"
 )
 
-const geoHTTPTransportPoolMaxSize = 32
+const (
+	geoHTTPTransportPoolMaxSize       = 32
+	geoHTTPDefaultMaxIdleConnsPerHost = 32
+)
 
 var (
 	defaultGeoHTTPPolicy    = NewGeoDNSPolicy("", true)
@@ -111,6 +114,9 @@ func newGeoHTTPTransportWithLookup(policy GeoDNSPolicy, lookup geoHostLookupFunc
 	transport := &http.Transport{}
 	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
 		transport = base.Clone()
+	}
+	if transport.MaxIdleConnsPerHost == 0 {
+		transport.MaxIdleConnsPerHost = geoHTTPDefaultMaxIdleConnsPerHost
 	}
 
 	policy = NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())

--- a/util/http_client_geo.go
+++ b/util/http_client_geo.go
@@ -5,54 +5,147 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
-// NewGeoHTTPClient 返回一个使用 Geo DNS 解析策略的 *http.Client。
-//
-// 内部 Transport.DialContext 会通过 LookupHostForGeo 解析目标 host，
-// 然后按 IP 拨号，保持请求 URL Host 不变（即 TLS SNI 不受影响）。
+const geoHTTPTransportPoolMaxSize = 32
+
+var (
+	defaultGeoHTTPPolicy    = NewGeoDNSPolicy("", true)
+	defaultGeoHTTPTransport = sync.OnceValue(func() *http.Transport {
+		return newGeoHTTPTransport(defaultGeoHTTPPolicy)
+	})
+	sharedGeoHTTPTransports = newGeoHTTPTransportPool(geoHTTPTransportPoolMaxSize)
+)
+
+type geoHTTPTransportPool struct {
+	mu         sync.Mutex
+	maxSize    int
+	transports map[GeoDNSPolicy]*http.Transport
+	order      []GeoDNSPolicy
+}
+
+type geoHostLookupFunc func(context.Context, string, GeoDNSPolicy) ([]net.IP, error)
+type geoDialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+func newGeoHTTPTransportPool(maxSize int) *geoHTTPTransportPool {
+	if maxSize < 1 {
+		maxSize = 1
+	}
+	return &geoHTTPTransportPool{
+		maxSize:    maxSize,
+		transports: make(map[GeoDNSPolicy]*http.Transport),
+	}
+}
+
+func (p *geoHTTPTransportPool) transportFor(policy GeoDNSPolicy) *http.Transport {
+	policy = NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())
+	p.mu.Lock()
+	if transport := p.transports[policy]; transport != nil {
+		p.mu.Unlock()
+		return transport
+	}
+
+	transport := newGeoHTTPTransport(policy)
+	p.transports[policy] = transport
+	p.order = append(p.order, policy)
+	var evicted *http.Transport
+	if len(p.order) > p.maxSize {
+		oldest := p.order[0]
+		copy(p.order, p.order[1:])
+		p.order[len(p.order)-1] = GeoDNSPolicy{}
+		p.order = p.order[:len(p.order)-1]
+		evicted = p.transports[oldest]
+		delete(p.transports, oldest)
+	}
+	p.mu.Unlock()
+
+	if evicted != nil {
+		evicted.CloseIdleConnections()
+	}
+	return transport
+}
+
+// NewGeoHTTPClient returns an independently configurable client whose Transport
+// captures the current Geo DNS policy.
 func NewGeoHTTPClient(timeout time.Duration) *http.Client {
-	dialer := &net.Dialer{
+	return NewGeoHTTPClientWithPolicy(timeout, CurrentGeoDNSPolicy())
+}
+
+// NewGeoHTTPClientWithPolicy returns an independently configurable client for policy.
+func NewGeoHTTPClientWithPolicy(timeout time.Duration, policy GeoDNSPolicy) *http.Client {
+	return &http.Client{
 		Timeout:   timeout,
-		KeepAlive: 30 * time.Second,
+		Transport: newGeoHTTPTransport(policy),
 	}
+}
 
-	transport := &http.Transport{}
-	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
-		transport = base.Clone()
+// NewSharedGeoHTTPClient returns a client backed by the shared immutable
+// Transport for the current Geo DNS policy.
+func NewSharedGeoHTTPClient(timeout time.Duration) *http.Client {
+	return NewSharedGeoHTTPClientWithPolicy(timeout, CurrentGeoDNSPolicy())
+}
+
+// NewSharedGeoHTTPClientWithPolicy returns a client backed by the shared
+// immutable Transport for policy. Callers must not mutate Client.Transport.
+func NewSharedGeoHTTPClientWithPolicy(timeout time.Duration, policy GeoDNSPolicy) *http.Client {
+	policy = NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())
+	var transport *http.Transport
+	if policy == defaultGeoHTTPPolicy {
+		transport = defaultGeoHTTPTransport()
+	} else {
+		transport = sharedGeoHTTPTransports.transportFor(policy)
 	}
-	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			// addr 可能不含端口号；原样拨号
-			return dialer.DialContext(ctx, network, addr)
-		}
-
-		// 用 Geo DNS 策略解析 host
-		ips, err := LookupHostForGeo(ctx, host)
-		if err != nil {
-			return nil, err
-		}
-
-		// 依次尝试解析到的 IP，优先使用地址族匹配的
-		var lastErr error
-		for _, ip := range ips {
-			target := net.JoinHostPort(ip.String(), port)
-			conn, dialErr := dialer.DialContext(ctx, network, target)
-			if dialErr == nil {
-				return conn, nil
-			}
-			lastErr = dialErr
-		}
-		if lastErr == nil {
-			return nil, fmt.Errorf("geo DNS returned no IPs for host %q", host)
-		}
-		return nil, lastErr
-	}
-
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
 	}
+}
+
+func newGeoHTTPTransport(policy GeoDNSPolicy) *http.Transport {
+	return newGeoHTTPTransportWithLookup(policy, LookupHostForGeoWithPolicy)
+}
+
+func newGeoHTTPTransportWithLookup(policy GeoDNSPolicy, lookup geoHostLookupFunc) *http.Transport {
+	transport := &http.Transport{}
+	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
+		transport = base.Clone()
+	}
+
+	policy = NewGeoDNSPolicy(policy.Resolver(), policy.Fallback())
+	dialer := &net.Dialer{KeepAlive: 30 * time.Second}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return dialer.DialContext(ctx, network, addr)
+		}
+		ips, err := lookup(ctx, host, policy)
+		if err != nil {
+			return nil, err
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("geo DNS returned no IPs for host %q", host)
+		}
+		return dialGeoAddresses(ctx, network, port, ips, dialer.DialContext)
+	}
+	return transport
+}
+
+func dialGeoAddresses(ctx context.Context, network, port string, ips []net.IP, dial geoDialContextFunc) (net.Conn, error) {
+	var lastErr error
+	for _, ip := range ips {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		conn, err := dial(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, lastErr
 }

--- a/util/http_client_geo_benchmark_test.go
+++ b/util/http_client_geo_benchmark_test.go
@@ -137,10 +137,90 @@ func BenchmarkNewGeoHTTPClient(b *testing.B) {
 	})
 }
 
+func BenchmarkNewSharedGeoHTTPClient(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "geo")
+	}))
+	b.Cleanup(server.Close)
+
+	b.Run("Construct", func(b *testing.B) {
+		b.ReportAllocs()
+		var client *http.Client
+		for b.Loop() {
+			client = NewSharedGeoHTTPClient(5 * time.Second)
+		}
+		b.ReportMetric(1, "clients/op")
+		benchmarkGeoHTTPClientSink = client
+	})
+
+	b.Run("MultiClientSequential", func(b *testing.B) {
+		clients := newSharedGeoHTTPBenchmarkClients(benchmarkGeoHTTPClientCount)
+		b.Cleanup(func() { closeGeoHTTPBenchmarkClients(clients) })
+		warmGeoHTTPBenchmarkClients(b, clients, server.URL)
+
+		b.ReportAllocs()
+		var total int64
+		clientIndex := 0
+		for b.Loop() {
+			n, err := runGeoHTTPBenchmarkRequest(clients[clientIndex], server.URL)
+			if err != nil {
+				b.Fatalf("client %d: %v", clientIndex, err)
+			}
+			total += n
+			clientIndex++
+			if clientIndex == len(clients) {
+				clientIndex = 0
+			}
+		}
+		b.ReportMetric(benchmarkGeoHTTPClientCount, "clients/set")
+		b.ReportMetric(1, "requests/op")
+		benchmarkGeoHTTPBytesSink = total
+	})
+
+	b.Run("MultiClientConcurrent", func(b *testing.B) {
+		clients := newSharedGeoHTTPBenchmarkClients(benchmarkGeoHTTPClientCount)
+		b.Cleanup(func() { closeGeoHTTPBenchmarkClients(clients) })
+		warmGeoHTTPBenchmarkClients(b, clients, server.URL)
+		results := make([]int64, benchmarkGeoHTTPClientCount)
+		errs := make([]error, benchmarkGeoHTTPClientCount)
+
+		b.ReportAllocs()
+		var total int64
+		for b.Loop() {
+			var wg sync.WaitGroup
+			wg.Add(benchmarkGeoHTTPClientCount)
+			for i, client := range clients {
+				go func(index int, requestClient *http.Client) {
+					defer wg.Done()
+					results[index], errs[index] = runGeoHTTPBenchmarkRequest(requestClient, server.URL)
+				}(i, client)
+			}
+			wg.Wait()
+			for i, err := range errs {
+				if err != nil {
+					b.Fatalf("client %d: %v", i, err)
+				}
+				total += results[i]
+			}
+		}
+		b.ReportMetric(benchmarkGeoHTTPClientCount, "clients/set")
+		b.ReportMetric(benchmarkGeoHTTPClientCount, "requests/op")
+		benchmarkGeoHTTPBytesSink = total
+	})
+}
+
 func newGeoHTTPBenchmarkClients(count int) []*http.Client {
 	clients := make([]*http.Client, count)
 	for i := range clients {
 		clients[i] = NewGeoHTTPClient(5 * time.Second)
+	}
+	return clients
+}
+
+func newSharedGeoHTTPBenchmarkClients(count int) []*http.Client {
+	clients := make([]*http.Client, count)
+	for i := range clients {
+		clients[i] = NewSharedGeoHTTPClient(5 * time.Second)
 	}
 	return clients
 }

--- a/util/http_client_geo_test.go
+++ b/util/http_client_geo_test.go
@@ -147,6 +147,17 @@ func TestNewGeoHTTPTransportClonesDefaultTransportSettings(t *testing.T) {
 	}
 }
 
+func TestNewGeoHTTPTransportExpandsImplicitIdlePoolForSharedUse(t *testing.T) {
+	original := http.DefaultTransport
+	defer func() { http.DefaultTransport = original }()
+	http.DefaultTransport = &http.Transport{MaxIdleConnsPerHost: 0}
+
+	transport := newGeoHTTPTransport(NewGeoDNSPolicy("", true))
+	if transport.MaxIdleConnsPerHost != geoHTTPDefaultMaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want %d", transport.MaxIdleConnsPerHost, geoHTTPDefaultMaxIdleConnsPerHost)
+	}
+}
+
 func TestGeoHTTPTransportUsesProxyEnvironmentInFreshProcess(t *testing.T) {
 	const helperEnv = "NEXTTRACE_GEO_PROXY_HELPER"
 	if os.Getenv(helperEnv) == "1" {
@@ -244,6 +255,57 @@ func TestNewSharedGeoHTTPClientReusesConnectionsAcrossClientWrappers(t *testing.
 
 	if got := newConnections.Load(); got > 3 {
 		t.Fatalf("new connections = %d, want at most 3 for 100 sequential requests", got)
+	}
+}
+
+func TestNewSharedGeoHTTPClientReusesConnectionsAcrossConcurrentWrappers(t *testing.T) {
+	var newConnections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "geo")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	policy := NewGeoDNSPolicy("concurrent-reuse", true)
+	clients := make([]*http.Client, 4)
+	for i := range clients {
+		clients[i] = NewSharedGeoHTTPClientWithPolicy(2*time.Second, policy)
+	}
+	defer clients[0].CloseIdleConnections()
+
+	for round := 0; round < 100; round++ {
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(clients))
+		for _, client := range clients {
+			wg.Go(func() {
+				resp, err := client.Get(server.URL)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				_, readErr := io.Copy(io.Discard, resp.Body)
+				closeErr := resp.Body.Close()
+				if readErr != nil {
+					errCh <- readErr
+				} else if closeErr != nil {
+					errCh <- closeErr
+				}
+			})
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Fatalf("round %d: %v", round, err)
+		}
+	}
+
+	if got := newConnections.Load(); got > 8 {
+		t.Fatalf("new connections = %d, want at most 8 for 400 concurrent requests", got)
 	}
 }
 

--- a/util/http_client_geo_test.go
+++ b/util/http_client_geo_test.go
@@ -243,7 +243,7 @@ func geoProxyHelperEnvironment(base []string, helperEnv, proxyURL string) []stri
 		"HTTPS_PROXY":    "",
 		"ALL_PROXY":      "",
 		"NO_PROXY":       "",
-		"http_proxy":     "",
+		"http_proxy":     proxyURL,
 		"https_proxy":    "",
 		"all_proxy":      "",
 		"no_proxy":       "",

--- a/util/http_client_geo_test.go
+++ b/util/http_client_geo_test.go
@@ -100,9 +100,10 @@ func TestNewGeoHTTPClientUsesPolicyAtDialTime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request with policy changed after client creation: %v", err)
 	}
-	defer resp.Body.Close()
-	if body, err := io.ReadAll(resp.Body); err != nil || string(body) != "ok" {
-		t.Fatalf("response body = %q, err = %v, want ok", body, err)
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil || closeErr != nil || string(body) != "ok" {
+		t.Fatalf("response body = %q, read error = %v, close error = %v, want ok", body, readErr, closeErr)
 	}
 }
 
@@ -228,7 +229,8 @@ func TestGeoHTTPTransportUsesProxyEnvironmentInFreshProcess(t *testing.T) {
 		t.Fatalf("test executable: %v", err)
 	}
 	cmd := exec.Command(executable, "-test.run=^TestGeoHTTPTransportUsesProxyEnvironmentInFreshProcess$")
-	cmd.Env = geoProxyHelperEnvironment(os.Environ(), helperEnv, proxy.URL)
+	helperBase := append(os.Environ(), "REQUEST_METHOD=GET")
+	cmd.Env = geoProxyHelperEnvironment(helperBase, helperEnv, proxy.URL)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("proxy helper failed: %v\n%s", err, output)
 	}
@@ -236,15 +238,16 @@ func TestGeoHTTPTransportUsesProxyEnvironmentInFreshProcess(t *testing.T) {
 
 func geoProxyHelperEnvironment(base []string, helperEnv, proxyURL string) []string {
 	overridden := map[string]string{
-		helperEnv:     "1",
-		"HTTP_PROXY":  proxyURL,
-		"HTTPS_PROXY": "",
-		"ALL_PROXY":   "",
-		"NO_PROXY":    "",
-		"http_proxy":  "",
-		"https_proxy": "",
-		"all_proxy":   "",
-		"no_proxy":    "",
+		helperEnv:        "1",
+		"HTTP_PROXY":     proxyURL,
+		"HTTPS_PROXY":    "",
+		"ALL_PROXY":      "",
+		"NO_PROXY":       "",
+		"http_proxy":     "",
+		"https_proxy":    "",
+		"all_proxy":      "",
+		"no_proxy":       "",
+		"REQUEST_METHOD": "",
 	}
 	env := make([]string, 0, len(base)+len(overridden))
 	for _, entry := range base {
@@ -447,7 +450,11 @@ func TestDialGeoAddressesPreservesDNSOrder(t *testing.T) {
 	}
 	var attempts []string
 	clientConn, serverConn := net.Pipe()
-	defer serverConn.Close()
+	defer func() {
+		if err := serverConn.Close(); err != nil {
+			t.Errorf("close server connection: %v", err)
+		}
+	}()
 	dial := func(_ context.Context, _ string, addr string) (net.Conn, error) {
 		attempts = append(attempts, addr)
 		if len(attempts) == len(ips) {

--- a/util/http_client_geo_test.go
+++ b/util/http_client_geo_test.go
@@ -1,7 +1,21 @@
 package util
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -37,5 +51,440 @@ func TestNewGeoHTTPClient_DifferentTimeouts(t *testing.T) {
 		if c.Timeout != d {
 			t.Errorf("NewGeoHTTPClient(%v).Timeout = %v", d, c.Timeout)
 		}
+	}
+}
+
+func TestNewGeoHTTPClientTransportRemainsIsolated(t *testing.T) {
+	first := NewGeoHTTPClient(time.Second)
+	second := NewGeoHTTPClient(time.Second)
+	if first.Transport == second.Transport {
+		t.Fatal("NewGeoHTTPClient unexpectedly exposes a shared mutable Transport")
+	}
+	firstTransport := first.Transport.(*http.Transport)
+	secondTransport := second.Transport.(*http.Transport)
+	firstTransport.MaxIdleConns = 1
+	if secondTransport.MaxIdleConns == 1 {
+		t.Fatal("mutating one legacy client Transport affected another client")
+	}
+}
+
+func TestNewSharedGeoHTTPClientSharesTransportByPolicy(t *testing.T) {
+	defaultPolicy := NewGeoDNSPolicy("", true)
+	first := NewSharedGeoHTTPClientWithPolicy(500*time.Millisecond, defaultPolicy)
+	second := NewSharedGeoHTTPClientWithPolicy(10*time.Second, defaultPolicy)
+	if first.Transport != second.Transport {
+		t.Fatal("default Geo HTTP clients do not share their Transport")
+	}
+	if first.Timeout != 500*time.Millisecond || second.Timeout != 10*time.Second {
+		t.Fatalf("client timeouts = (%s, %s), want per-client values", first.Timeout, second.Timeout)
+	}
+
+	google := NewGeoDNSPolicy(" Google ", true)
+	googleAgain := NewGeoDNSPolicy("google", true)
+	withoutFallback := NewGeoDNSPolicy("google", false)
+	googleClient := NewSharedGeoHTTPClientWithPolicy(time.Second, google)
+	googleClientAgain := NewSharedGeoHTTPClientWithPolicy(2*time.Second, googleAgain)
+	withoutFallbackClient := NewSharedGeoHTTPClientWithPolicy(time.Second, withoutFallback)
+	if googleClient.Transport != googleClientAgain.Transport {
+		t.Fatal("equivalent normalized policies do not share their Transport")
+	}
+	if googleClient.Transport == withoutFallbackClient.Transport {
+		t.Fatal("policies with different fallback behavior share a Transport")
+	}
+	if googleClient.Transport == first.Transport {
+		t.Fatal("default and non-default policies share a Transport")
+	}
+}
+
+func TestNewGeoHTTPTransportClonesDefaultTransportSettings(t *testing.T) {
+	original := http.DefaultTransport
+	defer func() { http.DefaultTransport = original }()
+
+	proxyErr := errors.New("proxy marker")
+	base := &http.Transport{
+		Proxy: func(*http.Request) (*url.URL, error) {
+			return nil, proxyErr
+		},
+		TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS13},
+		ForceAttemptHTTP2:   true,
+		MaxIdleConns:        73,
+		MaxIdleConnsPerHost: 17,
+		IdleConnTimeout:     41 * time.Second,
+	}
+	http.DefaultTransport = base
+
+	transport := newGeoHTTPTransportWithLookup(
+		NewGeoDNSPolicy("cloudflare", true),
+		func(context.Context, string, GeoDNSPolicy) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		},
+	)
+	if transport == base {
+		t.Fatal("Geo Transport reused the mutable default Transport instead of cloning it")
+	}
+	if transport.Proxy == nil {
+		t.Fatal("Geo Transport dropped the default proxy function")
+	}
+	if _, err := transport.Proxy(&http.Request{}); !errors.Is(err, proxyErr) {
+		t.Fatalf("Geo Transport proxy error = %v, want %v", err, proxyErr)
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("Geo Transport TLS config = %#v, want cloned TLS 1.3 config", transport.TLSClientConfig)
+	}
+	if transport.TLSClientConfig == base.TLSClientConfig {
+		t.Fatal("Geo Transport shares the default Transport TLS config pointer")
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Fatal("Geo Transport dropped ForceAttemptHTTP2")
+	}
+	if transport.MaxIdleConns != 73 || transport.MaxIdleConnsPerHost != 17 || transport.IdleConnTimeout != 41*time.Second {
+		t.Fatalf(
+			"Geo Transport pool settings = (%d, %d, %s), want (73, 17, 41s)",
+			transport.MaxIdleConns,
+			transport.MaxIdleConnsPerHost,
+			transport.IdleConnTimeout,
+		)
+	}
+}
+
+func TestGeoHTTPTransportUsesProxyEnvironmentInFreshProcess(t *testing.T) {
+	const helperEnv = "NEXTTRACE_GEO_PROXY_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		client := NewSharedGeoHTTPClientWithPolicy(time.Second, NewGeoDNSPolicy("", true))
+		resp, err := client.Get("http://geo-target.invalid/probe")
+		if err != nil {
+			t.Fatalf("proxy helper request: %v", err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil || closeErr != nil {
+			t.Fatalf("proxy helper response read=%v close=%v", readErr, closeErr)
+		}
+		if string(body) != "proxied" {
+			t.Fatalf("proxy helper body = %q, want proxied", body)
+		}
+		return
+	}
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Host != "geo-target.invalid" || r.URL.Path != "/probe" {
+			t.Errorf("proxy request URL = %s, want http://geo-target.invalid/probe", r.URL.String())
+		}
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	defer proxy.Close()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("test executable: %v", err)
+	}
+	cmd := exec.Command(executable, "-test.run=^TestGeoHTTPTransportUsesProxyEnvironmentInFreshProcess$")
+	cmd.Env = geoProxyHelperEnvironment(os.Environ(), helperEnv, proxy.URL)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("proxy helper failed: %v\n%s", err, output)
+	}
+}
+
+func geoProxyHelperEnvironment(base []string, helperEnv, proxyURL string) []string {
+	overridden := map[string]string{
+		helperEnv:     "1",
+		"HTTP_PROXY":  proxyURL,
+		"HTTPS_PROXY": "",
+		"ALL_PROXY":   "",
+		"NO_PROXY":    "",
+		"http_proxy":  "",
+		"https_proxy": "",
+		"all_proxy":   "",
+		"no_proxy":    "",
+	}
+	env := make([]string, 0, len(base)+len(overridden))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, replace := overridden[key]; replace {
+				continue
+			}
+		}
+		env = append(env, entry)
+	}
+	for key, value := range overridden {
+		env = append(env, key+"="+value)
+	}
+	return env
+}
+
+func TestNewSharedGeoHTTPClientReusesConnectionsAcrossClientWrappers(t *testing.T) {
+	var newConnections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "geo")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	policy := NewGeoDNSPolicy("", true)
+	for i := 0; i < 100; i++ {
+		client := NewSharedGeoHTTPClientWithPolicy(2*time.Second, policy)
+		resp, err := client.Get(server.URL)
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("read response %d: %v", i, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("close response %d: %v", i, err)
+		}
+	}
+
+	if got := newConnections.Load(); got > 3 {
+		t.Fatalf("new connections = %d, want at most 3 for 100 sequential requests", got)
+	}
+}
+
+func TestGeoHTTPTransportPoolEvictsOldestAndClosesIdleConnections(t *testing.T) {
+	idle := make(chan struct{}, 1)
+	closed := make(chan struct{}, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "geo")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateIdle:
+			select {
+			case idle <- struct{}{}:
+			default:
+			}
+		case http.StateClosed:
+			select {
+			case closed <- struct{}{}:
+			default:
+			}
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	pool := newGeoHTTPTransportPool(2)
+	firstPolicy := NewGeoDNSPolicy("resolver-1", true)
+	firstTransport := pool.transportFor(firstPolicy)
+	client := &http.Client{Timeout: time.Second, Transport: firstTransport}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("warm first Transport: %v", err)
+	}
+	_, readErr := io.Copy(io.Discard, resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("warm first Transport read=%v close=%v", readErr, closeErr)
+	}
+	select {
+	case <-idle:
+	case <-time.After(time.Second):
+		t.Fatal("first Transport connection did not become idle")
+	}
+
+	_ = pool.transportFor(NewGeoDNSPolicy("resolver-2", true))
+	_ = pool.transportFor(NewGeoDNSPolicy("resolver-3", true))
+
+	pool.mu.Lock()
+	_, firstStillCached := pool.transports[firstPolicy]
+	gotOrder := append([]GeoDNSPolicy(nil), pool.order...)
+	pool.mu.Unlock()
+	if firstStillCached {
+		t.Fatal("oldest Transport remains cached after FIFO eviction")
+	}
+	wantOrder := []GeoDNSPolicy{
+		NewGeoDNSPolicy("resolver-2", true),
+		NewGeoDNSPolicy("resolver-3", true),
+	}
+	if !reflect.DeepEqual(gotOrder, wantOrder) {
+		t.Fatalf("pool order = %#v, want %#v", gotOrder, wantOrder)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("evicted Transport did not close its idle connection")
+	}
+}
+
+func TestGeoHTTPTransportPoolCoalescesConcurrentMiss(t *testing.T) {
+	pool := newGeoHTTPTransportPool(geoHTTPTransportPoolMaxSize)
+	policy := NewGeoDNSPolicy("concurrent", true)
+	transports := make([]*http.Transport, 32)
+	var wg sync.WaitGroup
+	for i := range transports {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			transports[index] = pool.transportFor(policy)
+		}(i)
+	}
+	wg.Wait()
+	for i := 1; i < len(transports); i++ {
+		if transports[i] != transports[0] {
+			t.Fatalf("transport %d differs for one concurrent policy", i)
+		}
+	}
+	pool.mu.Lock()
+	gotSize := len(pool.transports)
+	pool.mu.Unlock()
+	if gotSize != 1 {
+		t.Fatalf("pool size = %d, want 1", gotSize)
+	}
+}
+
+func TestDialGeoAddressesPreservesDNSOrder(t *testing.T) {
+	ips := []net.IP{
+		net.ParseIP("2001:db8::1"),
+		net.ParseIP("192.0.2.1"),
+		net.ParseIP("198.51.100.2"),
+	}
+	var attempts []string
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+	dial := func(_ context.Context, _ string, addr string) (net.Conn, error) {
+		attempts = append(attempts, addr)
+		if len(attempts) == len(ips) {
+			return clientConn, nil
+		}
+		return nil, errors.New("unreachable")
+	}
+
+	conn, err := dialGeoAddresses(context.Background(), "tcp", "443", ips, dial)
+	if err != nil {
+		t.Fatalf("dialGeoAddresses() error = %v", err)
+	}
+	_ = conn.Close()
+	want := []string{
+		net.JoinHostPort("2001:db8::1", "443"),
+		net.JoinHostPort("192.0.2.1", "443"),
+		net.JoinHostPort("198.51.100.2", "443"),
+	}
+	if !reflect.DeepEqual(attempts, want) {
+		t.Fatalf("dial attempts = %#v, want DNS order %#v", attempts, want)
+	}
+}
+
+func TestDialGeoAddressesStopsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	result := make(chan error, 1)
+	var attempts atomic.Int32
+	go func() {
+		_, err := dialGeoAddresses(ctx, "tcp", "443", []net.IP{
+			net.ParseIP("192.0.2.1"),
+			net.ParseIP("198.51.100.2"),
+		}, func(ctx context.Context, _ string, _ string) (net.Conn, error) {
+			attempts.Add(1)
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+		result <- err
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("dialGeoAddresses() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("dial did not stop after context cancellation")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("dial attempts after cancellation = %d, want 1", got)
+	}
+}
+
+func TestGeoHTTPTransportKeepsURLHostForTLSAndHTTP(t *testing.T) {
+	lookedUpHost := make(chan string, 1)
+	gotSNI := make(chan string, 1)
+	gotHost := make(chan string, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSNI <- r.TLS.ServerName
+		gotHost <- r.Host
+		_, _ = io.WriteString(w, "geo")
+	}))
+	server.StartTLS()
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	transport := newGeoHTTPTransportWithLookup(
+		NewGeoDNSPolicy("test", false),
+		func(_ context.Context, host string, _ GeoDNSPolicy) ([]net.IP, error) {
+			lookedUpHost <- host
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		},
+	)
+	transport.Proxy = nil
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    roots,
+	}
+	client := &http.Client{Timeout: time.Second, Transport: transport}
+	resp, err := client.Get("https://" + net.JoinHostPort("example.com", port))
+	if err != nil {
+		t.Fatalf("TLS request: %v", err)
+	}
+	_, readErr := io.Copy(io.Discard, resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("TLS response read=%v close=%v", readErr, closeErr)
+	}
+	if host := <-lookedUpHost; host != "example.com" {
+		t.Fatalf("lookup host = %q, want example.com", host)
+	}
+	if sni := <-gotSNI; sni != "example.com" {
+		t.Fatalf("TLS SNI = %q, want example.com", sni)
+	}
+	if host := <-gotHost; host != net.JoinHostPort("example.com", port) {
+		t.Fatalf("HTTP Host = %q, want %q", host, net.JoinHostPort("example.com", port))
+	}
+}
+
+func TestGeoHTTPClientRequestContextCancelsBodyRead(t *testing.T) {
+	requestCanceled := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+		requestCanceled <- struct{}{}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	client := NewGeoHTTPClientWithPolicy(2*time.Second, NewGeoDNSPolicy("", true))
+	resp, err := client.Do(req)
+	if err == nil {
+		_, err = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("request/body error = %v, want context deadline exceeded", err)
+	}
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request context was not canceled")
 	}
 }

--- a/util/http_client_geo_test.go
+++ b/util/http_client_geo_test.go
@@ -68,6 +68,44 @@ func TestNewGeoHTTPClientTransportRemainsIsolated(t *testing.T) {
 	}
 }
 
+func TestNewGeoHTTPClientUsesPolicyAtDialTime(t *testing.T) {
+	previousPolicy := CurrentGeoDNSPolicy()
+	previousOverride := getGeoResolverOverride()
+	t.Cleanup(func() {
+		setGeoDNSPolicy(previousPolicy)
+		setGeoResolverOverride(previousOverride)
+	})
+
+	lookupErr := errors.New("blocked test resolver")
+	setGeoResolverOverride(&net.Resolver{
+		PreferGo: true,
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			return nil, lookupErr
+		},
+	})
+	setGeoDNSPolicy(NewGeoDNSPolicy("cloudflare", false))
+	client := NewGeoHTTPClient(time.Second)
+	t.Cleanup(client.CloseIdleConnections)
+
+	setGeoDNSPolicy(NewGeoDNSPolicy("", true))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	resp, err := client.Get("http://" + net.JoinHostPort("localhost", port))
+	if err != nil {
+		t.Fatalf("request with policy changed after client creation: %v", err)
+	}
+	defer resp.Body.Close()
+	if body, err := io.ReadAll(resp.Body); err != nil || string(body) != "ok" {
+		t.Fatalf("response body = %q, err = %v, want ok", body, err)
+	}
+}
+
 func TestNewSharedGeoHTTPClientSharesTransportByPolicy(t *testing.T) {
 	defaultPolicy := NewGeoDNSPolicy("", true)
 	first := NewSharedGeoHTTPClientWithPolicy(500*time.Millisecond, defaultPolicy)


### PR DESCRIPTION
## 问题

使用 `NewGeoHTTPClient` 的内建 HTTP Geo provider 每次请求都克隆新的
`http.Transport`，使短生命周期 client 无法跨请求复用连接。NextTrace API v4 的
连接缓存还把 token/timeout 与可变 resolver 状态混入生命周期；IPDB.One 首次刷新
由一次性 `sync.Once` 管理，过期刷新不能合并并发认证，失败传播与重试路径不统一。

## 前后调用链

| 路径 | 调整前 | 调整后 |
| --- | --- | --- |
| 普通 Geo provider | `NewGeoHTTPClient -> Transport.Clone -> 独立连接池` | `NewSharedGeoHTTPClient -> immutable DNS policy -> 共享 Transport` |
| 非默认 DNS 策略 | 每个 client 独立 Transport | 32 项 FIFO policy pool，淘汰时关闭空闲连接 |
| NextTrace API v4 | client/连接生命周期混入 token、timeout 与全局 resolver | endpoint + DNS policy + proxy policy 独立 Transport 池；timeout 由 request context 控制 |
| IPDB.One token | 首次由一次性 `sync.Once` 管理，过期刷新未合并 | 首次与过期统一使用 reusable singleflight；较长预算 waiter 可在短 flight 超时后重新竞争 |

## 变更

- 新增规范化、可比较的 `GeoDNSPolicy` 快照及按策略查询接口。
- 修复空 resolver scope 与非空 scope 生命周期不一致；相同策略允许安全嵌套，
  不同并发 scope 串行执行并恢复原状态。
- 新增显式共享 client 构造器；默认策略由 `sync.OnceValue` 持有，非默认策略按
  FIFO 最多缓存 32 个 Transport，命中不刷新顺序。
- Transport 从 `http.DefaultTransport` 克隆，保留 proxy、TLS、HTTP/2 和连接池；
  DNS 返回地址按原顺序 fallback，TLS SNI 保持 URL host。
- 本轮迁移的内建 HTTP provider 使用 request context 作为总预算，client timeout
  仅作兼容兜底。
- NextTrace API v4 使用独立的 32 项 Transport 池；key 排除 token/timeout，包含完整
  环境代理配置，重定向仍逐 URL 判定 proxy。
- FastIP 仅用于初始 endpoint 直连；失败回到该请求捕获的 DNS policy Dialer。
- IPDB.One 首次及过期 token 刷新使用 shared singleflight，保留 30 秒有效期、
  错误不缓存和原始查询总预算。
- 保留既有 `NewGeoHTTPClient` 在实际拨号时读取 active DNS policy、并使用传入值作为
  Dialer timeout 的行为；新增策略快照与共享接口不改变旧调用者语义。
- 新增可读证据报告：`docs/performance/go127-geo-http-transport.md`。

## 兼容性

- 保留既有 `NewGeoHTTPClient` 的签名及独立、可配置 Transport 语义；新增的
  `NewGeoHTTPClientWithPolicy` 也返回独立 Transport，共享行为只由新增接口显式选择。
- 不修改现有导出 API 的签名，不修改 CLI flag、退出码、stdout/stderr、JSON schema、
  MTR 统计、TTY/ANSI 或协议报文。
- 底层 context/http 超时包装文本不作为稳定合同；显式错误状态与 fallback 语义保留。
- tiny/ntr 的 Linux arm64 未压缩产物大小不变，没有扩大 flavor 依赖边界。

## 测试

本地 exact head `a2cfb9a39fa3bca6b829ca7178748da23ecbf417` 已通过：

- `go test -count=1 ./...`
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go build ./...`
- `go vet ./...`
- `go test -count=1 -tags flavor_tiny ./cmd ./server`
- `go test -count=1 -tags flavor_ntr ./cmd ./server`
- full、tiny、ntr 专项构建
- `node --test server/web/assets/*.test.cjs`：15/15
- `go mod verify`
- `go mod tidy -diff`：无差异
- `golangci-lint v2.13.2 --new-from-rev 2842829...`：0 issues
- `git diff --check`

implementation head `dfd0fb645eb30c102662fb66a36609568c26a77e` 的 release-style
Darwin 三 flavor `LC_BUILD_VERSION` 均为 `minos 13.0`。最终 exact head 的 GitHub
门禁完成 48 项：47 项成功，PR 场景的 `release` 正常跳过，0 项失败或等待；包含
默认/nojsonv2、race、lint、CodeQL、Linux/macOS/Windows regression、完整跨平台构建
矩阵和 Linux 性能交叉参考 artifact 校验。

新增 focused 回归覆盖 100 次顺序请求、100 轮每轮 4 个并发请求、DNS 地址顺序、
SNI、HTTP proxy 子进程、HTTPS CONNECT、重定向/NO_PROXY、dial/read 取消、FIFO
淘汰、并发 DNS scope、NextTrace v4 cache，以及 IPDB.One 的 32 并发刷新和长短预算。

## Race

- `go test -race -count=1 ./...`：通过。
- util/ipgeo focused race、IPDB 并发预算用例及 SNI/proxy/fallback 用例均通过。

## Benchstat

环境：Apple M5、Go 1.27.1、`GOMAXPROCS=10`、AC 供电、相同工具版本；每组
`count=10`、`benchtime=1s`。parent 为
`284282979f88f81a62a8d987189b8711174d02d5`，benchmark head 为
`407d84394397f0aa21ed7b05ab611afdb2e3ba75`；shared-path profile 同样对应该 head，
最终 focused head 为 `dfd0fb645eb30c102662fb66a36609568c26a77e`。后续兼容修复
只将共享路径的 DefaultTransport clone 逻辑等价抽取为 helper，未改变被 profile 的
共享策略、连接池或 benchmark 语义。

同一 head 内将生产共享路径与兼容独立路径比较：

- client construct：174.00 ns -> 16.96 ns，`-90.25%`。
- construct：1,232 B / 6 allocs -> 48 B / 1 alloc，分别 `-96.10%` / `-83.33%`。
- multi-client sequential：29.42 us -> 29.46 us，无显著差异。
- multi-client concurrent：72.16 us -> 71.60 us，无显著差异；293 -> 292 allocs/op。

连接计数测试确认 100 次顺序请求不超过 3 个新连接，100 轮每轮 4 并发请求不超过
8 个新连接。最终 focused 对比还确认既有独立构造器的请求耗时无显著差异，构造
耗时降低 23.93%、分配从 7 次降为 6 次。未修改 benchmark 的全套波动不作 PR-2
归因。完整数据见性能报告。

## Profile

`MultiClientConcurrent` 在无并行构建负载时以 `-benchtime=30s` 串行采集 CPU/heap
profile：

- 75.991 us -> 74.517 us。
- 24,899 B / 293 allocs -> 24,926 B / 292 allocs。
- CPU 两侧均主要由 syscall、cond wait 与 kevent 构成；heap 两侧均主要位于 HTTP
  header/request/connection 路径，未出现新的结构性热点。

原始 profile 作为本地/CI artifact，不提交仓库。

## 产物大小

相同 stripped 参数下：

- Darwin arm64：full `+32 B`，tiny/ntr 各 `+16 B`。
- Linux arm64 未压缩：full `+65,536 B`，tiny/ntr `0 B`。
- Linux arm64 UPX 5.2.1 `-9`：full `+0.068%`，tiny `+0.136%`，ntr `+0.137%`。

## 平台风险

- Darwin 最低版本继续为 macOS 13.0；Linux/Windows/Darwin 构建矩阵通过。
- 普通非默认策略池与 NextTrace API v4 策略池各有 32 项上限；默认策略另由
  `OnceValue` 持有。淘汰会在锁外关闭空闲连接。
- 共享 Transport 延长空闲连接生命周期，但 request context 继续约束 DNS、dial、
  response header 和 body read 的总预算。
- 代理、HTTP/2、TLS 与系统证书行为继续继承标准 Transport。

## 回退方案

按下列实现 commit 的逆序 revert 即可；没有配置、JSON、缓存格式或持久数据迁移，
旧导出 API 未删除或改签名。

## Commit 列表

- `af2b952698a7649bda088fb77700267a7ee4d580 perf(geo): 复用不可变 DNS 策略 Transport`
- `a1315a1d33071cd937edda6894c5074a97cf1432 perf(ipgeo): 复用 NextTrace API v4 策略 Transport`
- `b838fc06746f68d90ce05372bd059127346f6ecf perf(ipdbone): 合并并发 token 刷新`
- `407d84394397f0aa21ed7b05ab611afdb2e3ba75 perf(geo): 扩展共享连接池空闲容量`
- `dfd0fb645eb30c102662fb66a36609568c26a77e fix(geo): 保留旧 client 的动态 DNS 语义`
- `71b016b052495672458210c55be0c8774f6a3eb0 docs(perf): 记录 Geo HTTP Transport 复用证据`
- `369ab9e2d8704d706ae6c56589832f269b2d4130 fix(ipdbone): 在过期时刻失效缓存 token`
- `5d20b5651090ca16ce99341b422a2069fba546f6 test(geo): 隔离代理子进程 CGI 环境`
- `75a5db6ffb5da5158ac217b35f8726fcf53db78d test(geo): 统一 Windows 代理环境别名`
- `a2cfb9a39fa3bca6b829ca7178748da23ecbf417 test(geo): 动态扩容 goroutine 堆栈快照`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **性能优化**
  - 地理位置查询复用网络连接，减少客户端创建开销，提升请求构造与整体响应效率。
  - 支持按 GeoDNS 配置复用连接，并改善代理、TLS 与连接淘汰处理。

- **稳定性改进**
  - 请求统一支持超时与取消，避免长时间占用资源。
  - IPDB.One 并发获取令牌时减少重复认证；认证失败后支持安全重试。

- **文档**
  - 新增 Go 1.27 地理位置 HTTP 传输复用性能说明及验证数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->