### PR TITLE
perf(dn42): 索引 GeoFeed 最长前缀查询

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ In MTR mode (`--mtr`, `-r`, `-w`, including `--raw`), `-i/--ttl-time` sets the *
 >
 > Note: `--mtr` cannot be used together with `--table`, `--classic`, `--json`, `--output`, `--output-default`, `--route-path`, `--from`, `--fast-trace`, `--file`, or `--deploy`.
 
-#### `NextTrace` supports users to select their own IP API (currently supports: `NextTrace-API`, `IP.SB`, `IPInfo`, `IPInsight`, `IPAPI.com`, `IPInfoLocal`, `IPDB.One`, `CHUNZHEN`)
+#### `NextTrace` supports users to select their own IP API (currently supports: `NextTrace-API`, `IP.SB`, `IPInfo`, `IPInsight`, `IPAPI.com`, `IPInfoLocal`, `IPDB.One`, `CHUNZHEN`, `DN42`)
 
 ##### LeoMoeAPI name migration
 
@@ -809,7 +809,7 @@ Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
                  [-p|--port <integer>] [--icmp-mode <integer>] [-q|--queries <integer>]
                  [--max-attempts <integer>] [--parallel-requests <integer>]
                  [-m|--max-hops <integer>] [-d|--data-provider
-                 (IP.SB|ip.sb|IPInfo|ipinfo|IPInsight|ipinsight|IPAPI.com|ip-api.com|IPInfoLocal|ipinfolocal|chunzhen|NextTrace-API|ipdb.one|disable-geoip)]
+                 (IP.SB|ip.sb|IPInfo|ipinfo|IPInsight|ipinsight|IPAPI.com|ip-api.com|IPInfoLocal|ipinfolocal|chunzhen|NextTrace-API|ipdb.one|disable-geoip|DN42|dn42)]
                  [--pow-provider (api.nxtrace.org|sakura)] [-n|--no-rdns]
                  [-a|--always-rdns] [-P|--route-path] [--dn42] [-o|--output
                  "<value>"] [-O|--output-default] [--table] [--raw]
@@ -864,7 +864,7 @@ Arguments:
   -d  --data-provider                Choose IP Geographic Data Provider
                                      [NextTrace-API, IP.SB, IPInfo, IPInsight,
                                      IP-API.com, IPInfoLocal, ipdb.one,
-                                     chunzhen, disable-geoip]. Default:
+                                     chunzhen, disable-geoip, DN42]. Default:
                                      NextTrace-API
       --pow-provider                 Choose PoW Provider for NextTrace API v3
                                      [api.nxtrace.org, sakura] For China

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -647,7 +647,7 @@ raw stdout 契约仍严格保持 12 列。无限运行的 MTR 中，unreachable 
 >
 > 注意：`--mtr` 不可与 `--table`、`--classic`、`--json`、`--output`、`--output-default`、`--route-path`、`--from`、`--fast-trace`、`--file`、`--deploy` 同时使用。
 
-#### `NextTrace`支持用户自主选择 IP 数据库（目前支持：`NextTrace-API`, `IP.SB`, `IPInfo`, `IPInsight`, `IPAPI.com`, `IPInfoLocal`, `IPDB.One`, `CHUNZHEN`）
+#### `NextTrace`支持用户自主选择 IP 数据库（目前支持：`NextTrace-API`, `IP.SB`, `IPInfo`, `IPInsight`, `IPAPI.com`, `IPInfoLocal`, `IPDB.One`, `CHUNZHEN`, `DN42`）
 
 ##### LeoMoeAPI 名称迁移
 
@@ -785,7 +785,7 @@ Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
                  [-p|--port <integer>] [--icmp-mode <integer>] [-q|--queries <integer>]
                  [--max-attempts <integer>] [--parallel-requests <integer>]
                  [-m|--max-hops <integer>] [-d|--data-provider
-                 (IP.SB|ip.sb|IPInfo|ipinfo|IPInsight|ipinsight|IPAPI.com|ip-api.com|IPInfoLocal|ipinfolocal|chunzhen|NextTrace-API|ipdb.one|disable-geoip)]
+                 (IP.SB|ip.sb|IPInfo|ipinfo|IPInsight|ipinsight|IPAPI.com|ip-api.com|IPInfoLocal|ipinfolocal|chunzhen|NextTrace-API|ipdb.one|disable-geoip|DN42|dn42)]
                  [--pow-provider (api.nxtrace.org|sakura)] [-n|--no-rdns]
                  [-a|--always-rdns] [-P|--route-path] [--dn42] [-o|--output
                  "<value>"] [-O|--output-default] [--table] [--raw]
@@ -840,7 +840,7 @@ Arguments:
   -d  --data-provider                Choose IP Geographic Data Provider
                                      [NextTrace-API, IP.SB, IPInfo, IPInsight,
                                      IP-API.com, IPInfoLocal, ipdb.one,
-                                     chunzhen, disable-geoip]. Default:
+                                     chunzhen, disable-geoip, DN42]. Default:
                                      NextTrace-API
       --pow-provider                 Choose PoW Provider for NextTrace API v3
                                      [api.nxtrace.org, sakura] For China

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -845,6 +845,9 @@ func runFastTraceModeWithRuntime(ctx context.Context, dn42 bool, dataOrigin *str
 	nextTraceAPIV3WS, runtimePrepared := prepareFastTraceRuntimeEnvironment(ctx, dn42, dataOrigin, disableMaptrace, powProvider)
 	defer closeNextTraceAPIV3WebSocket(nextTraceAPIV3WS)
 	params.RuntimePrepared = runtimePrepared
+	params.DataProvider = *dataOrigin
+	params.IPGeoSource = ipgeo.GetSource(*dataOrigin)
+	params.DN42 = isDN42Provider(*dataOrigin)
 	return maybeRunFastTraceMode(from, fastTraceFlag, file, params, method)
 }
 
@@ -895,11 +898,15 @@ func resolveCLITargetOrExit(raw string, usage string) string {
 }
 
 func applyDN42Mode(enabled bool, dataOrigin *string, disableMaptrace *bool) {
-	if !enabled {
+	if !enabled && !isDN42Provider(*dataOrigin) {
 		return
 	}
 	applyDN42DataOrigin(dataOrigin)
 	*disableMaptrace = true
+}
+
+func isDN42Provider(provider string) bool {
+	return strings.EqualFold(strings.TrimSpace(provider), "DN42")
 }
 
 func applyDN42DataOrigin(dataOrigin *string) {
@@ -909,14 +916,24 @@ func applyDN42DataOrigin(dataOrigin *string) {
 
 func prepareRuntimeEnvironment(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string, asyncNextTraceAPIV3 bool) *wshandle.WsConn {
 	capabilitiesCheck()
+	dn42Configured := dn42 || isDN42Provider(*dataOrigin)
 	applyDN42Mode(dn42, dataOrigin, disableMaptrace)
-	return initNextTraceAPIV3WebSocket(ctx, dataOrigin, powProvider, asyncNextTraceAPIV3)
+	conn := initNextTraceAPIV3WebSocket(ctx, dataOrigin, powProvider, asyncNextTraceAPIV3)
+	if !dn42Configured {
+		applyDN42Mode(false, dataOrigin, disableMaptrace)
+	}
+	return conn
 }
 
 func prepareFastTraceRuntimeEnvironment(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string) (*wshandle.WsConn, bool) {
 	capabilitiesCheck()
+	dn42Configured := dn42 || isDN42Provider(*dataOrigin)
 	applyDN42Mode(dn42, dataOrigin, disableMaptrace)
-	return initNextTraceAPIRuntime(ctx, dataOrigin, powProvider, false)
+	conn, prepared := initNextTraceAPIRuntime(ctx, dataOrigin, powProvider, false)
+	if !dn42Configured {
+		applyDN42Mode(false, dataOrigin, disableMaptrace)
+	}
+	return conn, prepared
 }
 
 func initNextTraceAPIV3WebSocket(ctx context.Context, dataOrigin, powProvider *string, async bool) *wshandle.WsConn {
@@ -1031,31 +1048,34 @@ func buildTraceConfig(
 	tos int,
 	disableMPLS bool,
 ) trace.Config {
+	dn42 = dn42 || isDN42Provider(dataOrigin)
+	session := ipgeo.GetSourceSession(dataOrigin)
 	return trace.Config{
-		OSType:           osType,
-		ICMPMode:         icmpMode,
-		DN42:             dn42,
-		SrcAddr:          srcAddr,
-		SrcPort:          srcPort,
-		SourceDevice:     strings.TrimSpace(sourceDevice),
-		BeginHop:         beginHop,
-		DstIP:            ip,
-		DstPort:          port,
-		MaxHops:          maxHops,
-		PacketInterval:   packetInterval,
-		TTLInterval:      ttlInterval,
-		NumMeasurements:  numMeasurements,
-		MaxAttempts:      maxAttempts,
-		ParallelRequests: parallelRequests,
-		Lang:             lang,
-		RDNS:             !noRDNS,
-		AlwaysWaitRDNS:   alwaysRDNS,
-		IPGeoSource:      ipgeo.GetSource(dataOrigin),
-		Timeout:          time.Duration(timeout) * time.Millisecond,
-		PktSize:          packetSize,
-		RandomPacketSize: randomPacketSize,
-		TOS:              tos,
-		DisableMPLS:      disableMPLS,
+		OSType:             osType,
+		ICMPMode:           icmpMode,
+		DN42:               dn42,
+		SrcAddr:            srcAddr,
+		SrcPort:            srcPort,
+		SourceDevice:       strings.TrimSpace(sourceDevice),
+		BeginHop:           beginHop,
+		DstIP:              ip,
+		DstPort:            port,
+		MaxHops:            maxHops,
+		PacketInterval:     packetInterval,
+		TTLInterval:        ttlInterval,
+		NumMeasurements:    numMeasurements,
+		MaxAttempts:        maxAttempts,
+		ParallelRequests:   parallelRequests,
+		Lang:               lang,
+		RDNS:               !noRDNS,
+		AlwaysWaitRDNS:     alwaysRDNS,
+		IPGeoSource:        session.Source,
+		RefreshIPGeoSource: session.Refresh,
+		Timeout:            time.Duration(timeout) * time.Millisecond,
+		PktSize:            packetSize,
+		RandomPacketSize:   randomPacketSize,
+		TOS:                tos,
+		DisableMPLS:        disableMPLS,
 	}
 }
 
@@ -1635,6 +1655,7 @@ func Execute() {
 			*ttlInterval,
 			!*norDNS,
 			*alwaysrDNS,
+			isDN42Provider(*dataOrigin),
 			ipgeo.GetSource(*dataOrigin),
 			*lang,
 		)
@@ -1717,7 +1738,7 @@ func Execute() {
 		&trace.Config{
 			Context:         rootCtx,
 			OSType:          osType,
-			DN42:            *dn42,
+			DN42:            *dn42 || isDN42Provider(*dataOrigin),
 			NumMeasurements: *numMeasurements,
 			Lang:            *lang,
 			RDNS:            !*norDNS,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -389,9 +389,9 @@ func registerICMPModeFlag(parser *argparse.Parser) *int {
 }
 
 func registerDataProviderFlag(parser *argparse.Parser) *string {
-	return parser.Selector("d", "data-provider", []string{"IP.SB", "ip.sb", "IPInfo", "ipinfo", "IPInsight", "ipinsight", "IPAPI.com", "ip-api.com", "IPInfoLocal", "ipinfolocal", "chunzhen", ipgeo.NextTraceAPIProvider, "ipdb.one", "disable-geoip"}, &argparse.Options{
+	return parser.Selector("d", "data-provider", []string{"IP.SB", "ip.sb", "IPInfo", "ipinfo", "IPInsight", "ipinsight", "IPAPI.com", "ip-api.com", "IPInfoLocal", "ipinfolocal", "chunzhen", ipgeo.NextTraceAPIProvider, "ipdb.one", "disable-geoip", "DN42", "dn42"}, &argparse.Options{
 		Default: ipgeo.NextTraceAPIProvider,
-		Help:    "Choose IP Geographic Data Provider [NextTrace-API, IP.SB, IPInfo, IPInsight, IP-API.com, IPInfoLocal, ipdb.one, chunzhen, disable-geoip]",
+		Help:    "Choose IP Geographic Data Provider [NextTrace-API, IP.SB, IPInfo, IPInsight, IP-API.com, IPInfoLocal, ipdb.one, chunzhen, disable-geoip, DN42]",
 	})
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1215,6 +1215,25 @@ func TestNormalizedNextTraceAPIProviderArgsParseAgainstCanonicalSelector(t *test
 	}
 }
 
+func TestDataProviderSelectorAcceptsDN42(t *testing.T) {
+	for _, args := range [][]string{
+		{"nexttrace", "-d", "DN42"},
+		{"nexttrace", "--data-provider=dn42"},
+	} {
+		parser := argparse.NewParser("nexttrace", "")
+		provider := registerDataProviderFlag(parser)
+		if err := parser.Parse(args); err != nil {
+			t.Fatalf("Parse(%q) error = %v", args, err)
+		}
+		if !isDN42Provider(*provider) {
+			t.Fatalf("Parse(%q) provider = %q, want DN42", args, *provider)
+		}
+		if usage := parser.Usage(nil); !strings.Contains(usage, "DN42") {
+			t.Fatalf("Parse(%q) usage does not mention DN42: %s", args, usage)
+		}
+	}
+}
+
 func TestInitNextTraceAPIRuntimeCanonicalizesLegacyEnvironmentAlias(t *testing.T) {
 	isolateCmdNextTraceAPIV4TokenFiles(t)
 	oldEnvDataProvider := util.EnvDataProvider

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nxtrace/NTrace-core/tracelog"
 	"github.com/nxtrace/NTrace-core/util"
 	"github.com/nxtrace/NTrace-core/wshandle"
+	"github.com/spf13/viper"
 )
 
 var errCmdOutputWriter = errors.New("cmd output writer failed")
@@ -431,6 +432,105 @@ func TestRunFastTraceModeLeavesRuntimeUnpreparedForNonNextTraceAPIProvider(t *te
 				t.Fatal("FastTest RuntimePrepared = true, want false for non-NextTrace API provider")
 			}
 		})
+	}
+}
+
+func TestRunFastTraceModePinsExplicitDN42Provider(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	oldRunFastTrace := runFastTraceFn
+	var got fastTrace.ParamsFastTrace
+	runFastTraceFn = func(_ trace.Method, params fastTrace.ParamsFastTrace) {
+		got = params
+	}
+	t.Cleanup(func() {
+		runFastTraceFn = oldRunFastTrace
+	})
+
+	dataProvider := " dn42 "
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+	if !runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned false, want true")
+	}
+	if dataProvider != "DN42" || got.DataProvider != "DN42" || !got.DN42 || got.IPGeoSource == nil {
+		t.Fatalf("DN42 fast trace params = provider %q, data %q, DN42 %v, source nil %v", dataProvider, got.DataProvider, got.DN42, got.IPGeoSource == nil)
+	}
+	if !disableMaptrace {
+		t.Fatal("disableMaptrace = false, want true for explicit DN42 provider")
+	}
+}
+
+func TestRunFastTraceModeAppliesDN42EnvironmentOverride(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldEnvDataProvider := util.EnvDataProvider
+	oldRunFastTrace := runFastTraceFn
+	util.EnvDataProvider = " dn42 "
+	var got fastTrace.ParamsFastTrace
+	runFastTraceFn = func(_ trace.Method, params fastTrace.ParamsFastTrace) {
+		got = params
+	}
+	t.Cleanup(func() {
+		util.EnvDataProvider = oldEnvDataProvider
+		runFastTraceFn = oldRunFastTrace
+	})
+
+	dataProvider := ipgeo.NextTraceAPIProvider
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+	if !runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned false, want true")
+	}
+	if dataProvider != "DN42" || got.DataProvider != "DN42" || !got.DN42 || got.IPGeoSource == nil {
+		t.Fatalf("DN42 env params = provider %q, data %q, DN42 %v, source nil %v", dataProvider, got.DataProvider, got.DN42, got.IPGeoSource == nil)
+	}
+	if !disableMaptrace || got.RuntimePrepared {
+		t.Fatalf("DN42 env state = disable maptrace %v, runtime prepared %v", disableMaptrace, got.RuntimePrepared)
+	}
+}
+
+func TestBuildTraceConfigPinsAndRefreshesDN42Source(t *testing.T) {
+	dir := t.TempDir()
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,First\n"), 0o600); err != nil {
+		t.Fatalf("write first geofeed: %v", err)
+	}
+	if err := os.WriteFile(ptrPath, nil, 0o600); err != nil {
+		t.Fatalf("write ptr: %v", err)
+	}
+	previousGeoFeedPath := viper.Get("geoFeedPath")
+	previousPtrPath := viper.Get("ptrPath")
+	viper.Set("geoFeedPath", geoFeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(func() {
+		viper.Set("geoFeedPath", previousGeoFeedPath)
+		viper.Set("ptrPath", previousPtrPath)
+	})
+
+	cfg := buildTraceConfig(
+		3, 0, false, "", "", 0, 1, net.ParseIP("10.0.0.1"), 0,
+		30, 50, 300, 3, 3, 18, "en", true, false, "DN42", 1000,
+		0, false, 0, false,
+	)
+	if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.RefreshIPGeoSource == nil {
+		t.Fatalf("DN42 config = %+v", cfg)
+	}
+	first, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
+	if err != nil || first.City != "First" {
+		t.Fatalf("first source = (%+v, %v), want First", first, err)
+	}
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,Second City\n"), 0o600); err != nil {
+		t.Fatalf("write second geofeed: %v", err)
+	}
+	stillFirst, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
+	if err != nil || stillFirst.City != "First" {
+		t.Fatalf("pinned source = (%+v, %v), want First", stillFirst, err)
+	}
+	cfg.RefreshIPGeoSource()
+	second, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
+	if err != nil || second.City != "Second City" {
+		t.Fatalf("refreshed source = (%+v, %v), want Second City", second, err)
 	}
 }
 

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -253,6 +253,7 @@ func normalizeMTRReportConfig(conf trace.Config, wide bool) trace.Config {
 	}
 
 	normalized.IPGeoSource = nil
+	normalized.RefreshIPGeoSource = nil
 	if normalized.RDNS {
 		normalized.AlwaysWaitRDNS = true
 	}

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -438,13 +438,14 @@ func TestNormalizeMTRReportConfig_NonWideDisablesGeoAndKeepsRDNS(t *testing.T) {
 		return &ipgeo.IPGeoData{}, nil
 	}
 	original := trace.Config{
-		TTLInterval:    1200,
-		IPGeoSource:    geoSource,
-		RDNS:           true,
-		AlwaysWaitRDNS: false,
-		PacketInterval: 25,
-		Timeout:        3,
-		MaxHops:        18,
+		TTLInterval:        1200,
+		IPGeoSource:        geoSource,
+		RefreshIPGeoSource: func() {},
+		RDNS:               true,
+		AlwaysWaitRDNS:     false,
+		PacketInterval:     25,
+		Timeout:            3,
+		MaxHops:            18,
 	}
 
 	normalized := normalizeMTRReportConfig(original, false)
@@ -455,6 +456,9 @@ func TestNormalizeMTRReportConfig_NonWideDisablesGeoAndKeepsRDNS(t *testing.T) {
 	if normalized.IPGeoSource != nil {
 		t.Fatal("non-wide report should disable IPGeoSource")
 	}
+	if normalized.RefreshIPGeoSource != nil {
+		t.Fatal("non-wide report should disable RefreshIPGeoSource")
+	}
 	if !normalized.RDNS {
 		t.Fatal("non-wide report should preserve RDNS=true")
 	}
@@ -464,7 +468,7 @@ func TestNormalizeMTRReportConfig_NonWideDisablesGeoAndKeepsRDNS(t *testing.T) {
 	if normalized.PacketInterval != original.PacketInterval || normalized.Timeout != original.Timeout || normalized.MaxHops != original.MaxHops {
 		t.Fatalf("unexpected mutation of other fields: %+v", normalized)
 	}
-	if original.IPGeoSource == nil || original.TTLInterval != 1200 || original.AlwaysWaitRDNS {
+	if original.IPGeoSource == nil || original.RefreshIPGeoSource == nil || original.TTLInterval != 1200 || original.AlwaysWaitRDNS {
 		t.Fatalf("original config was modified in place: %+v", original)
 	}
 }
@@ -497,12 +501,14 @@ func TestNormalizeMTRReportConfig_WidePreservesGeoSettings(t *testing.T) {
 	geoSource := func(_ string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
 		return &ipgeo.IPGeoData{}, nil
 	}
+	refreshCalls := 0
 	original := trace.Config{
-		TTLInterval:    1200,
-		IPGeoSource:    geoSource,
-		RDNS:           true,
-		AlwaysWaitRDNS: false,
-		PacketInterval: 25,
+		TTLInterval:        1200,
+		IPGeoSource:        geoSource,
+		RefreshIPGeoSource: func() { refreshCalls++ },
+		RDNS:               true,
+		AlwaysWaitRDNS:     false,
+		PacketInterval:     25,
 	}
 
 	normalized := normalizeMTRReportConfig(original, true)
@@ -513,13 +519,20 @@ func TestNormalizeMTRReportConfig_WidePreservesGeoSettings(t *testing.T) {
 	if normalized.IPGeoSource == nil {
 		t.Fatal("wide report should preserve IPGeoSource")
 	}
+	if normalized.RefreshIPGeoSource == nil {
+		t.Fatal("wide report should preserve RefreshIPGeoSource")
+	}
+	normalized.RefreshIPGeoSource()
+	if refreshCalls != 1 {
+		t.Fatalf("wide report refresh calls = %d, want 1", refreshCalls)
+	}
 	if !normalized.RDNS {
 		t.Fatal("wide report should preserve RDNS=true")
 	}
 	if normalized.AlwaysWaitRDNS != original.AlwaysWaitRDNS {
 		t.Fatalf("wide report should preserve AlwaysWaitRDNS, got %v want %v", normalized.AlwaysWaitRDNS, original.AlwaysWaitRDNS)
 	}
-	if original.IPGeoSource == nil || original.TTLInterval != 1200 {
+	if original.IPGeoSource == nil || original.RefreshIPGeoSource == nil || original.TTLInterval != 1200 {
 		t.Fatalf("original config was modified in place: %+v", original)
 	}
 }

--- a/cmd/mtu_mode.go
+++ b/cmd/mtu_mode.go
@@ -364,6 +364,7 @@ func buildMTUTraceConfig(
 	ttlIntervalMs int,
 	rdns bool,
 	alwaysWaitRDNS bool,
+	dn42 bool,
 	geoSource ipgeo.Source,
 	lang string,
 ) mtutrace.Config {
@@ -383,6 +384,7 @@ func buildMTUTraceConfig(
 		AlwaysWaitRDNS: alwaysWaitRDNS,
 		IPGeoSource:    geoSource,
 		Lang:           lang,
+		DN42:           dn42,
 	}
 }
 

--- a/cmd/mtu_mode_test.go
+++ b/cmd/mtu_mode_test.go
@@ -85,11 +85,36 @@ func TestBuildMTUTraceConfigCarriesResolvedSourceDevice(t *testing.T) {
 		300,
 		true,
 		false,
+		false,
 		ipgeo.IPInfo,
 		"en",
 	)
 	if conf.SourceDevice != "Ethernet0" {
 		t.Fatalf("buildMTUTraceConfig().SourceDevice = %q, want Ethernet0", conf.SourceDevice)
+	}
+}
+
+func TestBuildMTUTraceConfigCarriesDN42Mode(t *testing.T) {
+	conf := buildMTUTraceConfig(
+		"10.0.0.1",
+		net.ParseIP("10.0.0.1"),
+		nil,
+		"",
+		0,
+		33494,
+		1,
+		30,
+		3,
+		1000,
+		300,
+		false,
+		false,
+		true,
+		ipgeo.DN42,
+		"en",
+	)
+	if !conf.DN42 || conf.IPGeoSource == nil {
+		t.Fatalf("DN42 MTU config = %+v", conf)
 	}
 }
 

--- a/cmd/nali_mode.go
+++ b/cmd/nali_mode.go
@@ -218,11 +218,15 @@ func runNaliMode(ctx context.Context, opts naliRunOptions) error {
 	restoreFastIPOutput := setFastIPOutputSuppression(true)
 	defer restoreFastIPOutput()
 
-	if opts.dn42 {
+	dn42Configured := opts.dn42 || isDN42Provider(opts.data)
+	if dn42Configured {
 		applyDN42DataOrigin(&opts.data)
 	}
 	nextTraceAPIV3WS := initNextTraceAPIV3WebSocket(ctx, &opts.data, &opts.pow, false)
 	defer closeNextTraceAPIV3WebSocket(nextTraceAPIV3WS)
+	if !dn42Configured && isDN42Provider(opts.data) {
+		applyDN42DataOrigin(&opts.data)
+	}
 
 	family := nali.FamilyAll
 	if opts.ipv4Only {
@@ -235,5 +239,6 @@ func runNaliMode(ctx context.Context, opts naliRunOptions) error {
 		Timeout: time.Duration(opts.timeoutMs) * time.Millisecond,
 		Lang:    opts.lang,
 		Family:  family,
+		DN42:    isDN42Provider(opts.data),
 	}, opts.stdin, opts.stdout, opts.target)
 }

--- a/cmd/nali_mode_test.go
+++ b/cmd/nali_mode_test.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/akamensky/argparse"
+	"github.com/spf13/viper"
 )
 
 func TestRegisterNaliFlagWithAvailabilityEnabledAddsHelpEntry(t *testing.T) {
@@ -166,6 +169,43 @@ func TestRunNaliModeTargetWithDisableGeoIPKeepsOriginal(t *testing.T) {
 		t.Fatalf("runNaliMode() error = %v", err)
 	}
 	if got, want := out.String(), "A 8.8.8.8\n"; got != want {
+		t.Fatalf("runNaliMode() output = %q, want %q", got, want)
+	}
+}
+
+func TestRunNaliModeExplicitDN42ProviderBypassesReservedFilter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,Test City,AS4242420001,Example Owner\n"), 0o600); err != nil {
+		t.Fatalf("write geofeed: %v", err)
+	}
+	if err := os.WriteFile(ptrPath, nil, 0o600); err != nil {
+		t.Fatalf("write ptr: %v", err)
+	}
+	previousGeoFeedPath := viper.Get("geoFeedPath")
+	previousPtrPath := viper.Get("ptrPath")
+	viper.Set("geoFeedPath", geoFeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(func() {
+		viper.Set("geoFeedPath", previousGeoFeedPath)
+		viper.Set("ptrPath", previousPtrPath)
+	})
+
+	var out bytes.Buffer
+	err := runNaliMode(context.Background(), naliRunOptions{
+		stdout:    &out,
+		data:      "DN42",
+		pow:       "api.nxtrace.org",
+		lang:      "en",
+		timeoutMs: 100,
+		target:    "router 10.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("runNaliMode() error = %v", err)
+	}
+	if got, want := out.String(), "router 10.0.0.1 [AS4242420001, United States, Test City, Example Owner]\n"; got != want {
 		t.Fatalf("runNaliMode() output = %q, want %q", got, want)
 	}
 }

--- a/config/viper.go
+++ b/config/viper.go
@@ -6,11 +6,17 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 
 	"github.com/spf13/viper"
 )
 
+var viperMu sync.RWMutex
+
 func InitConfig() {
+	viperMu.Lock()
+	defer viperMu.Unlock()
+
 	// 配置文件名， 不加扩展
 	viper.SetConfigName("nt_config") // name of config file (without extension)
 	// 设置文件的扩展名
@@ -80,4 +86,16 @@ func InitConfig() {
 		fmt.Println("加载配置文件失败:", err)
 		return
 	}
+}
+
+func GeoFeedPath() string {
+	viperMu.RLock()
+	defer viperMu.RUnlock()
+	return viper.GetString("geoFeedPath")
+}
+
+func PtrPath() string {
+	viperMu.RLock()
+	defer viperMu.RUnlock()
+	return viper.GetString("ptrPath")
 }

--- a/config/viper_test.go
+++ b/config/viper_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestConfigAccessorsAreSafeDuringConcurrentInit(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	content := []byte("geoFeedPath: " + geoFeedPath + "\nptrPath: " + ptrPath + "\n")
+	configPath := filepath.Join(dir, "nt_config.yaml")
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	viper.Reset()
+	viper.SetConfigFile(configPath)
+	InitConfig()
+	t.Cleanup(viper.Reset)
+
+	const workers = 16
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Go(func() {
+			for range 25 {
+				InitConfig()
+				_ = GeoFeedPath()
+				_ = PtrPath()
+			}
+		})
+	}
+	wait.Wait()
+
+	if got := GeoFeedPath(); got != geoFeedPath {
+		t.Fatalf("GeoFeedPath() = %q, want %q", got, geoFeedPath)
+	}
+	if got := PtrPath(); got != ptrPath {
+		t.Fatalf("PtrPath() = %q, want %q", got, ptrPath)
+	}
+}

--- a/dn42/geofeed.go
+++ b/dn42/geofeed.go
@@ -54,7 +54,7 @@ func FindGeoFeedRow(ipStr string, rows []GeoFeedRow) (GeoFeedRow, bool) {
 	}
 
 	for _, row := range rows {
-		if row.IPNet != nil && row.IPNet.Contains(ip) {
+		if row.IPNet.Contains(ip) {
 			return row, true
 		}
 	}

--- a/dn42/geofeed.go
+++ b/dn42/geofeed.go
@@ -55,7 +55,7 @@ func FindGeoFeedRow(ipStr string, rows []GeoFeedRow) (GeoFeedRow, bool) {
 
 	for _, row := range rows {
 		if row.IPNet != nil && row.IPNet.Contains(ip) {
-			return cloneGeoFeedRow(row), true
+			return row, true
 		}
 	}
 	return GeoFeedRow{}, false
@@ -106,15 +106,4 @@ func prefixToIPNet(prefix netip.Prefix) *net.IPNet {
 		IP:   append(net.IP(nil), ip[:]...),
 		Mask: net.CIDRMask(bits, 128),
 	}
-}
-
-func cloneGeoFeedRow(row GeoFeedRow) GeoFeedRow {
-	if row.IPNet == nil {
-		return row
-	}
-	row.IPNet = &net.IPNet{
-		IP:   append(net.IP(nil), row.IPNet.IP...),
-		Mask: append(net.IPMask(nil), row.IPNet.Mask...),
-	}
-	return row
 }

--- a/dn42/geofeed.go
+++ b/dn42/geofeed.go
@@ -1,15 +1,12 @@
 package dn42
 
 import (
-	"encoding/csv"
-	"fmt"
 	"net"
-	"os"
+	"net/netip"
 	"sort"
-
-	"github.com/spf13/viper"
 )
 
+// GeoFeedRow is the legacy GeoFeed representation kept for API compatibility.
 type GeoFeedRow struct {
 	IPNet   *net.IPNet
 	CIDR    string
@@ -20,86 +17,104 @@ type GeoFeedRow struct {
 	IPWhois string
 }
 
+// GetGeoFeed returns the longest-prefix GeoFeed match for ip.
 func GetGeoFeed(ip string) (GeoFeedRow, bool) {
-	rows, err := ReadGeoFeed()
+	addr, err := netip.ParseAddr(ip)
 	if err != nil {
-		// 无法加载 geofeed 数据，返回未找到
 		return GeoFeedRow{}, false
 	}
 
-	row, find := FindGeoFeedRow(ip, rows)
-	return row, find
-
+	index, _ := LoadGeoFeedIndex()
+	if index == nil {
+		return GeoFeedRow{}, false
+	}
+	record, found := index.Lookup(addr)
+	if !found {
+		return GeoFeedRow{}, false
+	}
+	return geoFeedRecordToRow(record), true
 }
 
+// ReadGeoFeed returns a detached legacy view of the current GeoFeed snapshot.
+// When a reload fails, it returns the last valid snapshot together with the
+// reload error.
 func ReadGeoFeed() ([]GeoFeedRow, error) {
-	path := viper.GetString("geoFeedPath")
-	if path == "" {
-		return nil, fmt.Errorf("geoFeedPath not configured")
-	}
-	f, err := os.Open(path)
-	if err != nil {
+	index, err := LoadGeoFeedIndex()
+	if index == nil {
 		return nil, err
 	}
-	defer f.Close()
-
-	r := csv.NewReader(f)
-	rows, err := r.ReadAll()
-	if err != nil {
-		return nil, err
-	}
-
-	// 将 CSV 中的每一行转换为 GeoFeedRow 类型，并保存到 rowsSlice 中
-	var rowsSlice []GeoFeedRow
-	for _, row := range rows {
-		cidr := row[0] // 假设第一列是 CIDR 字段
-		_, ipnet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			// 如果解析 CIDR 失败，跳过这一行
-			continue
-		}
-		if len(row) == 4 {
-			rowsSlice = append(rowsSlice, GeoFeedRow{
-				IPNet:   ipnet,
-				CIDR:    cidr,
-				LtdCode: row[1],
-				ISO3166: row[2],
-				City:    row[3],
-			})
-		} else if len(row) >= 6 {
-			rowsSlice = append(rowsSlice, GeoFeedRow{
-				IPNet:   ipnet,
-				CIDR:    cidr,
-				LtdCode: row[1],
-				ISO3166: row[2],
-				City:    row[3],
-				ASN:     row[4],
-				IPWhois: row[5],
-			})
-		}
-
-	}
-	// 根据 CIDR 范围从小到大排序，方便后面查找
-	sort.Slice(rowsSlice, func(i, j int) bool {
-		return rowsSlice[i].IPNet.Mask.String() > rowsSlice[j].IPNet.Mask.String()
-	})
-
-	return rowsSlice, nil
+	return index.legacyRows(), err
 }
 
+// FindGeoFeedRow preserves the legacy first-match lookup contract.
 func FindGeoFeedRow(ipStr string, rows []GeoFeedRow) (GeoFeedRow, bool) {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
-		// 如果传入的 IP 无效，直接返回
 		return GeoFeedRow{}, false
 	}
 
-	// 遍历每个 CIDR 范围，找到第一个包含传入的 IP 的 CIDR
 	for _, row := range rows {
-		if row.IPNet.Contains(ip) {
-			return row, true
+		if row.IPNet != nil && row.IPNet.Contains(ip) {
+			return cloneGeoFeedRow(row), true
 		}
 	}
-
 	return GeoFeedRow{}, false
+}
+
+func (index *GeoFeedIndex) legacyRows() []GeoFeedRow {
+	if index == nil || len(index.records) == 0 {
+		return nil
+	}
+	rows := make([]GeoFeedRow, len(index.records))
+	for i, record := range index.records {
+		rows[i] = geoFeedRecordToRow(record)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].IPNet.Mask.String() > rows[j].IPNet.Mask.String()
+	})
+	return rows
+}
+
+func geoFeedRecordToRow(record GeoFeedRecord) GeoFeedRow {
+	ipNet := prefixToIPNet(record.Prefix)
+	if _, legacyIPNet, err := net.ParseCIDR(record.CIDR); err == nil {
+		ipNet = legacyIPNet
+	}
+	return GeoFeedRow{
+		IPNet:   ipNet,
+		CIDR:    record.CIDR,
+		LtdCode: record.LtdCode,
+		ISO3166: record.ISO3166,
+		City:    record.City,
+		ASN:     record.ASN,
+		IPWhois: record.IPWhois,
+	}
+}
+
+func prefixToIPNet(prefix netip.Prefix) *net.IPNet {
+	addr := prefix.Addr()
+	bits := prefix.Bits()
+	if addr.Is4() {
+		ip := addr.As4()
+		return &net.IPNet{
+			IP:   net.IPv4(ip[0], ip[1], ip[2], ip[3]).To4(),
+			Mask: net.CIDRMask(bits, 32),
+		}
+	}
+	ip := addr.As16()
+	return &net.IPNet{
+		IP:   append(net.IP(nil), ip[:]...),
+		Mask: net.CIDRMask(bits, 128),
+	}
+}
+
+func cloneGeoFeedRow(row GeoFeedRow) GeoFeedRow {
+	if row.IPNet == nil {
+		return row
+	}
+	row.IPNet = &net.IPNet{
+		IP:   append(net.IP(nil), row.IPNet.IP...),
+		Mask: append(net.IPMask(nil), row.IPNet.Mask...),
+	}
+	return row
 }

--- a/dn42/geofeed_benchmark_test.go
+++ b/dn42/geofeed_benchmark_test.go
@@ -1,9 +1,14 @@
 package dn42
 
 import (
+	"encoding/csv"
 	"fmt"
+	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -13,9 +18,10 @@ import (
 const benchmarkGeoFeedEntryCount = 4096
 
 var (
-	benchmarkGeoFeedRowsSink  []GeoFeedRow
-	benchmarkGeoFeedRowSink   GeoFeedRow
-	benchmarkGeoFeedFoundSink bool
+	benchmarkGeoFeedRowsSink   []GeoFeedRow
+	benchmarkGeoFeedRowSink    GeoFeedRow
+	benchmarkGeoFeedRecordSink GeoFeedRecord
+	benchmarkGeoFeedFoundSink  bool
 )
 
 func BenchmarkReadGeoFeedCSV(b *testing.B) {
@@ -38,15 +44,15 @@ func BenchmarkReadGeoFeedCSV(b *testing.B) {
 }
 
 func BenchmarkFindGeoFeedRow(b *testing.B) {
-	for _, tc := range []struct {
+	for _, test := range []struct {
 		name string
 		ipv6 bool
 	}{
-		{name: "IPv4", ipv6: false},
+		{name: "IPv4"},
 		{name: "IPv6", ipv6: true},
 	} {
-		b.Run(tc.name, func(b *testing.B) {
-			content := buildBenchmarkGeoFeedCSV(tc.ipv6, benchmarkGeoFeedEntryCount)
+		b.Run(test.name, func(b *testing.B) {
+			content := buildBenchmarkGeoFeedCSV(test.ipv6, benchmarkGeoFeedEntryCount)
 			setBenchmarkGeoFeedPath(b, writeBenchmarkGeoFeed(b, content))
 			rows, err := ReadGeoFeed()
 			if err != nil {
@@ -56,56 +62,27 @@ func BenchmarkFindGeoFeedRow(b *testing.B) {
 				b.Fatalf("ReadGeoFeed() rows = %d, want %d", len(rows), benchmarkGeoFeedEntryCount)
 			}
 
-			lookupCases := []struct {
+			lookups := []struct {
 				name     string
 				target   string
 				wantCIDR string
 				wantHit  bool
 			}{
-				{
-					name:     "HeadHit",
-					target:   rows[0].IPNet.IP.String(),
-					wantCIDR: rows[0].CIDR,
-					wantHit:  true,
-				},
-				{
-					name:     "MiddleHit",
-					target:   rows[len(rows)/2].IPNet.IP.String(),
-					wantCIDR: rows[len(rows)/2].CIDR,
-					wantHit:  true,
-				},
-				{
-					name:     "TailHit",
-					target:   rows[len(rows)-1].IPNet.IP.String(),
-					wantCIDR: rows[len(rows)-1].CIDR,
-					wantHit:  true,
-				},
-				{
-					name:    "Miss",
-					target:  benchmarkGeoFeedMissTarget(tc.ipv6),
-					wantHit: false,
-				},
+				{name: "HeadHit", target: rows[0].IPNet.IP.String(), wantCIDR: rows[0].CIDR, wantHit: true},
+				{name: "MiddleHit", target: rows[len(rows)/2].IPNet.IP.String(), wantCIDR: rows[len(rows)/2].CIDR, wantHit: true},
+				{name: "TailHit", target: rows[len(rows)-1].IPNet.IP.String(), wantCIDR: rows[len(rows)-1].CIDR, wantHit: true},
+				{name: "Miss", target: benchmarkGeoFeedMissTarget(test.ipv6)},
 			}
-
-			for _, lookup := range lookupCases {
+			for _, lookup := range lookups {
 				b.Run(lookup.name, func(b *testing.B) {
 					b.ReportAllocs()
-					var (
-						row   GeoFeedRow
-						found bool
-					)
+					var row GeoFeedRow
+					var found bool
 					for b.Loop() {
 						row, found = FindGeoFeedRow(lookup.target, rows)
 					}
 					if found != lookup.wantHit || found && row.CIDR != lookup.wantCIDR {
-						b.Fatalf(
-							"FindGeoFeedRow(%q) = (%+v, %v), want CIDR %q, found %v",
-							lookup.target,
-							row,
-							found,
-							lookup.wantCIDR,
-							lookup.wantHit,
-						)
+						b.Fatalf("FindGeoFeedRow(%q) = (%+v, %v), want CIDR %q, found %v", lookup.target, row, found, lookup.wantCIDR, lookup.wantHit)
 					}
 					benchmarkGeoFeedRowSink = row
 					benchmarkGeoFeedFoundSink = found
@@ -113,6 +90,294 @@ func BenchmarkFindGeoFeedRow(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkGeoFeedParseIndex(b *testing.B) {
+	content := buildBenchmarkGeoFeedCSV(false, benchmarkGeoFeedEntryCount/2) +
+		buildBenchmarkGeoFeedCSV(true, benchmarkGeoFeedEntryCount/2)
+	b.ReportAllocs()
+	var index *GeoFeedIndex
+	for b.Loop() {
+		var err error
+		index, err = parseGeoFeedIndex(strings.NewReader(content), geoFeedFileIdentity{}, 1)
+		if err != nil {
+			b.Fatalf("parseGeoFeedIndex() error = %v", err)
+		}
+	}
+	if len(index.records) != benchmarkGeoFeedEntryCount {
+		b.Fatalf("parsed records = %d, want %d", len(index.records), benchmarkGeoFeedEntryCount)
+	}
+	benchmarkGeoFeedRecordSink = index.records[len(index.records)-1]
+}
+
+func BenchmarkGeoFeedLookupImplementationsMixed4096(b *testing.B) {
+	for _, test := range []struct {
+		name string
+		ipv6 bool
+	}{
+		{name: "IPv4"},
+		{name: "IPv6", ipv6: true},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			content := buildMixedBenchmarkGeoFeedCSV(test.ipv6, benchmarkGeoFeedEntryCount)
+			path := writeBenchmarkGeoFeed(b, content)
+			rows, err := legacyReadGeoFeed(path)
+			if err != nil {
+				b.Fatalf("legacyReadGeoFeed() error = %v", err)
+			}
+			index, err := parseGeoFeedIndex(strings.NewReader(content), geoFeedFileIdentity{}, 1)
+			if err != nil {
+				b.Fatalf("parseGeoFeedIndex() error = %v", err)
+			}
+			validateMixedBenchmarkGeoFeedShape(b, rows, index, test.ipv6)
+			trie := buildBenchmarkGeoFeedTrie(index.records)
+			queries := benchmarkGeoFeedQueries(index, test.ipv6)
+			validateBenchmarkGeoFeedImplementations(b, rows, index, trie, queries)
+
+			b.Run("LegacyEndToEnd", func(b *testing.B) {
+				b.ReportAllocs()
+				queryIndex := 0
+				var row GeoFeedRow
+				var found bool
+				for b.Loop() {
+					query := queries[queryIndex&3]
+					queryIndex++
+					loadedRows, loadErr := legacyReadGeoFeed(path)
+					if loadErr != nil {
+						b.Fatalf("legacyReadGeoFeed() error = %v", loadErr)
+					}
+					row, found = legacyFindGeoFeedRow(query.text, loadedRows)
+				}
+				benchmarkGeoFeedRowSink = row
+				benchmarkGeoFeedFoundSink = found
+			})
+
+			b.Run("LegacyPreparsedSlice", func(b *testing.B) {
+				b.ReportAllocs()
+				queryIndex := 0
+				var row GeoFeedRow
+				var found bool
+				for b.Loop() {
+					query := queries[queryIndex&3]
+					queryIndex++
+					row, found = legacyFindGeoFeedRowParsed(query.ip, rows)
+				}
+				benchmarkGeoFeedRowSink = row
+				benchmarkGeoFeedFoundSink = found
+			})
+
+			b.Run("PrefixMap", func(b *testing.B) {
+				b.ReportAllocs()
+				queryIndex := 0
+				var record GeoFeedRecord
+				var found bool
+				for b.Loop() {
+					query := queries[queryIndex&3]
+					queryIndex++
+					record, found = index.Lookup(query.addr)
+				}
+				benchmarkGeoFeedRecordSink = record
+				benchmarkGeoFeedFoundSink = found
+			})
+
+			b.Run("TestOnlyTrie", func(b *testing.B) {
+				b.ReportAllocs()
+				queryIndex := 0
+				var record GeoFeedRecord
+				var found bool
+				for b.Loop() {
+					query := queries[queryIndex&3]
+					queryIndex++
+					record, found = trie.lookup(query.addr)
+				}
+				benchmarkGeoFeedRecordSink = record
+				benchmarkGeoFeedFoundSink = found
+			})
+		})
+	}
+}
+
+func validateMixedBenchmarkGeoFeedShape(b *testing.B, rows []GeoFeedRow, index *GeoFeedIndex, ipv6 bool) {
+	b.Helper()
+	if len(rows) != benchmarkGeoFeedEntryCount || len(index.records) != benchmarkGeoFeedEntryCount {
+		b.Fatalf("mixed dataset sizes = rows %d index %d, want %d", len(rows), len(index.records), benchmarkGeoFeedEntryCount)
+	}
+	wantBits := []int{27, 26, 25, 24, 23, 22, 21, 20}
+	gotBits := index.v4.prefixBits
+	if ipv6 {
+		wantBits = []int{128, 112, 96, 80, 72, 64, 56, 48}
+		gotBits = index.v6.prefixBits
+	}
+	if !slices.Equal(gotBits, wantBits) {
+		b.Fatalf("mixed prefix bits = %v, want %v", gotBits, wantBits)
+	}
+}
+
+type benchmarkGeoFeedQuery struct {
+	text string
+	ip   net.IP
+	addr netip.Addr
+}
+
+func benchmarkGeoFeedQueries(index *GeoFeedIndex, ipv6 bool) []benchmarkGeoFeedQuery {
+	indices := []int{0, len(index.records) / 2, len(index.records) - 1}
+	queries := make([]benchmarkGeoFeedQuery, 0, 4)
+	for _, recordIndex := range indices {
+		queries = append(queries, newBenchmarkGeoFeedQuery(index.records[recordIndex].Prefix.Addr().String()))
+	}
+	queries = append(queries, newBenchmarkGeoFeedQuery(benchmarkGeoFeedMissTarget(ipv6)))
+	return queries
+}
+
+func newBenchmarkGeoFeedQuery(target string) benchmarkGeoFeedQuery {
+	return benchmarkGeoFeedQuery{
+		text: target,
+		ip:   net.ParseIP(target),
+		addr: netip.MustParseAddr(target),
+	}
+}
+
+func validateBenchmarkGeoFeedImplementations(
+	b *testing.B,
+	rows []GeoFeedRow,
+	index *GeoFeedIndex,
+	trie *benchmarkGeoFeedTrie,
+	queries []benchmarkGeoFeedQuery,
+) {
+	b.Helper()
+	for _, query := range queries {
+		legacyRow, legacyFound := legacyFindGeoFeedRowParsed(query.ip, rows)
+		mapRecord, mapFound := index.Lookup(query.addr)
+		trieRecord, trieFound := trie.lookup(query.addr)
+		if legacyFound != mapFound || mapFound != trieFound {
+			b.Fatalf("lookup %s found mismatch: legacy=%v map=%v trie=%v", query.text, legacyFound, mapFound, trieFound)
+		}
+		if mapFound && (legacyRow.CIDR != mapRecord.CIDR || mapRecord.CIDR != trieRecord.CIDR) {
+			b.Fatalf("lookup %s CIDR mismatch: legacy=%q map=%q trie=%q", query.text, legacyRow.CIDR, mapRecord.CIDR, trieRecord.CIDR)
+		}
+	}
+}
+
+func legacyReadGeoFeed(path string) ([]GeoFeedRow, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	input, err := csv.NewReader(file).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]GeoFeedRow, 0, len(input))
+	for _, fields := range input {
+		if len(fields) == 0 {
+			continue
+		}
+		cidr := fields[0]
+		_, ipNet, parseErr := net.ParseCIDR(cidr)
+		if parseErr != nil {
+			continue
+		}
+		row := GeoFeedRow{IPNet: ipNet, CIDR: cidr}
+		switch {
+		case len(fields) == 4:
+			row.LtdCode, row.ISO3166, row.City = fields[1], fields[2], fields[3]
+		case len(fields) >= 6:
+			row.LtdCode, row.ISO3166, row.City = fields[1], fields[2], fields[3]
+			row.ASN, row.IPWhois = fields[4], fields[5]
+		default:
+			continue
+		}
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].IPNet.Mask.String() > rows[j].IPNet.Mask.String()
+	})
+	return rows, nil
+}
+
+func legacyFindGeoFeedRow(target string, rows []GeoFeedRow) (GeoFeedRow, bool) {
+	return legacyFindGeoFeedRowParsed(net.ParseIP(target), rows)
+}
+
+func legacyFindGeoFeedRowParsed(target net.IP, rows []GeoFeedRow) (GeoFeedRow, bool) {
+	if target == nil {
+		return GeoFeedRow{}, false
+	}
+	for _, row := range rows {
+		if row.IPNet.Contains(target) {
+			return row, true
+		}
+	}
+	return GeoFeedRow{}, false
+}
+
+type benchmarkGeoFeedTrie struct {
+	v4 benchmarkGeoFeedTrieNode
+	v6 benchmarkGeoFeedTrieNode
+}
+
+type benchmarkGeoFeedTrieNode struct {
+	children [2]*benchmarkGeoFeedTrieNode
+	record   GeoFeedRecord
+	hasValue bool
+}
+
+func buildBenchmarkGeoFeedTrie(records []GeoFeedRecord) *benchmarkGeoFeedTrie {
+	trie := new(benchmarkGeoFeedTrie)
+	for _, record := range records {
+		root := &trie.v6
+		addr := record.Prefix.Addr()
+		if addr.Is4() {
+			root = &trie.v4
+		}
+		node := root
+		for bitIndex := range record.Prefix.Bits() {
+			bit := geoFeedBitAtAddr(addr, bitIndex)
+			if node.children[bit] == nil {
+				node.children[bit] = new(benchmarkGeoFeedTrieNode)
+			}
+			node = node.children[bit]
+		}
+		node.record = record
+		node.hasValue = true
+	}
+	return trie
+}
+
+func (trie *benchmarkGeoFeedTrie) lookup(addr netip.Addr) (GeoFeedRecord, bool) {
+	if trie == nil || !addr.IsValid() {
+		return GeoFeedRecord{}, false
+	}
+	addr = addr.Unmap()
+	root := &trie.v6
+	maxBits := 128
+	if addr.Is4() {
+		root = &trie.v4
+		maxBits = 32
+	}
+	node := root
+	best, found := node.record, node.hasValue
+	for bitIndex := range maxBits {
+		node = node.children[geoFeedBitAtAddr(addr, bitIndex)]
+		if node == nil {
+			break
+		}
+		if node.hasValue {
+			best, found = node.record, true
+		}
+	}
+	return best, found
+}
+
+func geoFeedBitAtAddr(addr netip.Addr, bitIndex int) byte {
+	if addr.Is4() {
+		value := addr.As4()
+		return (value[bitIndex/8] >> (7 - uint(bitIndex%8))) & 1
+	}
+	value := addr.As16()
+	return (value[bitIndex/8] >> (7 - uint(bitIndex%8))) & 1
 }
 
 func benchmarkGeoFeedMissTarget(ipv6 bool) string {
@@ -125,7 +390,7 @@ func benchmarkGeoFeedMissTarget(ipv6 bool) string {
 func buildBenchmarkGeoFeedCSV(ipv6 bool, entries int) string {
 	var content strings.Builder
 	content.Grow(entries * 72)
-	for i := 0; i < entries; i++ {
+	for i := range entries {
 		if ipv6 {
 			_, _ = fmt.Fprintf(
 				&content,
@@ -142,6 +407,47 @@ func buildBenchmarkGeoFeedCSV(ipv6 bool, entries int) string {
 			"10.%d.%d.0/24,us,US,City-%d,AS%d,Owner-%d\n",
 			(i/256)%256,
 			i%256,
+			i,
+			64512+i,
+			i,
+		)
+	}
+	return content.String()
+}
+
+func buildMixedBenchmarkGeoFeedCSV(ipv6 bool, entries int) string {
+	var content strings.Builder
+	content.Grow(entries * 72)
+	if ipv6 {
+		bits := [...]int{48, 56, 64, 72, 80, 96, 112, 128}
+		for i := range entries {
+			group := i % len(bits)
+			ordinal := i / len(bits)
+			_, _ = fmt.Fprintf(
+				&content,
+				"fd00:%x:%x::/%d,us,US,City-%d,AS%d,Owner-%d\n",
+				group,
+				ordinal,
+				bits[group],
+				i,
+				64512+i,
+				i,
+			)
+		}
+		return content.String()
+	}
+
+	bits := [...]int{20, 21, 22, 23, 24, 25, 26, 27}
+	for i := range entries {
+		group := i % len(bits)
+		ordinal := i / len(bits)
+		block := group*(benchmarkGeoFeedEntryCount/len(bits)) + ordinal
+		_, _ = fmt.Fprintf(
+			&content,
+			"10.%d.%d.0/%d,us,US,City-%d,AS%d,Owner-%d\n",
+			block>>4,
+			(block&15)<<4,
+			bits[group],
 			i,
 			64512+i,
 			i,

--- a/dn42/geofeed_index.go
+++ b/dn42/geofeed_index.go
@@ -1,0 +1,331 @@
+package dn42
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/config"
+)
+
+// GeoFeedRecord is an immutable value stored in a GeoFeedIndex.
+type GeoFeedRecord struct {
+	Prefix  netip.Prefix
+	CIDR    string
+	LtdCode string
+	ISO3166 string
+	City    string
+	ASN     string
+	IPWhois string
+}
+
+// GeoFeedIndex is an immutable longest-prefix-match GeoFeed snapshot.
+type GeoFeedIndex struct {
+	v4         geoFeedFamilyIndex
+	v6         geoFeedFamilyIndex
+	records    []GeoFeedRecord
+	generation uint64
+	identity   geoFeedFileIdentity
+}
+
+type geoFeedFamilyIndex struct {
+	prefixBits []int
+	byBits     map[int]map[netip.Prefix]GeoFeedRecord
+}
+
+type geoFeedFileIdentity struct {
+	path    string
+	modTime time.Time
+	size    int64
+}
+
+type geoFeedStore struct {
+	mu             sync.Mutex
+	current        atomic.Pointer[GeoFeedIndex]
+	nextGeneration uint64
+}
+
+var defaultGeoFeedStore geoFeedStore
+
+// LoadGeoFeedIndex lazily loads or reloads the configured GeoFeed file. A
+// failed reload returns the last valid snapshot and leaves it published.
+func LoadGeoFeedIndex() (*GeoFeedIndex, error) {
+	path := config.GeoFeedPath()
+	if path == "" {
+		return defaultGeoFeedStore.current.Load(), fmt.Errorf("geoFeedPath not configured")
+	}
+	return defaultGeoFeedStore.load(path)
+}
+
+// Generation identifies the successful publication that produced index.
+func (index *GeoFeedIndex) Generation() uint64 {
+	if index == nil {
+		return 0
+	}
+	return index.generation
+}
+
+// Lookup performs a longest-prefix match without file I/O.
+func (index *GeoFeedIndex) Lookup(addr netip.Addr) (GeoFeedRecord, bool) {
+	if index == nil || !addr.IsValid() {
+		return GeoFeedRecord{}, false
+	}
+	addr = addr.Unmap()
+	if addr.Is4() {
+		return index.v4.lookup(addr)
+	}
+	return index.v6.lookup(addr)
+}
+
+func (family geoFeedFamilyIndex) lookup(addr netip.Addr) (GeoFeedRecord, bool) {
+	for _, bits := range family.prefixBits {
+		prefix := netip.PrefixFrom(addr, bits).Masked()
+		if record, found := family.byBits[bits][prefix]; found {
+			return record, true
+		}
+	}
+	return GeoFeedRecord{}, false
+}
+
+func (store *geoFeedStore) load(path string) (*GeoFeedIndex, error) {
+	identity, err := statGeoFeed(path)
+	if err != nil {
+		return store.current.Load(), err
+	}
+	if current := store.current.Load(); current != nil && current.identity.equal(identity) {
+		return current, nil
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	identity, err = statGeoFeed(path)
+	if err != nil {
+		return store.current.Load(), err
+	}
+	if current := store.current.Load(); current != nil && current.identity.equal(identity) {
+		return current, nil
+	}
+
+	generation := store.nextGeneration + 1
+	index, err := loadGeoFeedFile(path, identity, generation)
+	if err != nil {
+		return store.current.Load(), err
+	}
+	store.nextGeneration = generation
+	store.current.Store(index)
+	return index, nil
+}
+
+func statGeoFeed(path string) (geoFeedFileIdentity, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return geoFeedFileIdentity{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return geoFeedFileIdentity{}, fmt.Errorf("geofeed %q is not a regular file", path)
+	}
+	return geoFeedFileIdentity{path: path, modTime: info.ModTime(), size: info.Size()}, nil
+}
+
+func (identity geoFeedFileIdentity) equal(other geoFeedFileIdentity) bool {
+	return identity.path == other.path &&
+		identity.size == other.size &&
+		identity.modTime.Equal(other.modTime)
+}
+
+func loadGeoFeedFile(
+	path string,
+	wantIdentity geoFeedFileIdentity,
+	generation uint64,
+) (*GeoFeedIndex, error) {
+	return loadGeoFeedFileWithFinalStat(path, wantIdentity, generation, os.Stat)
+}
+
+func loadGeoFeedFileWithFinalStat(
+	path string,
+	wantIdentity geoFeedFileIdentity,
+	generation uint64,
+	finalStat func(string) (os.FileInfo, error),
+) (*GeoFeedIndex, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	openedIdentity := geoFeedFileIdentity{
+		path:    path,
+		modTime: openedInfo.ModTime(),
+		size:    openedInfo.Size(),
+	}
+	if !wantIdentity.equal(openedIdentity) {
+		return nil, fmt.Errorf("geofeed %q changed before loading", path)
+	}
+
+	index, err := parseGeoFeedIndex(file, openedIdentity, generation)
+	if err != nil {
+		return nil, err
+	}
+
+	loadedInfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	loadedIdentity := geoFeedFileIdentity{
+		path:    path,
+		modTime: loadedInfo.ModTime(),
+		size:    loadedInfo.Size(),
+	}
+	currentInfo, err := finalStat(path)
+	if err != nil {
+		return nil, err
+	}
+	currentIdentity := geoFeedFileIdentity{
+		path:    path,
+		modTime: currentInfo.ModTime(),
+		size:    currentInfo.Size(),
+	}
+	if !openedIdentity.equal(loadedIdentity) ||
+		!openedIdentity.equal(currentIdentity) ||
+		!os.SameFile(openedInfo, currentInfo) {
+		return nil, fmt.Errorf("geofeed %q changed while loading", path)
+	}
+	return index, nil
+}
+
+func parseGeoFeedIndex(
+	reader io.Reader,
+	identity geoFeedFileIdentity,
+	generation uint64,
+) (*GeoFeedIndex, error) {
+	csvReader := csv.NewReader(reader)
+	csvReader.FieldsPerRecord = -1
+
+	records := make([]GeoFeedRecord, 0)
+	for {
+		row, err := csvReader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if record, valid := parseGeoFeedRecord(row); valid {
+			records = append(records, record)
+		}
+	}
+	return buildGeoFeedIndex(records, identity, generation), nil
+}
+
+func parseGeoFeedRecord(row []string) (GeoFeedRecord, bool) {
+	if len(row) != 4 && len(row) < 6 {
+		return GeoFeedRecord{}, false
+	}
+	prefix, err := netip.ParsePrefix(row[0])
+	if err != nil {
+		return GeoFeedRecord{}, false
+	}
+	prefix, valid := normalizeGeoFeedPrefix(prefix)
+	if !valid {
+		return GeoFeedRecord{}, false
+	}
+
+	record := GeoFeedRecord{
+		Prefix:  prefix,
+		CIDR:    row[0],
+		LtdCode: row[1],
+		ISO3166: row[2],
+		City:    row[3],
+	}
+	if len(row) >= 6 {
+		record.ASN = row[4]
+		record.IPWhois = row[5]
+	}
+	return record, true
+}
+
+func normalizeGeoFeedPrefix(prefix netip.Prefix) (netip.Prefix, bool) {
+	if !prefix.IsValid() {
+		return netip.Prefix{}, false
+	}
+	addr := prefix.Addr()
+	bits := prefix.Bits()
+	if addr.Is4In6() {
+		if bits < 96 {
+			return netip.Prefix{}, false
+		}
+		return netip.PrefixFrom(addr.Unmap(), bits-96).Masked(), true
+	}
+	return prefix.Masked(), true
+}
+
+func buildGeoFeedIndex(
+	records []GeoFeedRecord,
+	identity geoFeedFileIdentity,
+	generation uint64,
+) *GeoFeedIndex {
+	index := &GeoFeedIndex{
+		v4:         newGeoFeedFamilyIndex(),
+		v6:         newGeoFeedFamilyIndex(),
+		generation: generation,
+		identity:   identity,
+	}
+	for _, record := range records {
+		family := &index.v6
+		if record.Prefix.Addr().Is4() {
+			family = &index.v4
+		}
+		bits := record.Prefix.Bits()
+		bucket := family.byBits[bits]
+		if bucket == nil {
+			bucket = make(map[netip.Prefix]GeoFeedRecord)
+			family.byBits[bits] = bucket
+		}
+		bucket[record.Prefix] = record
+	}
+	index.v4.finalize()
+	index.v6.finalize()
+	index.records = appendFamilyRecords(index.records, index.v4)
+	index.records = appendFamilyRecords(index.records, index.v6)
+	return index
+}
+
+func newGeoFeedFamilyIndex() geoFeedFamilyIndex {
+	return geoFeedFamilyIndex{byBits: make(map[int]map[netip.Prefix]GeoFeedRecord)}
+}
+
+func (family *geoFeedFamilyIndex) finalize() {
+	family.prefixBits = make([]int, 0, len(family.byBits))
+	for bits := range family.byBits {
+		family.prefixBits = append(family.prefixBits, bits)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(family.prefixBits)))
+}
+
+func appendFamilyRecords(records []GeoFeedRecord, family geoFeedFamilyIndex) []GeoFeedRecord {
+	for _, bits := range family.prefixBits {
+		prefixes := make([]netip.Prefix, 0, len(family.byBits[bits]))
+		for prefix := range family.byBits[bits] {
+			prefixes = append(prefixes, prefix)
+		}
+		sort.Slice(prefixes, func(i, j int) bool {
+			return prefixes[i].Addr().Compare(prefixes[j].Addr()) < 0
+		})
+		for _, prefix := range prefixes {
+			records = append(records, family.byBits[bits][prefix])
+		}
+	}
+	return records
+}

--- a/dn42/geofeed_index.go
+++ b/dn42/geofeed_index.go
@@ -95,7 +95,7 @@ func (family geoFeedFamilyIndex) lookup(addr netip.Addr) (GeoFeedRecord, bool) {
 }
 
 func (store *geoFeedStore) load(path string) (*GeoFeedIndex, error) {
-	identity, err := statGeoFeed(path)
+	identity, _, err := statGeoFeed(path)
 	if err != nil {
 		return store.current.Load(), err
 	}
@@ -106,7 +106,7 @@ func (store *geoFeedStore) load(path string) (*GeoFeedIndex, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
-	identity, err = statGeoFeed(path)
+	identity, statInfo, err := statGeoFeed(path)
 	if err != nil {
 		return store.current.Load(), err
 	}
@@ -115,7 +115,7 @@ func (store *geoFeedStore) load(path string) (*GeoFeedIndex, error) {
 	}
 
 	generation := store.nextGeneration + 1
-	index, err := loadGeoFeedFile(path, identity, generation)
+	index, err := loadGeoFeedFile(path, identity, statInfo, generation)
 	if err != nil {
 		return store.current.Load(), err
 	}
@@ -124,15 +124,15 @@ func (store *geoFeedStore) load(path string) (*GeoFeedIndex, error) {
 	return index, nil
 }
 
-func statGeoFeed(path string) (geoFeedFileIdentity, error) {
+func statGeoFeed(path string) (geoFeedFileIdentity, os.FileInfo, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return geoFeedFileIdentity{}, err
+		return geoFeedFileIdentity{}, nil, err
 	}
 	if !info.Mode().IsRegular() {
-		return geoFeedFileIdentity{}, fmt.Errorf("geofeed %q is not a regular file", path)
+		return geoFeedFileIdentity{}, nil, fmt.Errorf("geofeed %q is not a regular file", path)
 	}
-	return geoFeedFileIdentity{path: path, modTime: info.ModTime(), size: info.Size()}, nil
+	return geoFeedFileIdentity{path: path, modTime: info.ModTime(), size: info.Size()}, info, nil
 }
 
 func (identity geoFeedFileIdentity) equal(other geoFeedFileIdentity) bool {
@@ -144,18 +144,21 @@ func (identity geoFeedFileIdentity) equal(other geoFeedFileIdentity) bool {
 func loadGeoFeedFile(
 	path string,
 	wantIdentity geoFeedFileIdentity,
+	wantInfo os.FileInfo,
 	generation uint64,
 ) (*GeoFeedIndex, error) {
-	return loadGeoFeedFileWithFinalStat(path, wantIdentity, generation, os.Stat)
+	return loadGeoFeedFileWithFileOps(path, wantIdentity, wantInfo, generation, os.Open, os.Stat)
 }
 
-func loadGeoFeedFileWithFinalStat(
+func loadGeoFeedFileWithFileOps(
 	path string,
 	wantIdentity geoFeedFileIdentity,
+	wantInfo os.FileInfo,
 	generation uint64,
+	openFile func(string) (*os.File, error),
 	finalStat func(string) (os.FileInfo, error),
 ) (*GeoFeedIndex, error) {
-	file, err := os.Open(path)
+	file, err := openFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +173,7 @@ func loadGeoFeedFileWithFinalStat(
 		modTime: openedInfo.ModTime(),
 		size:    openedInfo.Size(),
 	}
-	if !wantIdentity.equal(openedIdentity) {
+	if !wantIdentity.equal(openedIdentity) || !os.SameFile(wantInfo, openedInfo) {
 		return nil, fmt.Errorf("geofeed %q changed before loading", path)
 	}
 

--- a/dn42/geofeed_test.go
+++ b/dn42/geofeed_test.go
@@ -288,7 +288,7 @@ func TestGeoFeedStoreInitialFailureDoesNotConsumeGeneration(t *testing.T) {
 	}
 }
 
-func TestGeoFeedLegacyAPIsReturnDetachedIPNet(t *testing.T) {
+func TestGeoFeedIndexBackedLegacyAPIsReturnDetachedIPNet(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "geofeed.csv")
 	modTime := time.Unix(1_700_000_000, 0)
 	writeGeoFeedAt(t, path, "10.1.0.0/16,na,US,Legacy,AS64512,Owner\n", modTime)
@@ -338,9 +338,8 @@ func TestGeoFeedLegacyAPIsReturnDetachedIPNet(t *testing.T) {
 	if !found {
 		t.Fatal("FindGeoFeedRow() did not find input row")
 	}
-	foundRow.IPNet.IP[0] = 192
-	if input[0].IPNet.IP[0] != 10 {
-		t.Fatal("FindGeoFeedRow() returned aliased IPNet")
+	if foundRow.CIDR != input[0].CIDR {
+		t.Fatalf("FindGeoFeedRow() CIDR = %q, want %q", foundRow.CIDR, input[0].CIDR)
 	}
 	if _, found := FindGeoFeedRow("10.1.2.3", []GeoFeedRow{{IPNet: nil}}); found {
 		t.Fatal("FindGeoFeedRow() matched nil IPNet")

--- a/dn42/geofeed_test.go
+++ b/dn42/geofeed_test.go
@@ -341,9 +341,6 @@ func TestGeoFeedIndexBackedLegacyAPIsReturnDetachedIPNet(t *testing.T) {
 	if foundRow.CIDR != input[0].CIDR {
 		t.Fatalf("FindGeoFeedRow() CIDR = %q, want %q", foundRow.CIDR, input[0].CIDR)
 	}
-	if _, found := FindGeoFeedRow("10.1.2.3", []GeoFeedRow{{IPNet: nil}}); found {
-		t.Fatal("FindGeoFeedRow() matched nil IPNet")
-	}
 }
 
 func TestGeoFeedLegacyRowsPreserveMaskStringOrder(t *testing.T) {

--- a/dn42/geofeed_test.go
+++ b/dn42/geofeed_test.go
@@ -1,13 +1,488 @@
 package dn42
 
 import (
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/spf13/viper"
 )
+
+func TestParseGeoFeedIndexSkipsRecordErrors(t *testing.T) {
+	index, err := parseGeoFeedIndex(strings.NewReader(strings.Join([]string{
+		"10.0.0.0/8,na,US,Four columns",
+		"too-short",
+		"10.1.0.0/16,na,US,Five columns,AS64512",
+		"bad-cidr,na,US,Bad CIDR",
+		"10.1.2.0/24,eu,DE,Six columns,AS64513,Example",
+		"2001:db8::/32,eu,DE,Extra columns,AS64514,Example,ignored",
+	}, "\n")+"\n"), geoFeedFileIdentity{}, 7)
+	if err != nil {
+		t.Fatalf("parseGeoFeedIndex() error = %v", err)
+	}
+	if got := index.Generation(); got != 7 {
+		t.Fatalf("Generation() = %d, want 7", got)
+	}
+
+	tests := []struct {
+		addr     string
+		wantCIDR string
+		wantASN  string
+	}{
+		{addr: "10.2.3.4", wantCIDR: "10.0.0.0/8"},
+		{addr: "10.1.2.3", wantCIDR: "10.1.2.0/24", wantASN: "AS64513"},
+		{addr: "2001:db8::1", wantCIDR: "2001:db8::/32", wantASN: "AS64514"},
+	}
+	for _, test := range tests {
+		record, found := index.Lookup(netip.MustParseAddr(test.addr))
+		if !found || record.CIDR != test.wantCIDR || record.ASN != test.wantASN {
+			t.Errorf("Lookup(%s) = (%+v, %v), want CIDR %q ASN %q", test.addr, record, found, test.wantCIDR, test.wantASN)
+		}
+	}
+	if _, found := index.Lookup(netip.MustParseAddr("192.0.2.1")); found {
+		t.Error("Lookup(miss) found a record")
+	}
+	if got := len(index.records); got != 3 {
+		t.Fatalf("record count = %d, want 3", got)
+	}
+	if !slices.Equal(index.v4.prefixBits, []int{24, 8}) {
+		t.Fatalf("IPv4 prefix bits = %v, want [24 8]", index.v4.prefixBits)
+	}
+	if !slices.Equal(index.v6.prefixBits, []int{32}) {
+		t.Fatalf("IPv6 prefix bits = %v, want [32]", index.v6.prefixBits)
+	}
+}
+
+func TestParseGeoFeedIndexRejectsStructuralAndIOErrors(t *testing.T) {
+	t.Run("MalformedCSV", func(t *testing.T) {
+		_, err := parseGeoFeedIndex(
+			strings.NewReader("10.0.0.0/8,na,US,\"unterminated\n"),
+			geoFeedFileIdentity{},
+			1,
+		)
+		if err == nil {
+			t.Fatal("parseGeoFeedIndex() error = nil, want CSV parse error")
+		}
+	})
+
+	t.Run("ReaderFailure", func(t *testing.T) {
+		wantErr := errors.New("injected read failure")
+		_, err := parseGeoFeedIndex(errorReader{err: wantErr}, geoFeedFileIdentity{}, 1)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("parseGeoFeedIndex() error = %v, want %v", err, wantErr)
+		}
+	})
+}
+
+func TestParseGeoFeedIndexCSVFixtures(t *testing.T) {
+	index := mustParseGeoFeedIndex(t,
+		"10.3.0.0/16,na,US,\"City, With Comma\"\r\n"+
+			"10.4.0.0/16,na,US,\"City\r\nWith Newline\",AS64512,Owner\r\n",
+	)
+	tests := []struct {
+		addr     string
+		wantCity string
+	}{
+		{addr: "10.3.1.1", wantCity: "City, With Comma"},
+		{addr: "10.4.1.1", wantCity: "City\nWith Newline"},
+	}
+	for _, test := range tests {
+		record, found := index.Lookup(netip.MustParseAddr(test.addr))
+		if !found || record.City != test.wantCity {
+			t.Errorf("Lookup(%s) = (%+v, %v), want city %q", test.addr, record, found, test.wantCity)
+		}
+	}
+}
+
+func TestGeoFeedIndexLongestPrefixLastWinsAndMappedIPv4(t *testing.T) {
+	index := mustParseGeoFeedIndex(t, strings.Join([]string{
+		"10.0.0.0/8,na,US,Broad,AS1,Broad Owner",
+		"10.1.0.0/16,na,US,Narrow,AS2,Narrow Owner",
+		"10.1.2.99/24,na,US,First,AS3,First Owner",
+		"10.1.2.0/24,na,US,Last,AS4,Last Owner",
+		"10.1.2.0/24,na,US,Invalid Later Row,AS5",
+		"::ffff:10.2.0.0/112,na,US,Mapped Prefix,AS5,Mapped Owner",
+		"2001:db8::/32,na,US,IPv6 Broad,AS6,IPv6 Broad Owner",
+		"2001:db8:1::/48,na,US,IPv6 Narrow,AS7,IPv6 Narrow Owner",
+	}, "\n")+"\n")
+
+	tests := []struct {
+		addr     string
+		wantCity string
+	}{
+		{addr: "10.1.2.8", wantCity: "Last"},
+		{addr: "::ffff:10.1.2.8", wantCity: "Last"},
+		{addr: "10.1.9.8", wantCity: "Narrow"},
+		{addr: "10.2.9.8", wantCity: "Mapped Prefix"},
+		{addr: "2001:db8:1::1", wantCity: "IPv6 Narrow"},
+		{addr: "2001:db8:2::1", wantCity: "IPv6 Broad"},
+	}
+	for _, test := range tests {
+		record, found := index.Lookup(netip.MustParseAddr(test.addr))
+		if !found || record.City != test.wantCity {
+			t.Errorf("Lookup(%s) = (%+v, %v), want city %q", test.addr, record, found, test.wantCity)
+		}
+	}
+	if _, found := index.Lookup(netip.Addr{}); found {
+		t.Error("Lookup(invalid) found a record")
+	}
+}
+
+func TestGeoFeedStoreLazyReloadAndGeneration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "geofeed.csv")
+	baseTime := time.Unix(1_700_000_000, 0)
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,First\n", baseTime)
+
+	var store geoFeedStore
+	first, err := store.load(path)
+	if err != nil {
+		t.Fatalf("first load error = %v", err)
+	}
+	if first.Generation() != 1 {
+		t.Fatalf("first generation = %d, want 1", first.Generation())
+	}
+	unchanged, err := store.load(path)
+	if err != nil {
+		t.Fatalf("unchanged load error = %v", err)
+	}
+	if unchanged != first {
+		t.Fatal("unchanged file published a new snapshot")
+	}
+
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,Other\n", baseTime)
+	sameMetadata, err := store.load(path)
+	if err != nil {
+		t.Fatalf("same-metadata load error = %v", err)
+	}
+	if sameMetadata != first {
+		t.Fatal("same path/mtime/size published a new snapshot")
+	}
+	record, found := sameMetadata.Lookup(netip.MustParseAddr("10.1.2.3"))
+	if !found || record.City != "First" {
+		t.Fatalf("same-metadata Lookup() = (%+v, %v), want retained First", record, found)
+	}
+
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,Other\n", baseTime.Add(time.Second))
+	second, err := store.load(path)
+	if err != nil {
+		t.Fatalf("changed load error = %v", err)
+	}
+	if second == first || second.Generation() != 2 {
+		t.Fatalf("changed load = %p generation %d, want new snapshot generation 2", second, second.Generation())
+	}
+	record, found = second.Lookup(netip.MustParseAddr("10.1.2.3"))
+	if !found || record.City != "Other" {
+		t.Fatalf("mtime-changed Lookup() = (%+v, %v), want Other", record, found)
+	}
+
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,Longer\n", baseTime.Add(time.Second))
+	third, err := store.load(path)
+	if err != nil {
+		t.Fatalf("size-changed load error = %v", err)
+	}
+	if third == second || third.Generation() != 3 {
+		t.Fatalf("size-changed load = %p generation %d, want new snapshot generation 3", third, third.Generation())
+	}
+
+	otherPath := filepath.Join(dir, "other.csv")
+	writeGeoFeedAt(t, otherPath, "10.0.0.0/8,na,US,Longer\n", baseTime.Add(time.Second))
+	fourth, err := store.load(otherPath)
+	if err != nil {
+		t.Fatalf("path-changed load error = %v", err)
+	}
+	if fourth == third || fourth.Generation() != 4 {
+		t.Fatalf("path-changed load = %p generation %d, want new snapshot generation 4", fourth, fourth.Generation())
+	}
+}
+
+func TestGeoFeedStoreFailedReloadPreservesSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "geofeed.csv")
+	baseTime := time.Unix(1_700_000_000, 0)
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,Valid\n", baseTime)
+
+	var store geoFeedStore
+	valid, err := store.load(path)
+	if err != nil {
+		t.Fatalf("valid load error = %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove geofeed: %v", err)
+	}
+	stale, err := store.load(path)
+	if err == nil || stale != valid {
+		t.Fatalf("missing-file reload = (%p, %v), want old %p and error", stale, err, valid)
+	}
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,\"unterminated\n", baseTime.Add(time.Second))
+
+	stale, err = store.load(path)
+	if err == nil {
+		t.Fatal("malformed reload error = nil")
+	}
+	if stale != valid || stale.Generation() != 1 {
+		t.Fatalf("failed reload returned %p generation %d, want old %p generation 1", stale, stale.Generation(), valid)
+	}
+	record, found := stale.Lookup(netip.MustParseAddr("10.1.2.3"))
+	if !found || record.City != "Valid" {
+		t.Fatalf("stale Lookup() = (%+v, %v), want Valid", record, found)
+	}
+
+	writeGeoFeedAt(t, path, "", baseTime.Add(2*time.Second))
+	empty, err := store.load(path)
+	if err != nil {
+		t.Fatalf("empty reload error = %v", err)
+	}
+	if empty == valid || empty.Generation() != 2 {
+		t.Fatalf("empty reload = %p generation %d, want new snapshot generation 2", empty, empty.Generation())
+	}
+	if _, found := empty.Lookup(netip.MustParseAddr("10.1.2.3")); found {
+		t.Error("empty snapshot unexpectedly contains old record")
+	}
+}
+
+func TestLoadGeoFeedFileRejectsSameMetadataReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "geofeed.csv")
+	replacement := filepath.Join(dir, "replacement.csv")
+	modTime := time.Unix(1_700_000_000, 0)
+	content := "10.0.0.0/8,na,US,Same metadata\n"
+	writeGeoFeedAt(t, path, content, modTime)
+	writeGeoFeedAt(t, replacement, content, modTime)
+
+	identity, err := statGeoFeed(path)
+	if err != nil {
+		t.Fatalf("statGeoFeed() error = %v", err)
+	}
+	_, err = loadGeoFeedFileWithFinalStat(
+		path,
+		identity,
+		1,
+		func(string) (os.FileInfo, error) { return os.Stat(replacement) },
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed while loading") {
+		t.Fatalf("same-metadata replacement error = %v, want changed-while-loading error", err)
+	}
+}
+
+func TestGeoFeedStoreInitialFailureDoesNotConsumeGeneration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "geofeed.csv")
+	var store geoFeedStore
+	if index, err := store.load(path); err == nil || index != nil {
+		t.Fatalf("load(missing) = (%p, %v), want nil and error", index, err)
+	}
+
+	writeGeoFeedAt(t, path, "bad,na,US,Invalid\n", time.Unix(1_700_000_000, 0))
+	index, err := store.load(path)
+	if err != nil {
+		t.Fatalf("record-level errors should publish empty snapshot: %v", err)
+	}
+	if index.Generation() != 1 || len(index.records) != 0 {
+		t.Fatalf("invalid-only snapshot = generation %d records %d, want 1 and 0", index.Generation(), len(index.records))
+	}
+}
+
+func TestGeoFeedLegacyAPIsReturnDetachedIPNet(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "geofeed.csv")
+	modTime := time.Unix(1_700_000_000, 0)
+	writeGeoFeedAt(t, path, "10.1.0.0/16,na,US,Legacy,AS64512,Owner\n", modTime)
+	setGeoFeedPathForTest(t, path)
+
+	rows, err := ReadGeoFeed()
+	if err != nil {
+		t.Fatalf("ReadGeoFeed() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ReadGeoFeed() rows = %d, want 1", len(rows))
+	}
+	rows[0].IPNet.IP[0] = 192
+	rows[0].IPNet.Mask[0] = 0
+
+	again, err := ReadGeoFeed()
+	if err != nil {
+		t.Fatalf("second ReadGeoFeed() error = %v", err)
+	}
+	if got := again[0].IPNet.String(); got != "10.1.0.0/16" {
+		t.Fatalf("second ReadGeoFeed() IPNet = %q, want 10.1.0.0/16", got)
+	}
+	row, found := GetGeoFeed("10.1.2.3")
+	if !found || row.City != "Legacy" {
+		t.Fatalf("GetGeoFeed() = (%+v, %v), want Legacy", row, found)
+	}
+	row.IPNet.IP[0] = 192
+	row, found = GetGeoFeed("10.1.2.3")
+	if !found || row.IPNet.String() != "10.1.0.0/16" {
+		t.Fatalf("second GetGeoFeed() = (%+v, %v), want detached IPNet", row, found)
+	}
+	writeGeoFeedAt(t, path, "10.1.0.0/16,na,US,\"unterminated\n", modTime.Add(time.Second))
+	staleRows, err := ReadGeoFeed()
+	if err == nil || len(staleRows) != 1 || staleRows[0].City != "Legacy" {
+		t.Fatalf("ReadGeoFeed() after failed reload = (%+v, %v), want stale Legacy row and error", staleRows, err)
+	}
+	row, found = GetGeoFeed("10.1.2.3")
+	if !found || row.City != "Legacy" {
+		t.Fatalf("GetGeoFeed() after failed reload = (%+v, %v), want stale Legacy row", row, found)
+	}
+
+	input := []GeoFeedRow{{
+		IPNet: &net.IPNet{IP: net.IPv4(10, 0, 0, 0).To4(), Mask: net.CIDRMask(8, 32)},
+		CIDR:  "10.0.0.0/8",
+	}}
+	foundRow, found := FindGeoFeedRow("10.1.2.3", input)
+	if !found {
+		t.Fatal("FindGeoFeedRow() did not find input row")
+	}
+	foundRow.IPNet.IP[0] = 192
+	if input[0].IPNet.IP[0] != 10 {
+		t.Fatal("FindGeoFeedRow() returned aliased IPNet")
+	}
+	if _, found := FindGeoFeedRow("10.1.2.3", []GeoFeedRow{{IPNet: nil}}); found {
+		t.Fatal("FindGeoFeedRow() matched nil IPNet")
+	}
+}
+
+func TestGeoFeedLegacyRowsPreserveMaskStringOrder(t *testing.T) {
+	index := mustParseGeoFeedIndex(t, strings.Join([]string{
+		"10.0.0.0/8,na,US,IPv4 Eight",
+		"2001:db8::/32,na,US,IPv6 Thirty Two",
+		"10.1.2.0/24,na,US,IPv4 Twenty Four",
+		"2001:db8:1::/64,na,US,IPv6 Sixty Four",
+	}, "\n")+"\n")
+	rows := index.legacyRows()
+	got := make([]string, len(rows))
+	for i, row := range rows {
+		got[i] = row.CIDR
+	}
+	want := []string{
+		"2001:db8:1::/64",
+		"2001:db8::/32",
+		"10.1.2.0/24",
+		"10.0.0.0/8",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("legacy row order = %v, want %v", got, want)
+	}
+}
+
+func TestGeoFeedLegacyRowsPreserveMappedIPv4IPNet(t *testing.T) {
+	index := mustParseGeoFeedIndex(t, "::ffff:10.2.0.0/112,na,US,Mapped\n")
+	rows := index.legacyRows()
+	if len(rows) != 1 {
+		t.Fatalf("legacy rows = %d, want 1", len(rows))
+	}
+	ones, bits := rows[0].IPNet.Mask.Size()
+	if ones != 112 || bits != 128 || len(rows[0].IPNet.IP) != net.IPv6len {
+		t.Fatalf("mapped legacy IPNet = %v mask (%d, %d) IP len %d", rows[0].IPNet, ones, bits, len(rows[0].IPNet.IP))
+	}
+	if !rows[0].IPNet.Contains(net.ParseIP("::ffff:10.2.1.1")) {
+		t.Fatal("mapped legacy IPNet no longer contains mapped IPv4 address")
+	}
+}
+
+func TestGeoFeedStoreConcurrentLoadAndLookup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "geofeed.csv")
+	writeGeoFeedAt(t, path, "10.0.0.0/8,na,US,Concurrent\n", time.Unix(1_700_000_000, 0))
+
+	var store geoFeedStore
+	const workers = 32
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Go(func() {
+			<-start
+			for range 100 {
+				index, err := store.load(path)
+				if err != nil {
+					errs <- err
+					return
+				}
+				record, found := index.Lookup(netip.MustParseAddr("10.1.2.3"))
+				if !found || record.City != "Concurrent" {
+					errs <- errors.New("concurrent lookup returned wrong record")
+					return
+				}
+			}
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	if index := store.current.Load(); index == nil || index.Generation() != 1 {
+		t.Fatalf("published index = %p generation %d, want non-nil generation 1", index, index.Generation())
+	}
+}
+
+func TestGeoFeedIndexLookupAllocations(t *testing.T) {
+	index := mustParseGeoFeedIndex(t, "10.0.0.0/8,na,US,Allocation\n")
+	addr := netip.MustParseAddr("10.1.2.3")
+	allocs := testing.AllocsPerRun(1000, func() {
+		record, found := index.Lookup(addr)
+		if !found || record.City != "Allocation" {
+			panic("unexpected lookup result")
+		}
+	})
+	if allocs > 1 {
+		t.Fatalf("Lookup() allocations = %.2f, want <= 1", allocs)
+	}
+}
 
 func TestFindGeoFeedRowInvalidIP(t *testing.T) {
 	row, found := FindGeoFeedRow("not-an-ip", nil)
-	assert.False(t, found)
-	assert.Equal(t, GeoFeedRow{}, row)
+	if found || row != (GeoFeedRow{}) {
+		t.Fatalf("FindGeoFeedRow(invalid) = (%+v, %v), want zero and false", row, found)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (reader errorReader) Read([]byte) (int, error) {
+	return 0, reader.err
+}
+
+func mustParseGeoFeedIndex(t *testing.T, content string) *GeoFeedIndex {
+	t.Helper()
+	index, err := parseGeoFeedIndex(strings.NewReader(content), geoFeedFileIdentity{}, 1)
+	if err != nil {
+		t.Fatalf("parseGeoFeedIndex() error = %v", err)
+	}
+	return index
+}
+
+func writeGeoFeedAt(t *testing.T, path, content string, modTime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write geofeed: %v", err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("set geofeed timestamps: %v", err)
+	}
+}
+
+func setGeoFeedPathForTest(t *testing.T, path string) {
+	t.Helper()
+	previous := viper.Get("geoFeedPath")
+	defaultGeoFeedStore.mu.Lock()
+	defaultGeoFeedStore.current.Store(nil)
+	defaultGeoFeedStore.nextGeneration = 0
+	defaultGeoFeedStore.mu.Unlock()
+	viper.Set("geoFeedPath", path)
+	t.Cleanup(func() {
+		defaultGeoFeedStore.mu.Lock()
+		defaultGeoFeedStore.current.Store(nil)
+		defaultGeoFeedStore.nextGeneration = 0
+		defaultGeoFeedStore.mu.Unlock()
+		viper.Set("geoFeedPath", previous)
+	})
 }

--- a/dn42/geofeed_test.go
+++ b/dn42/geofeed_test.go
@@ -256,18 +256,46 @@ func TestLoadGeoFeedFileRejectsSameMetadataReplacement(t *testing.T) {
 	writeGeoFeedAt(t, path, content, modTime)
 	writeGeoFeedAt(t, replacement, content, modTime)
 
-	identity, err := statGeoFeed(path)
+	identity, statInfo, err := statGeoFeed(path)
 	if err != nil {
 		t.Fatalf("statGeoFeed() error = %v", err)
 	}
-	_, err = loadGeoFeedFileWithFinalStat(
+	_, err = loadGeoFeedFileWithFileOps(
 		path,
 		identity,
+		statInfo,
 		1,
+		os.Open,
 		func(string) (os.FileInfo, error) { return os.Stat(replacement) },
 	)
 	if err == nil || !strings.Contains(err.Error(), "changed while loading") {
 		t.Fatalf("same-metadata replacement error = %v, want changed-while-loading error", err)
+	}
+}
+
+func TestLoadGeoFeedFileRejectsSameMetadataReplacementBeforeOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "geofeed.csv")
+	replacement := filepath.Join(dir, "replacement.csv")
+	modTime := time.Unix(1_700_000_000, 0)
+	content := "10.0.0.0/8,na,US,Same metadata\n"
+	writeGeoFeedAt(t, path, content, modTime)
+	writeGeoFeedAt(t, replacement, content, modTime)
+
+	identity, statInfo, err := statGeoFeed(path)
+	if err != nil {
+		t.Fatalf("statGeoFeed() error = %v", err)
+	}
+	_, err = loadGeoFeedFileWithFileOps(
+		path,
+		identity,
+		statInfo,
+		1,
+		func(string) (*os.File, error) { return os.Open(replacement) },
+		os.Stat,
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed before loading") {
+		t.Fatalf("same-metadata replacement error = %v, want changed-before-loading error", err)
 	}
 }
 

--- a/dn42/ptr.go
+++ b/dn42/ptr.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/spf13/viper"
+	"github.com/nxtrace/NTrace-core/config"
 )
 
 type PtrRow struct {
@@ -31,7 +31,7 @@ func matchesPattern(prefix string, s string) bool {
 }
 
 func FindPtrRecord(ptr string) (PtrRow, error) {
-	path := viper.GetString("ptrPath")
+	path := config.PtrPath()
 	if path == "" {
 		return PtrRow{}, errors.New("ptrPath not configured")
 	}

--- a/docs/performance/go127-dn42-geofeed.md
+++ b/docs/performance/go127-dn42-geofeed.md
@@ -23,7 +23,7 @@ bits 的合同，因此选用 prefix map。
 | --- | --- |
 | parent | `d2e27a66fbc13a4056d7cc4bf1d6c6da30164511` |
 | production benchmark head | `9ee2d1c53d6022a0d9990a38d184d9a38c371251` |
-| reviewed implementation/artifact head | `2e914d891d8a0b594041066a9e9797446d531355` |
+| reviewed implementation/artifact head | `d5775afa410e6b708d6ae7ff8e987909369a87ca` |
 | 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
 | 系统 | macOS 26.6.2，darwin/arm64 |
 | 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
@@ -124,9 +124,9 @@ CPU 93.06% 累积于 `GeoFeedIndex.Lookup`，主要为 family lookup 和 map acc
 
 | Flavor | parent | implementation head | 未压缩变化 | UPX 变化 |
 | --- | ---: | ---: | ---: | ---: |
-| nexttrace | 29,687,968 / 9,693,824 B | 29,753,504 / 9,705,552 B | +0.2207% | +0.1210% |
-| nexttrace-tiny | 10,879,136 / 4,074,364 B | 10,879,136 / 4,090,140 B | 0.0000% | +0.3872% |
-| ntr | 10,879,136 / 4,074,220 B | 10,879,136 / 4,089,876 B | 0.0000% | +0.3843% |
+| nexttrace | 29,687,968 / 9,693,824 B | 29,753,504 / 9,705,360 B | +0.2207% | +0.1190% |
+| nexttrace-tiny | 10,879,136 / 4,074,364 B | 10,879,136 / 4,090,276 B | 0.0000% | +0.3905% |
+| ntr | 10,879,136 / 4,074,220 B | 10,879,136 / 4,090,164 B | 0.0000% | +0.3913% |
 
 ## 验证
 
@@ -134,7 +134,7 @@ CPU 93.06% 累积于 `GeoFeedIndex.Lookup`，主要为 family lookup 和 map acc
 
 - 4 列、6+ 列、短行、5 列、坏 CIDR、结构错误、I/O 错误和空文件。
 - 最长前缀、重复 prefix 最后一条有效记录覆盖、IPv4-mapped IPv6 和 0 alloc lookup。
-- path/mtime/size reload、失败保留、generation、并发装载及不可变快照。
+- path/mtime/size reload、stat/open 文件身份、失败保留、generation、并发装载及不可变快照。
 - 国家代码精确小写匹配和未知值回退。
 - CLI、REST/WS、service/MCP、FastTrace、nali、MTU 的 DN42 source 固定与保留地址查询。
 - MTR legacy/per-hop reset 刷新、旧 generation 取消及结果隔离。

--- a/docs/performance/go127-dn42-geofeed.md
+++ b/docs/performance/go127-dn42-geofeed.md
@@ -1,0 +1,157 @@
+# Go 1.27 DN42 GeoFeed 索引证据
+
+## 范围与结论
+
+本轮只调整 DN42 GeoFeed 的装载、最长前缀查询和执行边界：
+
+- IPv4/IPv6 分别按实际出现的 prefix bits 建立不可变 prefix map，完整构造后以
+  `atomic.Pointer` 发布。
+- CLI、REST/WS、MCP/service、FastTrace、nali、MTU 和 MTR 在会话开始时固定
+  GeoFeed generation；MTR reset 才刷新到新 generation。
+- 文件变化只在执行边界按 path、mtime、size 检查，不增加常驻 watcher；热
+  `GeoFeedIndex.Lookup` 不访问文件系统。
+- DN42 查询绕过不适用的保留地址过滤、进程级 Geo cache 和 singleflight。
+
+混合 4096 条 IPv4/IPv6、8 种 prefix length 的最终数据见下文。prefix map 的热
+查询保持 0 alloc/op，并超过相对预解析旧 slice 至少 20 倍的合并门槛。测试用 trie
+没有在 IPv4/IPv6 两组都形成优势；prefix map 更简单，且直接表达实际出现 prefix
+bits 的合同，因此选用 prefix map。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `d2e27a66fbc13a4056d7cc4bf1d6c6da30164511` |
+| production benchmark head | `9ee2d1c53d6022a0d9990a38d184d9a38c371251` |
+| final code head | `c844e49e09e29cec3e9789ac2c223e92adcb08bc` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每组 10 次，每次 1 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+| 压缩工具 | UPX 5.2.1，`-9` |
+
+## 调用链变化
+
+### 旧生产查询
+
+此前每次 DN42 Geo 查询执行：
+
+`DN42 -> GetGeoFeed -> ReadGeoFeed -> os.Open -> csv.ReadAll -> ParseCIDR -> sort -> linear scan`
+
+文件读取、完整 CSV 解析、CIDR 构造和排序都位于逐 IP 热路径。MTR、Web 和批量
+nali 查询会重复这些工作。
+
+### 新生产查询
+
+会话边界现在执行：
+
+`GetSourceSession -> LoadGeoFeedIndex -> stat/reload if changed -> streaming CSV -> build index -> atomic publish`
+
+同一会话的每次热查询只执行：
+
+`session Source -> netip.Addr.Unmap -> descending present bits -> prefix map lookup`
+
+IPv4 与 IPv6 使用独立索引。相同 prefix 的最后一条有效记录覆盖之前记录；显示用
+CIDR 和字段仍保留输入值。IPv4-mapped IPv6 在索引内归一化为 IPv4，以便等价地址
+命中相同记录，旧 `GeoFeedRow.IPNet` 适配仍按原 CIDR 重建。
+
+### Reload 与会话 generation
+
+首次访问惰性装载。后续边界按 path、mtime、size 识别变化；完整解析成功后才增加
+generation 并发布。CSV 短行、5 列和坏 CIDR 作为记录错误跳过；CSV 结构或 I/O
+错误使 reload 失败并保留旧快照。空文件是有效新快照。
+
+普通 traceroute、FastTrace、nali、MTU、REST/WS 和 service/MCP 在请求或批次开始时
+固定 source。MTR legacy 与 per-hop 两条 reset 路径先隔离旧工作，再刷新 source，
+因此旧 generation 的 metadata 结果不会写入 reset 后统计。
+
+## Benchmark
+
+比较包含：
+
+- 旧生产端到端读取、解析、排序、线性查询。
+- 预解析旧 slice 的纯线性查询。
+- 最终 prefix map。
+- 仅用于选择的数据结构 trie。
+
+| Family / implementation | time/op | B/op | allocs/op | prefix map 相对预解析旧 slice |
+| --- | ---: | ---: | ---: | ---: |
+| IPv4 / legacy end-to-end | 994.3 us | 1.593 MiB | 24.61k | — |
+| IPv4 / legacy preparsed slice | 15.31 us | 0 B | 0 | — |
+| IPv4 / prefix map | 74.50 ns | 0 B | 0 | 205.5x |
+| IPv4 / test-only trie | 47.59 ns | 0 B | 0 | — |
+| IPv6 / legacy end-to-end | 1.343 ms | 1.686 MiB | 24.61k | — |
+| IPv6 / legacy preparsed slice | 11.56 us | 0 B | 0 | — |
+| IPv6 / prefix map | 75.34 ns | 0 B | 0 | 153.4x |
+| IPv6 / test-only trie | 150.7 ns | 0 B | 0 | — |
+
+PR-0 同名兼容 benchmark 也在 parent/head 各运行 10 次。`ReadGeoFeedCSV` 从
+1,179.5 us 降为 647.5 us（-45.11%），B/op 从 2.991 MiB 降为 1.028 MiB
+（-65.62%）；完整 legacy view 构造的 allocs/op 从 24.63k 增为 28.68k
+（+16.47%），但该构造只在装载/兼容接口边界执行，不在固定会话的查询热路径。
+
+首轮还发现 `FindGeoFeedRow` 命中路径因无必要防御性复制增加 3 alloc/op；最终实现
+恢复该旧接口原有的浅返回语义，所有命中/未命中子项重新保持 0 alloc/op，geomean
+从 3.310 us 降为 3.059 us（-7.59%）。七个子项改善 4.48% 到 13.72%；IPv4
+HeadHit 从 18.98 ns 变为 19.33 ns（+1.84%，绝对 +0.35 ns）。该 helper 的循环与
+parent 源码等价，现有差异属于链接/代码布局级波动；它不是新生产查询路径，不影响
+PR-3 的 prefix-map 合并门槛。
+
+## Profile
+
+代表性 CPU/heap profile 使用固定 10 秒采集。parent IPv4 TailHit 为
+24.645 us/op、0 alloc，CPU 98.97% 累积于 `FindGeoFeedRow`，主要为
+`IPNet.Contains` 和 mask 处理。head 混合数据 PrefixMap 为 75.23 ns/op、0 alloc，
+CPU 93.06% 累积于 `GeoFeedIndex.Lookup`，主要为 family lookup 和 map access。
+两侧 heap 热点均来自 fixture、索引/trie 构造和 profile 启动，查询热循环无分配。
+原始 `.pprof` 只作为本地/CI artifact 保存，不提交仓库。
+
+## 产物大小
+
+产物使用 `-buildvcs=false -trimpath`，并以 `-X` 固定 Version、BuildDate、CommitID，
+同时使用 `-ldflags '-w -s'`；Darwin 另加 `-macos=13.0`。
+
+### Darwin arm64，未压缩
+
+| Flavor | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,027,362 B | 30,043,938 B | +16,576 B / +0.0552% |
+| nexttrace-tiny | 10,950,674 B | 10,983,794 B | +33,120 B / +0.3024% |
+| ntr | 10,934,162 B | 10,983,794 B | +49,632 B / +0.4539% |
+
+### Linux arm64，未压缩 / UPX `-9`
+
+| Flavor | parent | head | 未压缩变化 | UPX 变化 |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 29,687,968 / 9,693,824 B | 29,753,504 / 9,705,776 B | +0.2207% | +0.1233% |
+| nexttrace-tiny | 10,879,136 / 4,074,364 B | 10,879,136 / 4,090,588 B | 0.0000% | +0.3982% |
+| ntr | 10,879,136 / 4,074,220 B | 10,879,136 / 4,090,568 B | 0.0000% | +0.4013% |
+
+## 验证
+
+新增回归覆盖：
+
+- 4 列、6+ 列、短行、5 列、坏 CIDR、结构错误、I/O 错误和空文件。
+- 最长前缀、重复 prefix 最后一条有效记录覆盖、IPv4-mapped IPv6 和 0 alloc lookup。
+- path/mtime/size reload、失败保留、generation、并发装载及不可变快照。
+- 国家代码精确小写匹配和未知值回退。
+- CLI、REST/WS、service/MCP、FastTrace、nali、MTU 的 DN42 source 固定与保留地址查询。
+- MTR legacy/per-hop reset 刷新、旧 generation 取消及结果隔离。
+
+final code head 已通过默认 JSON 与 `nojsonv2` 完整测试、全仓 race、build、vet、
+golangci-lint、full/tiny/ntr、Web 前端 Node 测试、module verify/tidy diff、安装脚本
+smoke，以及 Linux、Windows、Darwin 现有构建矩阵。Darwin amd64/arm64 release-style
+产物的 `LC_BUILD_VERSION` 均为 `minos 13.0`。相同 `nojsonv2` 完整测试的墙钟耗时
+为 parent 33.69 秒、final code head 25.52 秒，两侧均通过。
+
+## 平台风险与回退
+
+索引内存随有效 prefix 数量和实际出现的 prefix length 数量增长；没有额外后台
+goroutine 或 watcher。path/mtime/size 是锁定的变化检测合同，同尺寸且同 mtime 的
+原地内容改写不会触发 reload。失败 reload 会继续使用最后一个成功快照，并把错误
+返回给显式装载接口；既有 DN42 查询仍按原合同返回旧数据或空结果。
+
+如需回退，可逆序撤销本 PR 的实现提交。现有导出函数没有删除或改签名；新增
+`GeoFeedIndex`、`SourceSession` 与 `LookupIPGeoWithSession` 均为增量 API，不涉及
+配置、JSON 或持久数据迁移。

--- a/docs/performance/go127-dn42-geofeed.md
+++ b/docs/performance/go127-dn42-geofeed.md
@@ -23,7 +23,7 @@ bits 的合同，因此选用 prefix map。
 | --- | --- |
 | parent | `d2e27a66fbc13a4056d7cc4bf1d6c6da30164511` |
 | production benchmark head | `9ee2d1c53d6022a0d9990a38d184d9a38c371251` |
-| final code head | `c844e49e09e29cec3e9789ac2c223e92adcb08bc` |
+| reviewed implementation/artifact head | `2e914d891d8a0b594041066a9e9797446d531355` |
 | 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
 | 系统 | macOS 26.6.2，darwin/arm64 |
 | 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
@@ -114,7 +114,7 @@ CPU 93.06% 累积于 `GeoFeedIndex.Lookup`，主要为 family lookup 和 map acc
 
 ### Darwin arm64，未压缩
 
-| Flavor | parent | head | 变化 |
+| Flavor | parent | implementation head | 变化 |
 | --- | ---: | ---: | ---: |
 | nexttrace | 30,027,362 B | 30,043,938 B | +16,576 B / +0.0552% |
 | nexttrace-tiny | 10,950,674 B | 10,983,794 B | +33,120 B / +0.3024% |
@@ -122,11 +122,11 @@ CPU 93.06% 累积于 `GeoFeedIndex.Lookup`，主要为 family lookup 和 map acc
 
 ### Linux arm64，未压缩 / UPX `-9`
 
-| Flavor | parent | head | 未压缩变化 | UPX 变化 |
+| Flavor | parent | implementation head | 未压缩变化 | UPX 变化 |
 | --- | ---: | ---: | ---: | ---: |
-| nexttrace | 29,687,968 / 9,693,824 B | 29,753,504 / 9,705,776 B | +0.2207% | +0.1233% |
-| nexttrace-tiny | 10,879,136 / 4,074,364 B | 10,879,136 / 4,090,588 B | 0.0000% | +0.3982% |
-| ntr | 10,879,136 / 4,074,220 B | 10,879,136 / 4,090,568 B | 0.0000% | +0.4013% |
+| nexttrace | 29,687,968 / 9,693,824 B | 29,753,504 / 9,705,552 B | +0.2207% | +0.1210% |
+| nexttrace-tiny | 10,879,136 / 4,074,364 B | 10,879,136 / 4,090,140 B | 0.0000% | +0.3872% |
+| ntr | 10,879,136 / 4,074,220 B | 10,879,136 / 4,089,876 B | 0.0000% | +0.3843% |
 
 ## 验证
 
@@ -139,11 +139,14 @@ CPU 93.06% 累积于 `GeoFeedIndex.Lookup`，主要为 family lookup 和 map acc
 - CLI、REST/WS、service/MCP、FastTrace、nali、MTU 的 DN42 source 固定与保留地址查询。
 - MTR legacy/per-hop reset 刷新、旧 generation 取消及结果隔离。
 
-final code head 已通过默认 JSON 与 `nojsonv2` 完整测试、全仓 race、build、vet、
-golangci-lint、full/tiny/ntr、Web 前端 Node 测试、module verify/tidy diff、安装脚本
-smoke，以及 Linux、Windows、Darwin 现有构建矩阵。Darwin amd64/arm64 release-style
-产物的 `LC_BUILD_VERSION` 均为 `minos 13.0`。相同 `nojsonv2` 完整测试的墙钟耗时
-为 parent 33.69 秒、final code head 25.52 秒，两侧均通过。
+reviewed implementation/artifact head 已通过默认 JSON 与 `nojsonv2` 完整测试、全仓
+race、build、vet、golangci-lint、full/tiny/ntr、Web 前端 Node 测试、module
+verify/tidy diff、安装脚本 smoke，以及 Linux、Windows、Darwin 现有构建矩阵。
+Darwin amd64/arm64 release-style 产物的 `LC_BUILD_VERSION` 均为 `minos 13.0`。
+相同 `nojsonv2` 完整测试的成对墙钟记录为 parent 33.69 秒、实现头 25.52 秒，两侧
+均通过；review 修复后的实现头另以热构建缓存复核为 17.60 秒，不用于成对比较。
+紧随其后的证据提交只修改本 Markdown 文件，不改变 Go 源码或构建输入；PR exact-head
+CI 仍重新生成 benchmark、profile、测试耗时和三 flavor artifact 后才允许合并。
 
 ## 平台风险与回退
 

--- a/fast_trace/fast_trace ipv6.go
+++ b/fast_trace/fast_trace ipv6.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace"
 )
 
@@ -52,7 +51,7 @@ func (f *FastTracer) tracert_v6(location string, ispCollection ISPCollection) {
 		AlwaysWaitRDNS:   f.ParamsFastTrace.AlwaysWaitRDNS,
 		PacketInterval:   100,
 		TTLInterval:      500,
-		IPGeoSource:      ipgeo.GetSource(ipgeo.NextTraceAPIProvider),
+		IPGeoSource:      fastTraceGeoSource(f.ParamsFastTrace),
 		Timeout:          f.ParamsFastTrace.Timeout,
 		SrcAddr:          f.ParamsFastTrace.SrcAddr,
 		SourceDevice:     f.ParamsFastTrace.SrcDev,
@@ -60,6 +59,7 @@ func (f *FastTracer) tracert_v6(location string, ispCollection ISPCollection) {
 		RandomPacketSize: packetSizeSpec.Random,
 		TOS:              f.ParamsFastTrace.TOS,
 		Lang:             f.ParamsFastTrace.Lang,
+		DN42:             fastTraceDN42(f.ParamsFastTrace),
 	}
 	conf, err = normalizeFastTraceConfig(f.TracerouteMethod, conf)
 	if shouldStopFastTrace(err) {
@@ -148,6 +148,7 @@ func (f *FastTracer) testFastGZ_v6() {
 }
 
 func FastTestv6(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
+	paramsFastTrace = pinFastTraceGeoSource(paramsFastTrace)
 	choice, ok := readFastTestv6Choice(paramsFastTrace.Context)
 	if !ok {
 		return

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -53,6 +53,9 @@ type ParamsFastTrace struct {
 	Dot             string
 	OutputPath      string
 	RuntimePrepared bool
+	DataProvider    string
+	IPGeoSource     ipgeo.Source
+	DN42            bool
 }
 
 type IpListElement struct {
@@ -70,6 +73,28 @@ func resolveTraceMethod(traceMode trace.Method) trace.Method {
 	default:
 		return trace.ICMPTrace
 	}
+}
+
+func fastTraceGeoSource(params ParamsFastTrace) ipgeo.Source {
+	if params.IPGeoSource != nil {
+		return params.IPGeoSource
+	}
+	provider := strings.TrimSpace(params.DataProvider)
+	if provider == "" {
+		provider = ipgeo.NextTraceAPIProvider
+	}
+	return ipgeo.GetSource(provider)
+}
+
+func fastTraceDN42(params ParamsFastTrace) bool {
+	return params.DN42 || strings.EqualFold(strings.TrimSpace(params.DataProvider), "DN42")
+}
+
+func pinFastTraceGeoSource(params ParamsFastTrace) ParamsFastTrace {
+	if params.IPGeoSource == nil {
+		params.IPGeoSource = fastTraceGeoSource(params)
+	}
+	return params
 }
 
 func isContextStop(err error) bool {
@@ -125,7 +150,10 @@ var (
 )
 
 func openFastTraceWSIfNeeded(params ParamsFastTrace) func() {
-	if params.RuntimePrepared || ipgeo.NextTraceAPIV4TokenConfigured() {
+	provider := strings.TrimSpace(params.DataProvider)
+	if params.RuntimePrepared ||
+		(provider != "" && !ipgeo.IsNextTraceAPIProvider(provider)) ||
+		ipgeo.NextTraceAPIV4TokenConfigured() {
 		return func() {}
 	}
 	w := initFastTraceWSFn(params.Context)
@@ -259,7 +287,7 @@ func buildFileTraceConfig(params ParamsFastTrace, tracerouteMethod trace.Method,
 		AlwaysWaitRDNS:   params.AlwaysWaitRDNS,
 		PacketInterval:   100,
 		TTLInterval:      500,
-		IPGeoSource:      ipgeo.GetSource(ipgeo.NextTraceAPIProvider),
+		IPGeoSource:      fastTraceGeoSource(params),
 		Timeout:          params.Timeout,
 		SrcAddr:          params.SrcAddr,
 		SourceDevice:     params.SrcDev,
@@ -267,6 +295,7 @@ func buildFileTraceConfig(params ParamsFastTrace, tracerouteMethod trace.Method,
 		RandomPacketSize: packetSizeSpec.Random,
 		TOS:              params.TOS,
 		Lang:             params.Lang,
+		DN42:             fastTraceDN42(params),
 	}, nil
 }
 
@@ -413,7 +442,7 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 		AlwaysWaitRDNS:   f.ParamsFastTrace.AlwaysWaitRDNS,
 		PacketInterval:   100,
 		TTLInterval:      500,
-		IPGeoSource:      ipgeo.GetSource(ipgeo.NextTraceAPIProvider),
+		IPGeoSource:      fastTraceGeoSource(f.ParamsFastTrace),
 		Timeout:          f.ParamsFastTrace.Timeout,
 		SrcAddr:          f.ParamsFastTrace.SrcAddr,
 		SourceDevice:     f.ParamsFastTrace.SrcDev,
@@ -421,6 +450,7 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 		RandomPacketSize: packetSizeSpec.Random,
 		TOS:              f.ParamsFastTrace.TOS,
 		Lang:             f.ParamsFastTrace.Lang,
+		DN42:             fastTraceDN42(f.ParamsFastTrace),
 	}
 	conf, err = normalizeFastTraceConfig(f.TracerouteMethod, conf)
 	if shouldStopFastTrace(err) {
@@ -447,6 +477,7 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 }
 
 func FastTest(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
+	paramsFastTrace = pinFastTraceGeoSource(paramsFastTrace)
 	if paramsFastTrace.File != "" {
 		testFile(paramsFastTrace, traceMode)
 		return
@@ -476,6 +507,7 @@ func FastTest(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
 }
 
 func testFile(paramsFastTrace ParamsFastTrace, traceMode trace.Method) {
+	paramsFastTrace = pinFastTraceGeoSource(paramsFastTrace)
 	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
 	defer cleanupWS()
 

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -79,11 +79,18 @@ func fastTraceGeoSource(params ParamsFastTrace) ipgeo.Source {
 	if params.IPGeoSource != nil {
 		return params.IPGeoSource
 	}
+	return ipgeo.GetSource(fastTraceDataProvider(params))
+}
+
+func fastTraceDataProvider(params ParamsFastTrace) string {
 	provider := strings.TrimSpace(params.DataProvider)
-	if provider == "" {
-		provider = ipgeo.NextTraceAPIProvider
+	if provider == "" && params.DN42 {
+		return "DN42"
 	}
-	return ipgeo.GetSource(provider)
+	if provider == "" {
+		return ipgeo.NextTraceAPIProvider
+	}
+	return provider
 }
 
 func fastTraceDN42(params ParamsFastTrace) bool {
@@ -150,9 +157,9 @@ var (
 )
 
 func openFastTraceWSIfNeeded(params ParamsFastTrace) func() {
-	provider := strings.TrimSpace(params.DataProvider)
+	provider := fastTraceDataProvider(params)
 	if params.RuntimePrepared ||
-		(provider != "" && !ipgeo.IsNextTraceAPIProvider(provider)) ||
+		!ipgeo.IsNextTraceAPIProvider(provider) ||
 		ipgeo.NextTraceAPIV4TokenConfigured() {
 		return func() {}
 	}

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -13,9 +13,11 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
 	"github.com/nxtrace/NTrace-core/wshandle"
+	"github.com/spf13/viper"
 )
 
 func TestTrace(t *testing.T) {
@@ -306,6 +308,62 @@ func fastTraceTestParams(outputPath string) ParamsFastTrace {
 	}
 }
 
+func TestBuildFileTraceConfigUsesPinnedDN42Source(t *testing.T) {
+	wantSourceCalls := 0
+	source := func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+		wantSourceCalls++
+		return &ipgeo.IPGeoData{Country: "DN42"}, nil
+	}
+	cfg, err := buildFileTraceConfig(ParamsFastTrace{
+		Context:      context.Background(),
+		MaxHops:      30,
+		Timeout:      time.Second,
+		DataProvider: " dn42 ",
+		IPGeoSource:  source,
+	}, trace.ICMPTrace, IpListElement{Ip: "10.0.0.1", Version4: true})
+	if err != nil {
+		t.Fatalf("buildFileTraceConfig returned error: %v", err)
+	}
+	if !cfg.DN42 || cfg.IPGeoSource == nil {
+		t.Fatalf("DN42 config = %+v", cfg)
+	}
+	if _, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false); err != nil {
+		t.Fatalf("pinned source returned error: %v", err)
+	}
+	if wantSourceCalls != 1 {
+		t.Fatalf("source calls = %d, want 1", wantSourceCalls)
+	}
+}
+
+func TestPinFastTraceGeoSourceNormalizesDN42Provider(t *testing.T) {
+	dir := t.TempDir()
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,DN42 City\n"), 0o600); err != nil {
+		t.Fatalf("write geofeed: %v", err)
+	}
+	if err := os.WriteFile(ptrPath, nil, 0o600); err != nil {
+		t.Fatalf("write ptr: %v", err)
+	}
+	previousGeoFeedPath := viper.Get("geoFeedPath")
+	previousPtrPath := viper.Get("ptrPath")
+	viper.Set("geoFeedPath", geoFeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(func() {
+		viper.Set("geoFeedPath", previousGeoFeedPath)
+		viper.Set("ptrPath", previousPtrPath)
+	})
+
+	params := pinFastTraceGeoSource(ParamsFastTrace{DataProvider: " dn42 "})
+	if params.IPGeoSource == nil || !fastTraceDN42(params) {
+		t.Fatalf("pinned params = %+v", params)
+	}
+	geo, err := params.IPGeoSource("10.0.0.1", time.Second, "en", false)
+	if err != nil || geo.City != "DN42 City" {
+		t.Fatalf("pinned source = (%+v, %v), want DN42 City", geo, err)
+	}
+}
+
 func TestTestFileSkipsFastTraceWSWhenRuntimePrepared(t *testing.T) {
 	file := emptyFastTraceFile(t)
 	oldInit := initFastTraceWSFn
@@ -335,6 +393,27 @@ func TestTestFileSkipsFastTraceWSWhenRuntimePrepared(t *testing.T) {
 	}
 	if closeCalls != 0 {
 		t.Fatalf("closeFastTraceWS calls = %d, want 0 when runtime is prepared", closeCalls)
+	}
+}
+
+func TestTestFileSkipsFastTraceWSForDN42Provider(t *testing.T) {
+	file := emptyFastTraceFile(t)
+	oldInit := initFastTraceWSFn
+	var initCalls int
+	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+		initCalls++
+		return nil
+	}
+	t.Cleanup(func() { initFastTraceWSFn = oldInit })
+
+	testFile(ParamsFastTrace{
+		Context:      context.Background(),
+		File:         file,
+		DataProvider: "DN42",
+	}, trace.ICMPTrace)
+
+	if initCalls != 0 {
+		t.Fatalf("initFastTraceWS calls = %d, want 0 for DN42", initCalls)
 	}
 }
 

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -335,7 +335,7 @@ func TestBuildFileTraceConfigUsesPinnedDN42Source(t *testing.T) {
 	}
 }
 
-func TestPinFastTraceGeoSourceNormalizesDN42Provider(t *testing.T) {
+func TestPinFastTraceGeoSourceUsesEffectiveDN42Provider(t *testing.T) {
 	dir := t.TempDir()
 	geoFeedPath := filepath.Join(dir, "geofeed.csv")
 	ptrPath := filepath.Join(dir, "ptr.csv")
@@ -354,13 +354,23 @@ func TestPinFastTraceGeoSourceNormalizesDN42Provider(t *testing.T) {
 		viper.Set("ptrPath", previousPtrPath)
 	})
 
-	params := pinFastTraceGeoSource(ParamsFastTrace{DataProvider: " dn42 "})
-	if params.IPGeoSource == nil || !fastTraceDN42(params) {
-		t.Fatalf("pinned params = %+v", params)
-	}
-	geo, err := params.IPGeoSource("10.0.0.1", time.Second, "en", false)
-	if err != nil || geo.City != "DN42 City" {
-		t.Fatalf("pinned source = (%+v, %v), want DN42 City", geo, err)
+	for _, tt := range []struct {
+		name   string
+		params ParamsFastTrace
+	}{
+		{name: "provider", params: ParamsFastTrace{DataProvider: " dn42 "}},
+		{name: "flag", params: ParamsFastTrace{DN42: true}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			params := pinFastTraceGeoSource(tt.params)
+			if params.IPGeoSource == nil || !fastTraceDN42(params) {
+				t.Fatalf("pinned params = %+v", params)
+			}
+			geo, err := params.IPGeoSource("10.0.0.1", time.Second, "en", false)
+			if err != nil || geo.City != "DN42 City" {
+				t.Fatalf("pinned source = (%+v, %v), want DN42 City", geo, err)
+			}
+		})
 	}
 }
 
@@ -396,24 +406,33 @@ func TestTestFileSkipsFastTraceWSWhenRuntimePrepared(t *testing.T) {
 	}
 }
 
-func TestTestFileSkipsFastTraceWSForDN42Provider(t *testing.T) {
+func TestTestFileSkipsFastTraceWSForDN42(t *testing.T) {
 	file := emptyFastTraceFile(t)
 	oldInit := initFastTraceWSFn
-	var initCalls int
-	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
-		initCalls++
-		return nil
-	}
 	t.Cleanup(func() { initFastTraceWSFn = oldInit })
 
-	testFile(ParamsFastTrace{
-		Context:      context.Background(),
-		File:         file,
-		DataProvider: "DN42",
-	}, trace.ICMPTrace)
+	for _, tt := range []struct {
+		name   string
+		params ParamsFastTrace
+	}{
+		{name: "provider", params: ParamsFastTrace{DataProvider: "DN42"}},
+		{name: "flag", params: ParamsFastTrace{DN42: true}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var initCalls int
+			initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+				initCalls++
+				return nil
+			}
+			params := tt.params
+			params.Context = context.Background()
+			params.File = file
+			testFile(params, trace.ICMPTrace)
 
-	if initCalls != 0 {
-		t.Fatalf("initFastTraceWS calls = %d, want 0 for DN42", initCalls)
+			if initCalls != 0 {
+				t.Fatalf("initFastTraceWS calls = %d, want 0 for DN42", initCalls)
+			}
+		})
 	}
 }
 

--- a/internal/nali/nali.go
+++ b/internal/nali/nali.go
@@ -29,6 +29,7 @@ type Config struct {
 	Timeout time.Duration
 	Lang    string
 	Family  Family
+	DN42    bool
 }
 
 type Span struct {
@@ -207,10 +208,13 @@ func (a *Annotator) lookupLabel(ctx context.Context, ip string) string {
 
 	label := ""
 	shouldCache := false
-	if geo, ok := ipgeo.Filter(ip); ok {
-		label = FormatGeo(geo, a.cfg.Lang)
-		shouldCache = true
-	} else if a.cfg.Source != nil && ctx.Err() == nil {
+	if !a.cfg.DN42 {
+		if geo, ok := ipgeo.Filter(ip); ok {
+			label = FormatGeo(geo, a.cfg.Lang)
+			shouldCache = true
+		}
+	}
+	if !shouldCache && a.cfg.Source != nil && ctx.Err() == nil {
 		if geo, err := a.cfg.Source(ip, a.cfg.Timeout, a.cfg.Lang, false); err == nil {
 			label = FormatGeo(geo, a.cfg.Lang)
 			shouldCache = true

--- a/internal/nali/nali_test.go
+++ b/internal/nali/nali_test.go
@@ -43,6 +43,28 @@ func TestAnnotateLineIPv4AndCache(t *testing.T) {
 	}
 }
 
+func TestAnnotateLineDN42BypassesReservedAddressFilter(t *testing.T) {
+	calls := 0
+	a := New(Config{
+		DN42: true,
+		Lang: "en",
+		Source: func(ip string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+			calls++
+			if ip != "10.0.0.1" {
+				t.Fatalf("lookup ip = %q, want 10.0.0.1", ip)
+			}
+			return &ipgeo.IPGeoData{Asnumber: "4242420001", CountryEn: "DN42"}, nil
+		},
+	})
+
+	if got, want := a.AnnotateLine(context.Background(), "router 10.0.0.1"), "router 10.0.0.1 [AS4242420001, DN42]"; got != want {
+		t.Fatalf("AnnotateLine() = %q, want %q", got, want)
+	}
+	if calls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls)
+	}
+}
+
 func TestAnnotateLineIPv6AndMappedIPv6(t *testing.T) {
 	a := New(Config{
 		Lang: "cn",

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -70,6 +70,7 @@ var (
 	prepareNextTraceAPIV4FastIPFn    = ipgeo.PrepareNextTraceAPIV4FastIP
 	tracerouteWithContextFn          = trace.TracerouteWithContext
 	lookupIPGeoFn                    = trace.LookupIPGeo
+	lookupIPGeoWithSessionFn         = trace.LookupIPGeoWithSession
 	runMTRFn                         = trace.RunMTR
 	runMTRRawFn                      = trace.RunMTRRaw
 	runMTUTraceFn                    = mtutrace.Run
@@ -291,11 +292,13 @@ func (s *Service) AnnotateIPs(ctx context.Context, req AnnotateIPsRequest) (Anno
 	timeout := positiveOrDefault(req.TimeoutMs, defaultTimeoutMs)
 	provider, needsNextTraceAPIV3 := resolveStandaloneDataProvider(req.DataProvider)
 	return withServiceRuntime(ctx, runtimeOptions{NeedsNextTraceAPIV3: needsNextTraceAPIV3}, func() (AnnotateIPsResponse, error) {
+		session := ipgeo.GetSourceSession(provider)
 		annotator := nali.New(nali.Config{
-			Source:  ipgeo.GetSource(provider),
+			Source:  session.Source,
 			Timeout: time.Duration(timeout) * time.Millisecond,
 			Lang:    normalizeLanguage(req.Language),
 			Family:  family,
+			DN42:    session.Refresh != nil,
 		})
 		return AnnotateIPsResponse{
 			Text: annotator.AnnotateLine(ctx, req.Text),
@@ -313,7 +316,14 @@ func (s *Service) GeoLookup(ctx context.Context, req GeoLookupRequest) (GeoLooku
 	}
 	provider, needsNextTraceAPIV3 := resolveStandaloneDataProvider(req.DataProvider)
 	return withServiceRuntime(ctx, runtimeOptions{NeedsNextTraceAPIV3: needsNextTraceAPIV3}, func() (GeoLookupResponse, error) {
-		geo, err := lookupIPGeoFn(ctx, ipgeo.GetSource(provider), normalizeLanguage(req.Language), false, defaultQueries, query)
+		session := ipgeo.GetSourceSession(provider)
+		var geo *ipgeo.IPGeoData
+		var err error
+		if session.Refresh != nil {
+			geo, err = lookupIPGeoWithSessionFn(ctx, session, normalizeLanguage(req.Language), false, defaultQueries, query)
+		} else {
+			geo, err = lookupIPGeoFn(ctx, session.Source, normalizeLanguage(req.Language), false, defaultQueries, query)
+		}
 		if err != nil {
 			return GeoLookupResponse{}, err
 		}
@@ -406,6 +416,7 @@ func (s *Service) buildMTUConfig(ctx context.Context, req MTUTraceRequest) (mtut
 		port = 33494
 	}
 	provider, _ := resolveMTUDataProvider(req.DataProvider)
+	session := ipgeo.GetSourceSessionWithGeoDNS(provider, req.DotServer)
 	return mtutrace.Config{
 		Target:         target,
 		DstIP:          ip,
@@ -420,8 +431,9 @@ func (s *Service) buildMTUConfig(ctx context.Context, req MTUTraceRequest) (mtut
 		TTLInterval:    time.Duration(positiveOrDefault(req.TTLIntervalMs, defaultTTLIntervalMs)) * time.Millisecond,
 		RDNS:           !req.DisableRDNS,
 		AlwaysWaitRDNS: req.AlwaysRDNS,
-		IPGeoSource:    ipgeo.GetSourceWithGeoDNS(provider, req.DotServer),
+		IPGeoSource:    session.Source,
 		Lang:           normalizeLanguage(req.Language),
+		DN42:           session.Refresh != nil,
 	}, nil
 }
 
@@ -518,15 +530,19 @@ func resolveDataProvider(req *TraceRequest) (string, bool) {
 		req.DN42 = true
 	}
 	if req.DN42 {
-		config.InitConfig()
-		req.DisableMaptrace = true
 		provider = "DN42"
 	}
 	needsNextTraceAPIV3 := ipgeo.IsNextTraceAPIProvider(provider)
 	if needsNextTraceAPIV3 && util.EnvDataProvider != "" {
 		provider = normalizeDataProvider(util.EnvDataProvider, "")
-		needsNextTraceAPIV3 = ipgeo.IsNextTraceAPIProvider(provider)
 	}
+	if strings.EqualFold(provider, "DN42") {
+		req.DN42 = true
+		config.InitConfig()
+		req.DisableMaptrace = true
+		provider = "DN42"
+	}
+	needsNextTraceAPIV3 = ipgeo.IsNextTraceAPIProvider(provider)
 	return provider, needsNextTraceAPIV3
 }
 
@@ -542,8 +558,12 @@ func resolveStandaloneDataProvider(raw string) (string, bool) {
 	needsNextTraceAPIV3 := ipgeo.IsNextTraceAPIProvider(provider)
 	if needsNextTraceAPIV3 && util.EnvDataProvider != "" {
 		provider = normalizeDataProvider(util.EnvDataProvider, "")
-		needsNextTraceAPIV3 = ipgeo.IsNextTraceAPIProvider(provider)
 	}
+	if strings.EqualFold(strings.TrimSpace(provider), "DN42") {
+		config.InitConfig()
+		provider = "DN42"
+	}
+	needsNextTraceAPIV3 = ipgeo.IsNextTraceAPIProvider(provider)
 	return provider, needsNextTraceAPIV3
 }
 
@@ -560,32 +580,34 @@ func buildTraceConfig(req TraceRequest, method trace.Method, ip net.IP, provider
 	if req.TOS != nil {
 		tos = *req.TOS
 	}
+	session := ipgeo.GetSourceSessionWithGeoDNS(provider, req.DotServer)
 	return trace.Config{
-		OSType:           resolveOSType(),
-		ICMPMode:         req.ICMPMode,
-		SrcAddr:          strings.TrimSpace(req.SourceAddress),
-		SrcPort:          req.SourcePort,
-		SourceDevice:     strings.TrimSpace(req.SourceDevice),
-		BeginHop:         positiveOrDefault(req.BeginHop, defaultBeginHop),
-		MaxHops:          positiveOrDefault(req.MaxHops, defaultMaxHops),
-		NumMeasurements:  positiveOrDefault(req.Queries, defaultQueries),
-		MaxAttempts:      req.MaxAttempts,
-		ParallelRequests: positiveOrDefault(req.ParallelRequests, defaultParallelRequests),
-		Timeout:          time.Duration(positiveOrDefault(req.TimeoutMs, defaultTimeoutMs)) * time.Millisecond,
-		DstIP:            ip,
-		DstPort:          port,
-		IPGeoSource:      ipgeo.GetSourceWithGeoDNS(provider, req.DotServer),
-		RDNS:             !req.DisableRDNS,
-		AlwaysWaitRDNS:   req.AlwaysRDNS,
-		PacketInterval:   positiveOrDefault(req.PacketInterval, defaultPacketIntervalMs),
-		TTLInterval:      positiveOrDefault(req.TTLInterval, defaultTTLIntervalMs),
-		Lang:             normalizeLanguage(req.Language),
-		DN42:             req.DN42,
-		PktSize:          packetSizeSpec.PayloadSize,
-		RandomPacketSize: packetSizeSpec.Random,
-		TOS:              tos,
-		Maptrace:         !req.DisableMaptrace,
-		DisableMPLS:      req.DisableMPLS,
+		OSType:             resolveOSType(),
+		ICMPMode:           req.ICMPMode,
+		SrcAddr:            strings.TrimSpace(req.SourceAddress),
+		SrcPort:            req.SourcePort,
+		SourceDevice:       strings.TrimSpace(req.SourceDevice),
+		BeginHop:           positiveOrDefault(req.BeginHop, defaultBeginHop),
+		MaxHops:            positiveOrDefault(req.MaxHops, defaultMaxHops),
+		NumMeasurements:    positiveOrDefault(req.Queries, defaultQueries),
+		MaxAttempts:        req.MaxAttempts,
+		ParallelRequests:   positiveOrDefault(req.ParallelRequests, defaultParallelRequests),
+		Timeout:            time.Duration(positiveOrDefault(req.TimeoutMs, defaultTimeoutMs)) * time.Millisecond,
+		DstIP:              ip,
+		DstPort:            port,
+		IPGeoSource:        session.Source,
+		RefreshIPGeoSource: session.Refresh,
+		RDNS:               !req.DisableRDNS,
+		AlwaysWaitRDNS:     req.AlwaysRDNS,
+		PacketInterval:     positiveOrDefault(req.PacketInterval, defaultPacketIntervalMs),
+		TTLInterval:        positiveOrDefault(req.TTLInterval, defaultTTLIntervalMs),
+		Lang:               normalizeLanguage(req.Language),
+		DN42:               req.DN42 || session.Refresh != nil,
+		PktSize:            packetSizeSpec.PayloadSize,
+		RandomPacketSize:   packetSizeSpec.Random,
+		TOS:                tos,
+		Maptrace:           !req.DisableMaptrace,
+		DisableMPLS:        req.DisableMPLS,
 	}, nil
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -3,9 +3,15 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/viper"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace"
@@ -42,6 +48,19 @@ func TestResolveDataProviderCanonicalizesEnvironmentOverride(t *testing.T) {
 	}
 	if !needsV3 {
 		t.Fatal("resolveDataProvider() needsV3 = false, want true")
+	}
+}
+
+func TestResolveDataProviderAppliesDN42EnvironmentOverride(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldEnvDataProvider := util.EnvDataProvider
+	defer func() { util.EnvDataProvider = oldEnvDataProvider }()
+	util.EnvDataProvider = "dn42"
+
+	req := TraceRequest{DataProvider: ipgeo.NextTraceAPIProvider}
+	got, needsV3 := resolveDataProvider(&req)
+	if got != "DN42" || needsV3 || !req.DN42 || !req.DisableMaptrace {
+		t.Fatalf("resolveDataProvider() = (%q, %v, DN42=%v, disableMaptrace=%v)", got, needsV3, req.DN42, req.DisableMaptrace)
 	}
 }
 
@@ -246,6 +265,64 @@ func TestMTRResponsesUseMTRParameterBoundaries(t *testing.T) {
 	}
 }
 
+func TestMTRReportCarriesPinnedDN42SourceAndRefresh(t *testing.T) {
+	restore := stubServiceRuntimeForTests(t)
+	defer restore()
+	t.Chdir(t.TempDir())
+
+	dir := t.TempDir()
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,First\n"), 0o600); err != nil {
+		t.Fatalf("write first geofeed: %v", err)
+	}
+	if err := os.WriteFile(ptrPath, nil, 0o600); err != nil {
+		t.Fatalf("write ptr: %v", err)
+	}
+	previousGeoFeedPath := viper.Get("geoFeedPath")
+	previousPtrPath := viper.Get("ptrPath")
+	viper.Set("geoFeedPath", geoFeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(func() {
+		viper.Set("geoFeedPath", previousGeoFeedPath)
+		viper.Set("ptrPath", previousPtrPath)
+	})
+
+	runMTRFn = func(_ context.Context, _ trace.Method, cfg trace.Config, _ trace.MTROptions, _ trace.MTROnSnapshot) error {
+		if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.RefreshIPGeoSource == nil {
+			return errors.New("MTR did not receive the DN42 source session")
+		}
+		first, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
+		if err != nil || first.City != "First" {
+			return fmt.Errorf("first DN42 source = (%+v, %v)", first, err)
+		}
+		if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,Second City\n"), 0o600); err != nil {
+			return err
+		}
+		stillFirst, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
+		if err != nil || stillFirst.City != "First" {
+			return fmt.Errorf("pinned DN42 source = (%+v, %v)", stillFirst, err)
+		}
+		cfg.RefreshIPGeoSource()
+		second, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
+		if err != nil || second.City != "Second City" {
+			return fmt.Errorf("refreshed DN42 source = (%+v, %v)", second, err)
+		}
+		return nil
+	}
+
+	if _, err := New().MTRReport(context.Background(), MTRReportRequest{
+		TraceRequest: TraceRequest{
+			Target:       "10.0.0.1",
+			DataProvider: "DN42",
+			DisableRDNS:  true,
+		},
+		MaxPerHop: 1,
+	}); err != nil {
+		t.Fatalf("MTRReport returned error: %v", err)
+	}
+}
+
 func TestNewTraceStopReasonCopiesStableFields(t *testing.T) {
 	core := &trace.StopReason{
 		Hop:       7,
@@ -402,6 +479,66 @@ func TestAnnotateIPsAndGeoLookupSkipNextTraceAPIRuntimeForDisabledGeoIP(t *testi
 	}
 }
 
+func TestAnnotateIPsAndGeoLookupDN42BypassReservedFilter(t *testing.T) {
+	restore := stubServiceRuntimeForTests(t)
+	defer restore()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,Test City,AS4242420001,Example Owner\n"), 0o600); err != nil {
+		t.Fatalf("write geofeed: %v", err)
+	}
+	if err := os.WriteFile(ptrPath, nil, 0o600); err != nil {
+		t.Fatalf("write ptr: %v", err)
+	}
+	previousGeoFeedPath := viper.Get("geoFeedPath")
+	previousPtrPath := viper.Get("ptrPath")
+	viper.Set("geoFeedPath", geoFeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(func() {
+		viper.Set("geoFeedPath", previousGeoFeedPath)
+		viper.Set("ptrPath", previousPtrPath)
+	})
+
+	annotated, err := New().AnnotateIPs(context.Background(), AnnotateIPsRequest{
+		Text:         "router 10.0.0.1",
+		DataProvider: "DN42",
+		Language:     "en",
+	})
+	if err != nil {
+		t.Fatalf("AnnotateIPs returned error: %v", err)
+	}
+	if !strings.Contains(annotated.Text, "AS4242420001, United States, Test City, Example Owner") {
+		t.Fatalf("AnnotateIPs text = %q", annotated.Text)
+	}
+
+	lookup, err := New().GeoLookup(context.Background(), GeoLookupRequest{
+		Query:        "10.0.0.1",
+		DataProvider: "DN42",
+		Language:     "en",
+	})
+	if err != nil {
+		t.Fatalf("GeoLookup returned error: %v", err)
+	}
+	if lookup.Geo == nil || lookup.Geo.Asnumber != "AS4242420001" || lookup.Geo.Country != "United States" {
+		t.Fatalf("GeoLookup geo = %+v", lookup.Geo)
+	}
+
+	var gotMTUConfig mtutrace.Config
+	runMTUTraceFn = func(_ context.Context, cfg mtutrace.Config) (*mtutrace.Result, error) {
+		gotMTUConfig = cfg
+		return &mtutrace.Result{Target: cfg.Target, ResolvedIP: cfg.DstIP.String(), Protocol: "udp"}, nil
+	}
+	if _, err := New().MTUTrace(context.Background(), MTUTraceRequest{Target: "10.0.0.1", DataProvider: "DN42"}); err != nil {
+		t.Fatalf("MTUTrace returned error: %v", err)
+	}
+	if !gotMTUConfig.DN42 || gotMTUConfig.IPGeoSource == nil {
+		t.Fatalf("MTU DN42 config = %+v", gotMTUConfig)
+	}
+}
+
 func containsParam(params []string, target string) bool {
 	for _, param := range params {
 		if param == target {
@@ -435,6 +572,7 @@ func stubServiceRuntimeForTests(t *testing.T) func() {
 	oldPrepareFastIP := prepareNextTraceAPIV4FastIPFn
 	oldTracerouteWithContext := tracerouteWithContextFn
 	oldLookupIPGeo := lookupIPGeoFn
+	oldLookupIPGeoWithSession := lookupIPGeoWithSessionFn
 	oldRunMTR := runMTRFn
 	oldRunMTRRaw := runMTRRawFn
 	oldRunMTU := runMTUTraceFn
@@ -452,6 +590,7 @@ func stubServiceRuntimeForTests(t *testing.T) func() {
 		prepareNextTraceAPIV4FastIPFn = oldPrepareFastIP
 		tracerouteWithContextFn = oldTracerouteWithContext
 		lookupIPGeoFn = oldLookupIPGeo
+		lookupIPGeoWithSessionFn = oldLookupIPGeoWithSession
 		runMTRFn = oldRunMTR
 		runMTRRawFn = oldRunMTRRaw
 		runMTUTraceFn = oldRunMTU

--- a/ipgeo/dn42.go
+++ b/ipgeo/dn42.go
@@ -1,25 +1,57 @@
 package ipgeo
 
 import (
+	"net/netip"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/dn42"
 )
 
-func LtdCodeToCountryOrAreaName(Code string) string {
+var countryOrAreaNameByLtdCode = func() map[string]string {
 	regionName := []string{"United States", "Afghanistan", "Åland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Anguilla", "Antarctica", "Antigua and Barbuda", "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan", "Bahamas", "Bahrain", " Bangladesh", "Barbados", "Belarus", "Belgium", "Belize", "Benin", "Bermuda", "Bhutan", "Bolivia", "Bosnia and Herzegovina", "Botswana", "Bouvet Island", "Brazil", "British Indian Ocean Territory", "Brunei", "Bulgaria", "Burkina Faso", "Burundi", "Cambodia", "Cameroon", "Canada ", "Cape Verde", "Cayman Islands", "Central Africa", "Chad", "Chile", "China", "Christmas Island", "Cocos (Keeling) Islands", "Colombia", "Comoros", "Congo (Brazzaville)", "DRC", "Cook Islands", "Costa Rica", "Cote d'Ivoire", "Croatia", "Cuba", "Cyprus", "Czech Republic", " Denmark", "Djibouti", "Dominica", "Dominica", "Ecuador", "Egypt", "El Salvador", "Equatorial Guinea", "Eritrea", "Estonia", "Ethiopia", "Falkland Islands (Malvinas)", "Faroe Islands", "Fiji", "Finland", "France", "French Guiana", "French Polynesia", " French Southern Territories", "Gabon", "Gambia", "Georgia", "Germany", "Ghana", "Gibraltar", "Greece", "Greenland", "Grenada", "Guadeloupe", "Guam", "Guatemala", "Guernsey", "Guinea", "Guinea-Bissau", "Guyana", "Haiti", "Heard and McDonald Islands", "Vatican", "Honduras", "Hong Kong", "Hungary", "Iceland", "India", "Indonesia", "Iran", "Iraq", "Ireland", "British Isles of Man", "Israel", "Italy", "Jamaica", "Japan", "Jersey", "Jordan", "Kazakhstan", "Kenya", "Kiribati", "North Korea", "South Korea", " Kuwait", "Kyrgyzstan", "Laos", "Latvia", "Lebanon", "Lesotho", "Liberia", "Libya", "Liechtenstein", "Lithuania", "Luxembourg", "Macao", "FYROM", "Madagascar", "Malawi", "Malaysia", "Maldives", "Mali", "Malta", " Marshall Islands", "Martinique", "Mauritania", "Mauritius", "Mayotte", "Mexico", "Micronesia (Federated States of)", "Moldova", "Monaco", "Mongolia", "Montenegro", "Montserrat", "Morocco", "Mozambique", "Myanmar", "Namibia", "Nauru", "Nepal", "Netherlands", "Netherlands Antilles", "New Caledonia", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Niue", "Norfolk Island", "Northern Mariana", "Norway", "Oman", "Pakistan", "Palau", "Palestine", "Panama", "Papua New Guinea", "Paraguay", "Peru", "Philippines", "Pitcairn", "Poland", "Portugal", "Puerto Rico", "Qatar", "Reunion", "Romania", "Russian Federation", "Rwanda", "St. Helena", "St. Kitts and Nevis", "St. Lucia", "St. Pierre and Miquelon", "St. Vincent and the Grenadines", "Samoa", "San Marino", "Sao Tome and Principe", "Saudi Arabia", "Senegal", "Serbia", "Seychelles", "Sierra Leone", "Singapore", "Slovakia", "Slovenia", "Solomon Islands", "Somalia", "South Africa", "South Georgia and South Sandwich Islands", "Spain", "Sri Lanka", "Sudan", "Suriname", "Svalbard and Jan Mayen Islands", "Swaziland", "Sweden ", "Switzerland", "Syria", "Taiwan", "Tajikistan", "Tanzania", "Thailand", "Timor-Leste", "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Tunisia", "Turkey", "Turkmenistan", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Ukraine", "United Arab Emirates", " United Kingdom", "U.S. Minor Outlying Islands", "Uruguay", "Uzbekistan", "Vanuatu", "Venezuela", "Vietnam", "British Virgin Islands", "U.S. Virgin Islands", "Wallis and Futuna", "Western Sahara", "Yemen", "Zambia", "Zimbabwe"}
 	regionCode := []string{"us", "af", "ax", "al", "dz", "as", "ad", "ao", "ai", "aq", "ag", "ar", "am", "aw", "au", "at", "az", "bs", "bh", "bd", "bb", "by", "be", "bz", "bj", "bm", "bt", "bo", "ba", "bw", "bv", "br", "io", "bn", "bg", "bf", "bi", "kh", "cm", "ca", "cv", "ky", "cf", "td", "cl", "cn", "cx", "cc", "co", "km", "cg", "cd", "ck", "cr", "ci", "hr", "cu", "cy", "cz", "dk", "dj", "dm", "do", "ec", "eg", "sv", "gq", "er", "ee", "et", "fk", "fo", "fj", "fi", "fr", "gf", "pf", "tf", "ga", "gm", "ge", "de", "gh", "gi", "gr", "gl", "gd", "gp", "gu", "gt", "gg", "gn", "gw", "gy", "ht", "hm", "va", "hn", "hk", "hu", "is", "in", "id", "ir", "iq", "ie", "im", "il", "it", "jm", "jp", "je", "jo", "kz", "ke", "ki", "kp", "kr", "kw", "kg", "la", "lv", "lb", "ls", "lr", "ly", "li", "lt", "lu", "mo", "mk", "mg", "mw", "my", "mv", "ml", "mt", "mh", "mq", "mr", "mu", "yt", "mx", "fm", "md", "mc", "mn", "me", "ms", "ma", "mz", "mm", "na", "nr", "np", "nl", "an", "nc", "nz", "ni", "ne", "ng", "nu", "nf", "mp", "no", "om", "pk", "pw", "ps", "pa", "pg", "py", "pe", "ph", "pn", "pl", "pt", "pr", "qa", "re", "ro", "ru", "rw", "sh", "kn", "lc", "pm", "vc", "ws", "sm", "st", "sa", "sn", "rs", "sc", "sl", "sg", "sk", "si", "sb", "so", "za", "gs", "es", "lk", "sd", "sr", "sj", "sz", "se", "ch", "sy", "tw", "tj", "tz", "th", "tl", "tg", "tk", "to", "tt", "tn", "tr", "tm", "tc", "tv", "ug", "ua", "ae", "gb", "um", "uy", "uz", "vu", "ve", "vn", "vg", "vi", "wf", "eh", "ye", "zm", "zw"}
-	Code = strings.ToLower(Code)
+	countries := make(map[string]string, len(regionCode))
 	for i, v := range regionCode {
-		if strings.Contains(Code, v) {
-			return strings.TrimSpace(regionName[i])
-		}
+		countries[v] = strings.TrimSpace(regionName[i])
 	}
-	return Code
+	return countries
+}()
+
+func LtdCodeToCountryOrAreaName(Code string) string {
+	code := strings.ToLower(Code)
+	if country, ok := countryOrAreaNameByLtdCode[code]; ok {
+		return country
+	}
+	return code
 }
 
 func DN42(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
+	index, _ := dn42.LoadGeoFeedIndex()
+	return lookupDN42(index, ip)
+}
+
+func newDN42SourceSession() SourceSession {
+	var index atomic.Pointer[dn42.GeoFeedIndex]
+	refresh := func() {
+		next, _ := dn42.LoadGeoFeedIndex()
+		if next != nil {
+			index.Store(next)
+		}
+	}
+	refresh()
+
+	return SourceSession{
+		Source: func(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
+			current := index.Load()
+			return lookupDN42(current, ip)
+		},
+		Refresh: refresh,
+	}
+}
+
+func lookupDN42(index *dn42.GeoFeedIndex, ip string) (*IPGeoData, error) {
 	data := &IPGeoData{}
 	// 先解析传入过来的数据
 	ipTmp := strings.Split(ip, ",")
@@ -27,11 +59,13 @@ func DN42(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
 		ip = ipTmp[0]
 	}
 	// 先查找 GeoFeed
-	if geo, find := dn42.GetGeoFeed(ip); find {
-		data.Country = geo.LtdCode
-		data.City = geo.City
-		data.Asnumber = geo.ASN
-		data.Owner = geo.IPWhois
+	if addr, err := netip.ParseAddr(ip); err == nil && index != nil {
+		if geo, find := index.Lookup(addr); find {
+			data.Country = geo.LtdCode
+			data.City = geo.City
+			data.Asnumber = geo.ASN
+			data.Owner = geo.IPWhois
+		}
 	}
 	// 如果没找到，查找 PTR
 	if len(ipTmp) > 1 {

--- a/ipgeo/dn42_test.go
+++ b/ipgeo/dn42_test.go
@@ -1,8 +1,10 @@
 package ipgeo
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +12,197 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	dn42GeoFeedA = "192.0.2.0/24,hk,HK,Hong Kong,AS65000,Owner A\n"
+	dn42GeoFeedB = "192.0.2.0/24,tw,TW,Taipei,AS650001,Owner version B\n"
+)
+
+func TestLtdCodeToCountryOrAreaNameUsesExactCodes(t *testing.T) {
+	tests := map[string]string{
+		"US":        "United States",
+		"bd":        "Bangladesh",
+		"ca":        "Canada",
+		"dk":        "Denmark",
+		"do":        "Dominica",
+		"gb":        "United Kingdom",
+		"hk":        "Hong Kong",
+		"kw":        "Kuwait",
+		"mh":        "Marshall Islands",
+		"mo":        "Macao",
+		"se":        "Sweden",
+		"tf":        "French Southern Territories",
+		"tw":        "Taiwan",
+		"unknown":   "unknown",
+		"prefix-us": "prefix-us",
+		" us ":      " us ",
+	}
+
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			assert.Equal(t, want, LtdCodeToCountryOrAreaName(input))
+		})
+	}
+	assert.Len(t, countryOrAreaNameByLtdCode, 244)
+}
+
+func TestDN42SourceSessionPinsAndRefreshesIndex(t *testing.T) {
+	geofeedPath := configureDN42GeoFeed(t, dn42GeoFeedA)
+
+	session := GetSourceSession("DN42")
+	require.NotNil(t, session.Source)
+	require.NotNil(t, session.Refresh)
+	assertDN42GeoResult(t, session.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+
+	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedB)
+	assertDN42GeoResult(t, session.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+
+	session.Refresh()
+	assertDN42GeoResult(t, session.Source, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
+
+	legacySource := GetSource("DN42")
+	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedA)
+	assertDN42GeoResult(t, legacySource, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
+	assertDN42GeoResult(t, GetSource("DN42"), "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+}
+
+func TestDN42CountryAreaContracts(t *testing.T) {
+	configureDN42GeoFeed(t, "192.0.2.1/32,hk,HK,Hong Kong\n"+
+		"192.0.2.2/32,tw,TW,Taipei\n"+
+		"192.0.2.3/32,mo,MO,Macao\n")
+	source := GetSource("DN42")
+	tests := []struct {
+		ip      string
+		country string
+		prov    string
+	}{
+		{ip: "192.0.2.1", country: "China", prov: "Hong Kong"},
+		{ip: "192.0.2.2", country: "China", prov: "Taiwan"},
+		{ip: "192.0.2.3", country: "China", prov: "Macao"},
+		{ip: "192.0.2.4", country: "Unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.ip, func(t *testing.T) {
+			got, err := source(tc.ip, time.Second, "", false)
+			require.NoError(t, err)
+			assert.Equal(t, tc.country, got.Country)
+			assert.Equal(t, tc.prov, got.Prov)
+		})
+	}
+}
+
+func TestDN42SourceSessionFailedRefreshKeepsSnapshot(t *testing.T) {
+	geofeedPath := configureDN42GeoFeed(t, dn42GeoFeedA)
+	session := GetSourceSessionWithGeoDNS("DN42", "")
+
+	writeDN42GeoFeed(t, geofeedPath, `"unterminated`)
+	session.Refresh()
+	assertDN42GeoResult(t, session.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+
+	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedB)
+	session.Refresh()
+	assertDN42GeoResult(t, session.Source, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
+}
+
+func TestDN42SourceSessionConcurrentRefresh(t *testing.T) {
+	geofeedPath := configureDN42GeoFeed(t, dn42GeoFeedA)
+	session := GetSourceSession("DN42")
+
+	const workers = 16
+	stop := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				got, err := session.Source("192.0.2.8", time.Second, "", false)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !isDN42GeoFeedA(got) && !isDN42GeoFeedB(got) {
+					errs <- fmt.Errorf("lookup combined different generations: %+v", got)
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 40 {
+		content := dn42GeoFeedA
+		if i%2 == 0 {
+			content = dn42GeoFeedB
+		}
+		writeDN42GeoFeed(t, geofeedPath, content)
+		session.Refresh()
+	}
+	close(stop)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func configureDN42GeoFeed(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	geofeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	writeDN42GeoFeed(t, geofeedPath, content)
+	require.NoError(t, os.WriteFile(ptrPath, nil, 0o644))
+	viper.Set("geoFeedPath", geofeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(viper.Reset)
+	return geofeedPath
+}
+
+func writeDN42GeoFeed(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func assertDN42GeoResult(
+	t *testing.T,
+	source Source,
+	country string,
+	prov string,
+	city string,
+	asn string,
+	owner string,
+) {
+	t.Helper()
+	got, err := source("192.0.2.8", time.Second, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, country, got.Country)
+	assert.Equal(t, prov, got.Prov)
+	assert.Equal(t, city, got.City)
+	assert.Equal(t, asn, got.Asnumber)
+	assert.Equal(t, owner, got.Owner)
+}
+
+func isDN42GeoFeedA(got *IPGeoData) bool {
+	return got.Country == "China" &&
+		got.Prov == "Hong Kong" &&
+		got.City == "Hong Kong" &&
+		got.Asnumber == "AS65000" &&
+		got.Owner == "Owner A"
+}
+
+func isDN42GeoFeedB(got *IPGeoData) bool {
+	return got.Country == "China" &&
+		got.Prov == "Taiwan" &&
+		got.City == "Taipei" &&
+		got.Asnumber == "AS650001" &&
+		got.Owner == "Owner version B"
+}
 
 func TestDN42GeoFeedAndPtrIntegration(t *testing.T) {
 	dir := t.TempDir()

--- a/ipgeo/ipgeo.go
+++ b/ipgeo/ipgeo.go
@@ -30,6 +30,13 @@ type IPGeoData struct {
 
 type Source = func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error)
 
+// SourceSession pins any provider state used by Source. Refresh is non-nil only
+// for providers whose snapshot can change during a long-lived session.
+type SourceSession struct {
+	Source  Source
+	Refresh func()
+}
+
 // NextTraceAPIProvider is the canonical data-provider value for the official API.
 const NextTraceAPIProvider = "NextTrace-API"
 
@@ -49,45 +56,61 @@ func IsNextTraceAPIProvider(provider string) bool {
 }
 
 func GetSource(s string) Source {
+	return GetSourceSession(s).Source
+}
+
+// GetSourceSession returns a source whose provider state is fixed until Refresh
+// is called.
+func GetSourceSession(s string) SourceSession {
+	var source Source
 	switch strings.ToUpper(CanonicalizeNextTraceAPIProvider(s)) {
 	case "DN42":
-		return DN42
+		return newDN42SourceSession()
 	case "NEXTTRACE-API":
-		return NextTraceAPISource()
+		source = NextTraceAPISource()
 	case "IP.SB":
-		return IPSB
+		source = IPSB
 	case "IPINSIGHT":
-		return IPInSight
+		source = IPInSight
 	case "IPAPI.COM":
-		return IPApiCom
+		source = IPApiCom
 	case "IP-API.COM":
-		return IPApiCom
+		source = IPApiCom
 	case "IPINFO":
-		return IPInfo
+		source = IPInfo
 	case "IPINFOLOCAL":
-		return IPInfoLocal
+		source = IPInfoLocal
 	case "CHUNZHEN":
-		return Chunzhen
+		source = Chunzhen
 	case "DISABLE-GEOIP":
-		return disableGeoIP
+		source = disableGeoIP
 	case "IPDB.ONE":
-		return IPDBOne
+		source = IPDBOne
 	default:
-		return NextTraceAPISource()
+		source = NextTraceAPISource()
 	}
+	return SourceSession{Source: source}
 }
 
 func GetSourceWithGeoDNS(s string, dotServer string) Source {
-	base := GetSource(s)
+	return GetSourceSessionWithGeoDNS(s, dotServer).Source
+}
+
+// GetSourceSessionWithGeoDNS applies a scoped DNS policy without changing the
+// session's refresh behavior.
+func GetSourceSessionWithGeoDNS(s string, dotServer string) SourceSession {
+	session := GetSourceSession(s)
+	base := session.Source
 	dotServer = strings.TrimSpace(strings.ToLower(dotServer))
 	if base == nil {
-		return base
+		return session
 	}
-	return func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
+	session.Source = func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
 		return util.WithGeoDNSResolver(dotServer, func() (*IPGeoData, error) {
 			return base(ip, timeout, lang, maptrace)
 		})
 	}
+	return session
 }
 
 func disableGeoIP(string, time.Duration, string, bool) (*IPGeoData, error) {

--- a/ipgeo/ipgeo_test.go
+++ b/ipgeo/ipgeo_test.go
@@ -25,7 +25,6 @@ func TestGetSourceMappings(t *testing.T) {
 		input string
 		want  Source
 	}{
-		{name: "dn42", input: "DN42", want: DN42},
 		{name: "nexttrace api", input: NextTraceAPIProvider, want: NextTraceAPIV3GeoIP},
 		{name: "nexttrace api mixed case", input: "nExTtRaCe-ApI", want: NextTraceAPIV3GeoIP},
 		{name: "nexttrace api surrounding whitespace", input: "  nexttrace-api\n", want: NextTraceAPIV3GeoIP},
@@ -51,6 +50,13 @@ func TestGetSourceMappings(t *testing.T) {
 			assert.Equal(t, reflect.ValueOf(tc.want).Pointer(), reflect.ValueOf(got).Pointer())
 		})
 	}
+}
+
+func TestGetSourceSessionNonRefreshableProvider(t *testing.T) {
+	session := GetSourceSession("disable-geoip")
+	require.NotNil(t, session.Source)
+	assert.Nil(t, session.Refresh)
+	assert.Equal(t, reflect.ValueOf(disableGeoIP).Pointer(), reflect.ValueOf(session.Source).Pointer())
 }
 
 func TestCanonicalizeNextTraceAPIProvider(t *testing.T) {

--- a/server/trace_handler.go
+++ b/server/trace_handler.go
@@ -186,16 +186,20 @@ func resolveTraceDataProvider(req *traceRequest) (string, bool) {
 		req.DN42 = true
 	}
 	if req.DN42 {
-		config.InitConfig()
-		req.DisableMaptrace = true
 		dataProvider = "DN42"
 	}
 
 	needsNextTraceAPIV3 := ipgeo.IsNextTraceAPIProvider(dataProvider)
 	if needsNextTraceAPIV3 && util.EnvDataProvider != "" {
 		dataProvider = normalizeDataProvider(util.EnvDataProvider, "")
-		needsNextTraceAPIV3 = ipgeo.IsNextTraceAPIProvider(dataProvider)
 	}
+	if strings.EqualFold(dataProvider, "DN42") {
+		req.DN42 = true
+		config.InitConfig()
+		req.DisableMaptrace = true
+		dataProvider = "DN42"
+	}
+	needsNextTraceAPIV3 = ipgeo.IsNextTraceAPIProvider(dataProvider)
 	needsNextTraceAPIV3 = needsNextTraceAPIV3 && !ipgeo.NextTraceAPIV4TokenConfigured()
 
 	return dataProvider, needsNextTraceAPIV3
@@ -400,32 +404,34 @@ func buildTraceConfig(req traceRequest, method trace.Method, ip net.IP, dataProv
 		ostype = 2
 	}
 
+	session := ipgeo.GetSourceSessionWithGeoDNS(dataProvider, req.DotServer)
 	return trace.Config{
-		OSType:           ostype,
-		ICMPMode:         req.ICMPMode,
-		SrcAddr:          req.SourceAddress,
-		SrcPort:          req.SourcePort,
-		SourceDevice:     strings.TrimSpace(req.SourceDevice),
-		BeginHop:         beginHop,
-		MaxHops:          maxHops,
-		NumMeasurements:  queries,
-		MaxAttempts:      req.MaxAttempts,
-		ParallelRequests: parallel,
-		Timeout:          time.Duration(timeout) * time.Millisecond,
-		DstIP:            ip,
-		DstPort:          port,
-		IPGeoSource:      ipgeo.GetSourceWithGeoDNS(dataProvider, req.DotServer),
-		RDNS:             !req.DisableRDNS,
-		AlwaysWaitRDNS:   alwaysWait,
-		PacketInterval:   req.PacketInterval,
-		TTLInterval:      req.TTLInterval,
-		Lang:             lang,
-		DN42:             req.DN42,
-		PktSize:          packetSizeSpec.PayloadSize,
-		RandomPacketSize: packetSizeSpec.Random,
-		TOS:              tos,
-		Maptrace:         !req.DisableMaptrace,
-		DisableMPLS:      req.DisableMPLS,
+		OSType:             ostype,
+		ICMPMode:           req.ICMPMode,
+		SrcAddr:            req.SourceAddress,
+		SrcPort:            req.SourcePort,
+		SourceDevice:       strings.TrimSpace(req.SourceDevice),
+		BeginHop:           beginHop,
+		MaxHops:            maxHops,
+		NumMeasurements:    queries,
+		MaxAttempts:        req.MaxAttempts,
+		ParallelRequests:   parallel,
+		Timeout:            time.Duration(timeout) * time.Millisecond,
+		DstIP:              ip,
+		DstPort:            port,
+		IPGeoSource:        session.Source,
+		RefreshIPGeoSource: session.Refresh,
+		RDNS:               !req.DisableRDNS,
+		AlwaysWaitRDNS:     alwaysWait,
+		PacketInterval:     req.PacketInterval,
+		TTLInterval:        req.TTLInterval,
+		Lang:               lang,
+		DN42:               req.DN42 || session.Refresh != nil,
+		PktSize:            packetSizeSpec.PayloadSize,
+		RandomPacketSize:   packetSizeSpec.Random,
+		TOS:                tos,
+		Maptrace:           !req.DisableMaptrace,
+		DisableMPLS:        req.DisableMPLS,
 	}, nil
 }
 

--- a/server/trace_handler.go
+++ b/server/trace_handler.go
@@ -27,6 +27,7 @@ import (
 
 var traceMu = &service.RuntimeMu
 var nextTraceAPIV3ConnMu sync.Mutex
+var initDN42Config = sync.OnceFunc(config.InitConfig)
 var ensureNextTraceAPIV3ConnectionFn = ensureNextTraceAPIV3Connection
 var traceMapURLFn = tracemap.GetMapUrlWithContext
 var traceDomainLookupFn = util.DomainLookUpWithContext
@@ -195,7 +196,7 @@ func resolveTraceDataProvider(req *traceRequest) (string, bool) {
 	}
 	if strings.EqualFold(dataProvider, "DN42") {
 		req.DN42 = true
-		config.InitConfig()
+		initDN42Config()
 		req.DisableMaptrace = true
 		dataProvider = "DN42"
 	}

--- a/server/trace_handler_test.go
+++ b/server/trace_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -86,16 +88,34 @@ func TestResolveTraceDataProviderCanonicalizesEnvironmentOverride(t *testing.T) 
 }
 
 func TestResolveTraceDataProviderAppliesDN42EnvironmentOverride(t *testing.T) {
-	t.Chdir(t.TempDir())
 	isolateServerNextTraceAPIV4Token(t, "")
 	oldEnvDataProvider := util.EnvDataProvider
-	defer func() { util.EnvDataProvider = oldEnvDataProvider }()
+	oldInitDN42Config := initDN42Config
+	t.Cleanup(func() {
+		util.EnvDataProvider = oldEnvDataProvider
+		initDN42Config = oldInitDN42Config
+	})
+	var initCalls atomic.Int32
+	initDN42Config = sync.OnceFunc(func() { initCalls.Add(1) })
 	util.EnvDataProvider = "dn42"
 
-	req := traceRequest{DataProvider: ipgeo.NextTraceAPIProvider}
-	got, needsV3 := resolveTraceDataProvider(&req)
-	if got != "DN42" || needsV3 || !req.DN42 || !req.DisableMaptrace {
-		t.Fatalf("resolveTraceDataProvider() = (%q, %v, DN42=%v, disableMaptrace=%v)", got, needsV3, req.DN42, req.DisableMaptrace)
+	var invalidResults atomic.Int32
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			req := traceRequest{DataProvider: ipgeo.NextTraceAPIProvider}
+			got, needsV3 := resolveTraceDataProvider(&req)
+			if got != "DN42" || needsV3 || !req.DN42 || !req.DisableMaptrace {
+				invalidResults.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+	if got := initCalls.Load(); got != 1 {
+		t.Fatalf("DN42 config initialization calls = %d, want 1", got)
+	}
+	if got := invalidResults.Load(); got != 0 {
+		t.Fatalf("invalid concurrent DN42 resolutions = %d, want 0", got)
 	}
 }
 

--- a/server/trace_handler_test.go
+++ b/server/trace_handler_test.go
@@ -7,11 +7,14 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
 
 	"github.com/nxtrace/NTrace-core/internal/service"
 	"github.com/nxtrace/NTrace-core/ipgeo"
@@ -79,6 +82,20 @@ func TestResolveTraceDataProviderCanonicalizesEnvironmentOverride(t *testing.T) 
 	}
 	if !needsV3 {
 		t.Fatal("resolveTraceDataProvider() needsV3 = false, want true")
+	}
+}
+
+func TestResolveTraceDataProviderAppliesDN42EnvironmentOverride(t *testing.T) {
+	t.Chdir(t.TempDir())
+	isolateServerNextTraceAPIV4Token(t, "")
+	oldEnvDataProvider := util.EnvDataProvider
+	defer func() { util.EnvDataProvider = oldEnvDataProvider }()
+	util.EnvDataProvider = "dn42"
+
+	req := traceRequest{DataProvider: ipgeo.NextTraceAPIProvider}
+	got, needsV3 := resolveTraceDataProvider(&req)
+	if got != "DN42" || needsV3 || !req.DN42 || !req.DisableMaptrace {
+		t.Fatalf("resolveTraceDataProvider() = (%q, %v, DN42=%v, disableMaptrace=%v)", got, needsV3, req.DN42, req.DisableMaptrace)
 	}
 }
 
@@ -204,6 +221,57 @@ func TestBuildTraceConfig_PropagatesSessionScopedFields(t *testing.T) {
 	}
 	if cfg.TOS != 0 {
 		t.Fatalf("buildTraceConfig TOS = %d, want 0", cfg.TOS)
+	}
+}
+
+func TestBuildTraceConfig_DN42CarriesRefreshableSession(t *testing.T) {
+	cfg, err := buildTraceConfig(traceRequest{}, trace.ICMPTrace, net.ParseIP("10.0.0.1"), "DN42", 0)
+	if err != nil {
+		t.Fatalf("buildTraceConfig returned error: %v", err)
+	}
+	if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.RefreshIPGeoSource == nil {
+		t.Fatalf("DN42 config = %+v", cfg)
+	}
+}
+
+func TestBuildTraceConfig_DN42PinsRequestAndWebSocketSession(t *testing.T) {
+	dir := t.TempDir()
+	geoFeedPath := filepath.Join(dir, "geofeed.csv")
+	ptrPath := filepath.Join(dir, "ptr.csv")
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,First\n"), 0o600); err != nil {
+		t.Fatalf("write first geofeed: %v", err)
+	}
+	if err := os.WriteFile(ptrPath, nil, 0o600); err != nil {
+		t.Fatalf("write ptr: %v", err)
+	}
+	previousGeoFeedPath := viper.Get("geoFeedPath")
+	previousPtrPath := viper.Get("ptrPath")
+	viper.Set("geoFeedPath", geoFeedPath)
+	viper.Set("ptrPath", ptrPath)
+	t.Cleanup(func() {
+		viper.Set("geoFeedPath", previousGeoFeedPath)
+		viper.Set("ptrPath", previousPtrPath)
+	})
+
+	first, err := buildTraceConfig(traceRequest{DN42: true}, trace.ICMPTrace, net.ParseIP("10.0.0.1"), "DN42", 0)
+	if err != nil {
+		t.Fatalf("first buildTraceConfig returned error: %v", err)
+	}
+	if err := os.WriteFile(geoFeedPath, []byte("10.0.0.0/8,us,US,Second City\n"), 0o600); err != nil {
+		t.Fatalf("write second geofeed: %v", err)
+	}
+	second, err := buildTraceConfig(traceRequest{DN42: true}, trace.ICMPTrace, net.ParseIP("10.0.0.1"), "DN42", 0)
+	if err != nil {
+		t.Fatalf("second buildTraceConfig returned error: %v", err)
+	}
+
+	firstGeo, err := first.IPGeoSource("10.0.0.1", time.Second, "en", false)
+	if err != nil || firstGeo.City != "First" {
+		t.Fatalf("first pinned source = (%+v, %v), want First", firstGeo, err)
+	}
+	secondGeo, err := second.IPGeoSource("10.0.0.1", time.Second, "en", false)
+	if err != nil || secondGeo.City != "Second City" {
+		t.Fatalf("second source = (%+v, %v), want Second City", secondGeo, err)
 	}
 }
 

--- a/trace/geo_lookup.go
+++ b/trace/geo_lookup.go
@@ -18,6 +18,16 @@ var (
 
 // LookupIPGeo reuses traceroute's shared GeoIP cache/retry path for direct IP metadata lookups.
 func LookupIPGeo(ctx context.Context, source ipgeo.Source, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
+	return lookupIPGeo(ctx, ipgeo.SourceSession{Source: source}, lang, maptrace, numMeasurements, query)
+}
+
+// LookupIPGeoWithSession reuses a source session for direct IP metadata lookups.
+// Sessions with a refresh hook bypass process-wide filtering, caching, and singleflight.
+func LookupIPGeoWithSession(ctx context.Context, session ipgeo.SourceSession, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
+	return lookupIPGeo(ctx, session, lang, maptrace, numMeasurements, query)
+}
+
+func lookupIPGeo(ctx context.Context, session ipgeo.SourceSession, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return nil, ErrEmptyGeoQuery
@@ -28,21 +38,25 @@ func LookupIPGeo(ctx context.Context, source ipgeo.Source, lang string, maptrace
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if source == nil {
+	if session.Source == nil {
 		return nil, ErrNilGeoSource
 	}
 	if ip := net.ParseIP(query); ip == nil {
 		return nil, fmt.Errorf("%w: %q", ErrNotIPGeoQuery, query)
 	}
-	if geo, ok := ipgeo.Filter(query); ok {
-		geoCache.Store(query, geo)
-		return geo, nil
+	uncached := session.Refresh != nil
+	if !uncached {
+		if geo, ok := ipgeo.Filter(query); ok {
+			geoCache.Store(query, geo)
+			return geo, nil
+		}
 	}
 	return lookupGeoWithRetry(Config{
-		Context:         ctx,
-		IPGeoSource:     source,
-		Lang:            lang,
-		Maptrace:        maptrace,
-		NumMeasurements: numMeasurements,
-	}, query, query, false)
+		Context:            ctx,
+		IPGeoSource:        session.Source,
+		RefreshIPGeoSource: session.Refresh,
+		Lang:               lang,
+		Maptrace:           maptrace,
+		NumMeasurements:    numMeasurements,
+	}, query, query, uncached)
 }

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
@@ -235,42 +236,61 @@ func TestLookupGeoWithRetryDN42BypassesSingleflight(t *testing.T) {
 	}
 }
 
-func TestLookupGeoWithRetryDN42HonorsContextCancellation(t *testing.T) {
-	ClearCaches()
-	t.Cleanup(ClearCaches)
+func TestLookupGeoWithRetryDN42ReturnsCancellationAfterSourceFinishes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ClearCaches()
+		t.Cleanup(ClearCaches)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	started := make(chan struct{})
-	release := make(chan struct{})
-	defer close(release)
+		ctx, cancel := context.WithCancel(t.Context())
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var releaseOnce sync.Once
+		t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
 
-	done := make(chan error, 1)
-	go func() {
-		_, err := lookupGeoWithRetry(Config{
-			Context: ctx,
-			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
-				close(started)
-				<-release
-				return &ipgeo.IPGeoData{Asnumber: "DN42"}, nil
-			},
-			NumMeasurements: 1,
-		}, "172.20.0.3", "172.20.0.3", true)
-		done <- err
-	}()
+		done := make(chan error, 1)
+		go func() {
+			_, err := lookupGeoWithRetry(Config{
+				Context: ctx,
+				IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+					close(started)
+					<-release
+					return &ipgeo.IPGeoData{Asnumber: "DN42"}, nil
+				},
+				NumMeasurements: 1,
+			}, "172.20.0.3", "172.20.0.3", true)
+			done <- err
+		}()
 
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("DN42 source lookup did not start")
-	}
-	cancel()
-	select {
-	case err := <-done:
-		if !errors.Is(err, context.Canceled) {
+		<-started
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("lookupGeoWithRetry() returned %v before the source finished", err)
+		default:
+		}
+
+		releaseOnce.Do(func() { close(release) })
+		synctest.Wait()
+		if err := <-done; !errors.Is(err, context.Canceled) {
 			t.Fatalf("lookupGeoWithRetry() error = %v, want context.Canceled", err)
 		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("DN42 lookup did not return after context cancellation")
+	})
+}
+
+func TestLookupGeoSourceDirectWithContextDoesNotAllocate(t *testing.T) {
+	ctx := context.Background()
+	want := &ipgeo.IPGeoData{Asnumber: "DN42"}
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := lookupGeoSourceDirectWithContext(ctx, func() (any, error) {
+			return want, nil
+		})
+		if err != nil || got != want {
+			panic("unexpected direct geo lookup result")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("lookupGeoSourceDirectWithContext() allocations = %v, want 0", allocs)
 	}
 }
 

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -154,5 +155,167 @@ func TestLookupGeoWithRetryClampsLargeOffset(t *testing.T) {
 	}
 	if gotTimeout != 6*time.Second {
 		t.Fatalf("geo timeout = %s, want 6s", gotTimeout)
+	}
+}
+
+func TestLookupGeoWithRetryDN42BypassesCache(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	const key = "172.20.0.1,dn42.example"
+	stale := &ipgeo.IPGeoData{Asnumber: "STALE"}
+	geoCache.Store(key, stale)
+
+	var calls atomic.Int32
+	fresh := &ipgeo.IPGeoData{Asnumber: "FRESH"}
+	geo, err := lookupGeoWithRetry(Config{
+		IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			calls.Add(1)
+			return fresh, nil
+		},
+		NumMeasurements: 1,
+	}, key, key, true)
+	if err != nil {
+		t.Fatalf("lookupGeoWithRetry() error = %v", err)
+	}
+	if geo != fresh {
+		t.Fatalf("lookupGeoWithRetry() geo = %+v, want fresh result", geo)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("DN42 source calls = %d, want 1", got)
+	}
+	if cached, ok := geoCache.Load(key); !ok || cached != stale {
+		t.Fatalf("DN42 lookup changed shared cache: got %#v, want original stale entry", cached)
+	}
+}
+
+func TestLookupGeoWithRetryDN42BypassesSingleflight(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	var calls atomic.Int32
+	cfg := Config{
+		IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			calls.Add(1)
+			started <- struct{}{}
+			<-release
+			return &ipgeo.IPGeoData{Asnumber: "DN42"}, nil
+		},
+		NumMeasurements: 1,
+	}
+
+	errCh := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := lookupGeoWithRetry(cfg, "172.20.0.2", "172.20.0.2", true)
+			errCh <- err
+		}()
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("DN42 source call %d did not start independently", i+1)
+		}
+	}
+	releaseOnce.Do(func() { close(release) })
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("lookupGeoWithRetry() error = %v", err)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("concurrent DN42 source calls = %d, want 2", got)
+	}
+}
+
+func TestLookupGeoWithRetryDN42HonorsContextCancellation(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := lookupGeoWithRetry(Config{
+			Context: ctx,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				close(started)
+				<-release
+				return &ipgeo.IPGeoData{Asnumber: "DN42"}, nil
+			},
+			NumMeasurements: 1,
+		}, "172.20.0.3", "172.20.0.3", true)
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("DN42 source lookup did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("lookupGeoWithRetry() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("DN42 lookup did not return after context cancellation")
+	}
+}
+
+func TestLookupIPGeoWithSessionBypassesFilterAndCacheWithoutRefreshing(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	const query = "10.23.0.1"
+	geoCache.Store(query, &ipgeo.IPGeoData{Asnumber: "STALE"})
+
+	var state atomic.Int32
+	state.Store(1)
+	var sourceCalls atomic.Int32
+	var refreshCalls atomic.Int32
+	session := ipgeo.SourceSession{
+		Source: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			sourceCalls.Add(1)
+			if state.Load() == 1 {
+				return &ipgeo.IPGeoData{IP: ip, Asnumber: "OLD"}, nil
+			}
+			return &ipgeo.IPGeoData{IP: ip, Asnumber: "NEW"}, nil
+		},
+		Refresh: func() { refreshCalls.Add(1) },
+	}
+
+	first, err := LookupIPGeoWithSession(context.Background(), session, "en", false, 1, query)
+	if err != nil {
+		t.Fatalf("first LookupIPGeoWithSession() error = %v", err)
+	}
+	state.Store(2)
+	second, err := LookupIPGeoWithSession(context.Background(), session, "en", false, 1, query)
+	if err != nil {
+		t.Fatalf("second LookupIPGeoWithSession() error = %v", err)
+	}
+
+	if first.Asnumber != "OLD" || second.Asnumber != "NEW" {
+		t.Fatalf("session results = %q then %q, want OLD then NEW", first.Asnumber, second.Asnumber)
+	}
+	if got := sourceCalls.Load(); got != 2 {
+		t.Fatalf("session source calls = %d, want 2", got)
+	}
+	if got := refreshCalls.Load(); got != 0 {
+		t.Fatalf("LookupIPGeoWithSession invoked Refresh %d times, want 0", got)
+	}
+	if cached, ok := geoCache.Load(query); !ok || cached.(*ipgeo.IPGeoData).Asnumber != "STALE" {
+		t.Fatalf("session lookup changed shared cache: %#v", cached)
 	}
 }

--- a/trace/mtr_loop_runtime.go
+++ b/trace/mtr_loop_runtime.go
@@ -119,13 +119,16 @@ func (rt *mtrLoopRuntime) handleReset() {
 		return
 	}
 
+	if resetter, ok := rt.prober.(mtrResetter); ok {
+		resetter.resetFinalTTL()
+	}
+	if rt.config.RefreshIPGeoSource != nil {
+		rt.config.RefreshIPGeoSource()
+	}
 	rt.agg.Reset()
 	rt.iteration = 0
 	rt.consecutiveErrors = 0
 	rt.backoff = rt.bo.Initial
-	if resetter, ok := rt.prober.(mtrResetter); ok {
-		resetter.resetFinalTTL()
-	}
 	rt.pathTracker.reset()
 }
 

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace/internal"
 )
 
@@ -27,6 +28,17 @@ func (m *mockProber) probeRound(ctx context.Context) (*Result, error) {
 
 func (m *mockProber) close() {
 	atomic.AddInt32(&m.closed, 1)
+}
+
+type resettableMockProber struct {
+	*mockProber
+	resetFn func()
+}
+
+func (m *resettableMockProber) resetFinalTTL() {
+	if m.resetFn != nil {
+		m.resetFn()
+	}
 }
 
 func constantResultProber(res *Result) *mockProber {
@@ -73,6 +85,81 @@ func TestMTRLoopMaxRounds(t *testing.T) {
 	}
 	if atomic.LoadInt32(&prober.closed) != 1 {
 		t.Error("prober.close() was not called")
+	}
+}
+
+func TestMTRLoopResetRefreshesStableSource(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var rounds atomic.Int32
+	var proberResets atomic.Int32
+	var sourceGeneration atomic.Int32
+	sourceGeneration.Store(1)
+	prober := &resettableMockProber{
+		mockProber: &mockProber{
+			roundFn: func(_ context.Context) (*Result, error) {
+				rounds.Add(1)
+				return mkResult([]Hop{mkHop(1, "172.20.0.5", time.Millisecond)}), nil
+			},
+		},
+		resetFn: func() {
+			proberResets.Add(1)
+		},
+	}
+
+	var refreshCalls atomic.Int32
+	var resetConsumed atomic.Bool
+	config := Config{
+		DN42: true,
+		IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			if sourceGeneration.Load() == 1 {
+				return &ipgeo.IPGeoData{Asnumber: "OLD"}, nil
+			}
+			return &ipgeo.IPGeoData{Asnumber: "NEW"}, nil
+		},
+		RefreshIPGeoSource: func() {
+			refreshCalls.Add(1)
+			if proberResets.Load() == 0 {
+				t.Error("source refreshed before prober state reset")
+			}
+			sourceGeneration.Store(2)
+		},
+	}
+
+	var snapshotsAfterReset int
+	err := mtrLoop(context.Background(), prober, config, MTROptions{
+		MaxRounds: 2,
+		Interval:  time.Millisecond,
+		IsResetRequested: func() bool {
+			return rounds.Load() >= 1 && resetConsumed.CompareAndSwap(false, true)
+		},
+	}, NewMTRAggregator(), func(_ int, stats []MTRHopStat) {
+		if !resetConsumed.Load() {
+			if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "OLD" {
+				t.Errorf("pre-reset stats = %+v, want OLD metadata", stats)
+			}
+			return
+		}
+		snapshotsAfterReset++
+		if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "NEW" {
+			t.Errorf("post-reset stats = %+v, want NEW metadata", stats)
+		}
+	}, true, fastBackoff)
+	if err != nil {
+		t.Fatalf("mtrLoop() error = %v", err)
+	}
+	if got := refreshCalls.Load(); got != 1 {
+		t.Fatalf("source refresh calls = %d, want 1", got)
+	}
+	if got := proberResets.Load(); got != 1 {
+		t.Fatalf("prober reset calls = %d, want 1", got)
+	}
+	if got := rounds.Load(); got != 3 {
+		t.Fatalf("probe rounds = %d, want 3 (one before reset plus two after)", got)
+	}
+	if snapshotsAfterReset != 2 {
+		t.Fatalf("post-reset snapshots = %d, want 2", snapshotsAfterReset)
 	}
 }
 

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -809,7 +809,10 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	}
 
 	rt.generation++
-	rt.resetMetadataContext()
+	rt.cancelMetadataLookups()
+	if rt.cfg.BaseConfig.RefreshIPGeoSource != nil {
+		rt.cfg.BaseConfig.RefreshIPGeoSource()
+	}
 	for idx := range rt.states {
 		rt.states[idx] = mtrHopState{}
 	}
@@ -824,10 +827,6 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	rt.pathTracker.reset()
 	rt.agg.Reset()
 	_ = rt.prober.Reset()
-}
-
-func (rt *mtrSchedulerRuntime) resetMetadataContext() {
-	rt.cancelMetadataLookups()
 	rt.metadataCtx, rt.metadataCancel = context.WithCancel(rt.ctx)
 }
 

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -20,6 +20,7 @@ import (
 type mockTTLProber struct {
 	mu       sync.Mutex
 	probeFn  func(ctx context.Context, ttl int) (mtrProbeResult, error)
+	resetFn  func() error
 	resetCnt int32
 	closeCnt int32
 	probeCnt int32
@@ -39,6 +40,9 @@ func (m *mockTTLProber) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, 
 
 func (m *mockTTLProber) Reset() error {
 	atomic.AddInt32(&m.resetCnt, 1)
+	if m.resetFn != nil {
+		return m.resetFn()
+	}
 	return nil
 }
 
@@ -1586,6 +1590,121 @@ func TestScheduler_ResetCancelsMetadataGeneration(t *testing.T) {
 	if len(rt.metadataGeoInFlight) != 0 || len(rt.metadataHostInFlight) != 0 {
 		t.Fatalf("metadata in-flight after reset: geo=%d host=%d, want 0",
 			len(rt.metadataGeoInFlight), len(rt.metadataHostInFlight))
+	}
+}
+
+func TestScheduler_ResetRefreshesSourceAfterInvalidatingOldWork(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var proberReset atomic.Bool
+	prober := &mockTTLProber{
+		resetFn: func() error {
+			proberReset.Store(true)
+			return nil
+		},
+	}
+	var sourceGeneration atomic.Int32
+	sourceGeneration.Store(1)
+	var sourceCalls atomic.Int32
+	var refreshCalls atomic.Int32
+	resetRequested := true
+	var rt *mtrSchedulerRuntime
+	var oldMetadataCtx context.Context
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		IsResetRequested: func() bool {
+			requested := resetRequested
+			resetRequested = false
+			return requested
+		},
+		BaseConfig: Config{
+			DN42: true,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				sourceCalls.Add(1)
+				if sourceGeneration.Load() == 1 {
+					return &ipgeo.IPGeoData{Asnumber: "OLD"}, nil
+				}
+				return &ipgeo.IPGeoData{Asnumber: "NEW"}, nil
+			},
+			RefreshIPGeoSource: func() {
+				refreshCalls.Add(1)
+				if oldMetadataCtx.Err() == nil {
+					t.Error("source refreshed before canceling the old metadata context")
+				}
+				if rt.metadataCtx != oldMetadataCtx {
+					t.Error("new metadata context published before source refresh completed")
+				}
+				if proberReset.Load() {
+					t.Error("prober reset before source refresh")
+				}
+				sourceGeneration.Store(2)
+			},
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+	oldMetadataCtx = rt.metadataCtx
+	rt.inFlight = 1
+	rt.states[1].inFlightCount = 1
+	rt.handleReset()
+
+	if oldMetadataCtx.Err() == nil {
+		t.Fatal("reset did not cancel the previous metadata generation")
+	}
+	if rt.metadataCtx == oldMetadataCtx || rt.metadataCtx.Err() != nil {
+		t.Fatal("reset did not publish a fresh metadata context after cleanup")
+	}
+	if got := refreshCalls.Load(); got != 1 {
+		t.Fatalf("source refresh calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&prober.resetCnt); got != 1 {
+		t.Fatalf("prober reset calls = %d, want 1", got)
+	}
+
+	rt.processResult(mtrCompletedProbe{
+		ttl: 1,
+		gen: 0,
+		result: mtrProbeResult{
+			TTL:     1,
+			Success: true,
+			Addr:    &net.IPAddr{IP: net.ParseIP("172.20.0.4")},
+			RTT:     time.Millisecond,
+			Geo:     &ipgeo.IPGeoData{Asnumber: "STALE"},
+		},
+	})
+	if stats := rt.agg.Snapshot(); len(stats) != 0 {
+		t.Fatalf("old-generation probe survived reset: %+v", stats)
+	}
+	if got := sourceCalls.Load(); got != 0 {
+		t.Fatalf("old-generation probe triggered %d source calls, want 0", got)
+	}
+
+	rt.inFlight = 1
+	rt.states[1].inFlightCount = 1
+	rt.processResult(mtrCompletedProbe{
+		ttl: 1,
+		gen: rt.generation,
+		result: mtrProbeResult{
+			TTL:     1,
+			Success: true,
+			Addr:    &net.IPAddr{IP: net.ParseIP("172.20.0.4")},
+			RTT:     time.Millisecond,
+		},
+	})
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "NEW" {
+		t.Fatalf("post-reset stats = %+v, want refreshed NEW metadata", stats)
+	}
+	if got := sourceCalls.Load(); got != 1 {
+		t.Fatalf("post-reset source calls = %d, want 1", got)
 	}
 }
 

--- a/trace/mtu/metadata.go
+++ b/trace/mtu/metadata.go
@@ -49,8 +49,9 @@ func shouldFetchHopMetadata(cfg Config, hop Hop) bool {
 
 func startMTUPTRLookup(ctx context.Context, ipStr string) <-chan []string {
 	ch := make(chan []string, 1)
+	lookupAddr := mtuLookupAddr
 	go func() {
-		ptrs, err := mtuLookupAddr(ctx, ipStr)
+		ptrs, err := lookupAddr(ctx, ipStr)
 		if err != nil {
 			ch <- nil
 			return

--- a/trace/mtu/metadata.go
+++ b/trace/mtu/metadata.go
@@ -78,9 +78,11 @@ func startMTUGeoLookup(cfg Config, ipStr string) <-chan mtuGeoLookupResult {
 	}
 	ch := make(chan mtuGeoLookupResult, 1)
 	go func() {
-		if geo, ok := ipgeo.Filter(ipStr); ok {
-			ch <- mtuGeoLookupResult{geo: normalizeMTUGeoData(geo)}
-			return
+		if !cfg.DN42 {
+			if geo, ok := ipgeo.Filter(ipStr); ok {
+				ch <- mtuGeoLookupResult{geo: normalizeMTUGeoData(geo)}
+				return
+			}
 		}
 
 		geo, err := cfg.IPGeoSource(ipStr, cfg.Timeout, cfg.Lang, false)

--- a/trace/mtu/metadata_test.go
+++ b/trace/mtu/metadata_test.go
@@ -31,6 +31,32 @@ func TestEnrichHopMetadataGeoSuccess(t *testing.T) {
 	}
 }
 
+func TestEnrichHopMetadataDN42BypassesReservedAddressFilter(t *testing.T) {
+	calls := 0
+	cfg := Config{
+		DN42:    true,
+		Timeout: time.Second,
+		IPGeoSource: func(ip string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+			calls++
+			if ip != "10.0.0.1" {
+				t.Fatalf("lookup ip = %q, want 10.0.0.1", ip)
+			}
+			return &ipgeo.IPGeoData{CountryEn: "DN42"}, nil
+		},
+	}
+
+	hop, changed := enrichHopMetadata(context.Background(), cfg, Hop{IP: "10.0.0.1", Event: EventTimeExceeded})
+	if !changed {
+		t.Fatal("expected DN42 metadata to change")
+	}
+	if hop.Geo == nil || hop.Geo.CountryEn != "DN42" {
+		t.Fatalf("unexpected geo: %+v", hop.Geo)
+	}
+	if calls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls)
+	}
+}
+
 func TestEnrichHopMetadataDisableGeoIPReturnsNoGeo(t *testing.T) {
 	cfg := Config{
 		IPGeoSource: ipgeo.GetSource("disable-geoip"),

--- a/trace/mtu/types.go
+++ b/trace/mtu/types.go
@@ -42,6 +42,7 @@ type Config struct {
 	AlwaysWaitRDNS bool
 	IPGeoSource    ipgeo.Source
 	Lang           string
+	DN42           bool
 }
 
 type Hop struct {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1235,23 +1235,16 @@ func lookupGeoSourceWithContext(ctx context.Context, cacheKey string, fn func() 
 }
 
 func lookupGeoSourceDirectWithContext(ctx context.Context, fn func() (any, error)) (any, error) {
-	type result struct {
-		value any
-		err   error
+	// Source callbacks must honor their timeout argument. Running fn in a detached
+	// goroutine cannot stop a blocked callback and adds overhead to in-memory sources.
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
-
-	resultCh := make(chan result, 1)
-	go func() {
-		value, err := fn()
-		resultCh <- result{value: value, err: err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case result := <-resultCh:
-		return result.value, result.err
+	value, err := fn()
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, contextErr
 	}
+	return value, err
 }
 
 func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPGeoData, error) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -48,6 +48,10 @@ type Config struct {
 	DstPort          int
 	Quic             bool
 	IPGeoSource      ipgeo.Source
+
+	// RefreshIPGeoSource marks a refreshable source session and refreshes it at reset boundaries.
+	RefreshIPGeoSource func()
+
 	GeoLookupOffset  int
 	RDNS             bool
 	AlwaysWaitRDNS   bool
@@ -1230,10 +1234,32 @@ func lookupGeoSourceWithContext(ctx context.Context, cacheKey string, fn func() 
 	}
 }
 
+func lookupGeoSourceDirectWithContext(ctx context.Context, fn func() (any, error)) (any, error) {
+	type result struct {
+		value any
+		err   error
+	}
+
+	resultCh := make(chan result, 1)
+	go func() {
+		value, err := fn()
+		resultCh <- result{value: value, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		return result.value, result.err
+	}
+}
+
 func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPGeoData, error) {
-	if cacheVal, ok := geoCache.Load(cacheKey); ok {
-		if g, ok := cacheVal.(*ipgeo.IPGeoData); ok && g != nil {
-			return g, nil
+	if !dn42 {
+		if cacheVal, ok := geoCache.Load(cacheKey); ok {
+			if g, ok := cacheVal.(*ipgeo.IPGeoData); ok && g != nil {
+				return g, nil
+			}
 		}
 	}
 
@@ -1270,9 +1296,16 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 			}
 		}
 		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
-		v, err := lookupGeoSourceWithContext(attemptCtx, cacheKey, func() (any, error) {
+		lookup := func() (any, error) {
 			return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
-		})
+		}
+		var v any
+		var err error
+		if dn42 {
+			v, err = lookupGeoSourceDirectWithContext(attemptCtx, lookup)
+		} else {
+			v, err = lookupGeoSourceWithContext(attemptCtx, cacheKey, lookup)
+		}
 		cancel()
 		if err != nil {
 			lastErr = err
@@ -1288,7 +1321,9 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 			continue
 		}
 
-		geoCache.Store(cacheKey, geo)
+		if !dn42 {
+			geoCache.Store(cacheKey, geo)
+		}
 		return geo, nil
 	}
 


### PR DESCRIPTION
### Summary

- 为 DN42 GeoFeed 建立不可变 IPv4/IPv6 最长前缀索引，并以 `atomic.Pointer` 发布完整快照。
- 在 CLI、REST/WS、MCP/service、FastTrace、nali、MTU 与 MTR 边界固定 GeoFeed generation；MTR reset 才刷新。
- 保留 `GeoFeedRow`、`ReadGeoFeed`、`FindGeoFeedRow`、`GetGeoFeed` 的既有签名和适配行为。

### Motivation

旧 DN42 Geo 查询会为每个 IP 重新读取整个 CSV、解析 CIDR、排序并线性扫描。MTR、Web 与批量 nali 路径会重复这些文件 I/O 和构造工作，也无法明确表达 reload 失败与长会话 generation 的边界。

### Changes

- IPv4/IPv6 分离，按文件实际出现的 prefix bits 建立 `map[bits]map[netip.Prefix]record`；地址统一 `Unmap`。
- CSV 改为逐行 `Read` 且 `FieldsPerRecord=-1`；只接受 4 列或至少 6 列。短行、5 列、坏 CIDR 跳过；结构/I/O 错误不发布并保留旧快照。
- 相同 prefix 由最后一条有效记录覆盖；空文件发布有效空 generation。
- 按 path、mtime、size 惰性 reload；stat/open/final-stat 同时核验文件身份，拒绝同元数据替换；热 `GeoFeedIndex.Lookup` 无文件 I/O，无常驻 watcher。
- 新增 `SourceSession` 固定会话 source；MTR legacy/per-hop reset 刷新并隔离旧 generation metadata。
- DN42 路径绕过不适用的保留地址过滤、进程级 Geo cache 与 singleflight。
- `--data-provider` 增量接受 `DN42`/`dn42`；Web trace 只在首次 DN42 请求时惰性初始化配置。
- DN42 内存查询同步执行，不再为每次 lookup 创建 channel 与分离 goroutine。
- FastTrace 在仅设置 `DN42=true` 时也统一选择 DN42 source，并跳过 NextTrace V3 WebSocket。
- MTU PTR worker 在启动前固定查询函数，消除非等待 worker 与测试 seam 恢复的竞态。
- 国家代码查询改为包级小写精确 map，未知值继续回退为小写输入。

### Before / After Call Chain

Before：

`DN42 -> GetGeoFeed -> ReadGeoFeed -> os.Open -> csv.ReadAll -> ParseCIDR -> sort -> linear scan`

After：

`session boundary -> LoadGeoFeedIndex -> stat/reload if changed -> streaming CSV -> build -> atomic publish`

Hot lookup：

`session Source -> netip.Addr.Unmap -> descending present bits -> prefix map lookup`

### Compatibility

- 不删除或改签名现有导出 API；新增 API 均为增量接口。
- 既有 CLI flags、退出码、stdout/stderr、JSON schema、MTR 统计、TTY/ANSI 与协议布局不变；`--data-provider` 仅增量放行既有 DN42 provider。
- IPv4-mapped IPv6 在索引内规范化，但 legacy `GeoFeedRow.IPNet` 仍按原 CIDR 重建。
- 同一会话固定开始时 generation；只有新请求/批次或 MTR reset 观察 reload。

### Testing

- `go test -count=1 ./...`
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go build ./...`
- `go vet ./...`
- `golangci-lint v2.13.2 run --new-from-rev origin/main`：0 issues
- full、`flavor_tiny`、`flavor_ntr` 专项测试与构建
- `node --test server/web/assets/*.test.cjs`：15/15
- `go mod verify`、`go mod tidy -diff`
- installer smoke 与 shell syntax
- 相关包 100 次稳定性复测

新增回归覆盖 CSV 记录/结构错误、stat/open 同元数据替换、失败保留、空快照、generation、并发 reload、最长前缀、重复 prefix、mapped IPv4、0 alloc lookup、所有生产入口、两条 MTR reset 路径、真实 DN42 CLI 解析与 32 路 Web 配置初始化。

### Race

全仓 `go test -race -count=1 ./...` 通过。GeoFeed store 并发 load/lookup、source session refresh 与配置初始化均有并发覆盖；GitHub 暴露的 MTU PTR worker 竞态定向复测 100 次通过。

### Benchstat

本机 Apple M5、Go 1.27.1、`GOEXPERIMENT=nojsonv2`、`GOMAXPROCS=10`、AC 供电；每组 10 次、每次 1 秒。

| 实现 | IPv4 | IPv6 |
| --- | ---: | ---: |
| 旧生产端到端 | 994.3 us / 1.593 MiB / 24.61k alloc | 1.343 ms / 1.686 MiB / 24.61k alloc |
| 旧预解析 slice | 15.31 us / 0 alloc | 11.56 us / 0 alloc |
| Prefix-map | 74.50 ns / 0 alloc | 75.34 ns / 0 alloc |
| 测试用 trie | 47.59 ns / 0 alloc | 150.7 ns / 0 alloc |

Prefix-map 相对预解析旧 slice：IPv4 `205.5x`、IPv6 `153.4x`，均超过 `>=20x` 且 `<=1 alloc/op` 的门槛。Trie 只在 IPv4 更快，IPv6 慢约一倍；prefix-map 跨族更均衡且实现更简单。

PR-0 同名 benchmark 中，`ReadGeoFeedCSV` 为 1,179.5 us -> 647.5 us（-45.11%），B/op -65.62%；`FindGeoFeedRow` geomean -7.59% 且所有子项维持 0 alloc。IPv4 HeadHit 的等价旧 helper 为 18.98 ns -> 19.33 ns（+0.35 ns），其余七项改善 4.48% 到 13.72%；该 helper 不是新生产查询路径。

### Profile

- Parent IPv4 TailHit：24.645 us/op、0 alloc；CPU 98.97% 累积于线性 `FindGeoFeedRow`、`IPNet.Contains` 与 mask 处理。
- Head PrefixMap：75.23 ns/op、0 alloc；CPU 93.06% 累积于 `GeoFeedIndex.Lookup` 的 family lookup 与 map access。
- Heap 热点均来自 fixture、索引/trie 构造和 profile 启动；热查询无分配。

完整本机证据见 `docs/performance/go127-dn42-geofeed.md`；Linux performance workflow 会保存 benchmark、profile、测试耗时和三 flavor 二进制 artifact，仅作交叉参考。

### Binary Size

- Darwin arm64 未压缩：full +0.0552%，tiny +0.3024%，ntr +0.4539%。
- Linux arm64 未压缩：full +0.2207%，tiny/ntr 0%；UPX `-9` 后最高 +0.3913%。
- parent/head 相同 Go 1.27.1、构建参数与 UPX 5.2.1。

### Platform

- Linux 17 目标、Windows 3 目标、Darwin amd64/arm64 的三 flavor 均构建通过。
- tiny/ntr 依赖解耦检查通过。
- Darwin 所有 release-style 产物经 `vtool` 与 `otool` 确认唯一 `LC_BUILD_VERSION`、`minos 13.0`。

### Risks and Rollback

- 索引内存随有效 prefix 与实际 prefix length 数量增长；没有后台 watcher 或 goroutine。
- path/mtime/size 是变化检测合同；同尺寸、同 mtime 的原地内容改写不会触发 reload。
- reload 失败继续使用最后成功快照；显式装载接口仍返回错误。
- 自定义 `Source` 仍须履行传入的 timeout；Go 无法强制终止违规阻塞回调，DN42 热路径不再通过分离 goroutine 掩盖该问题。
- 可按逆序撤销本 PR 提交；无需迁移配置、JSON 或持久数据。

### Commits

- `58f47c6 perf(dn42): 索引 GeoFeed 最长前缀查询`
- `9ee2d1c perf(dn42): 保持兼容查询零分配`
- `c844e49 perf(dn42): 保留兼容查询热路径`
- `9cbea33 docs(perf): 记录 DN42 GeoFeed 索引证据`
- `0875119 perf(dn42): 移除内存查询分离协程`
- `eb5427c fix(cli): 放行 DN42 数据提供方`
- `17e6a6c perf(server): 避免重复初始化 DN42 配置`
- `5d821e7 fix(mtu): 固定 PTR worker 查询函数`
- `2e914d8 fix(fast-trace): 统一 DN42 有效提供方`
- `2315fb6 docs(perf): 对齐 DN42 最终实现证据`
- `d5775af fix(dn42): 检测装载前文件替换`
- `361b8ed docs(perf): 更新 DN42 reviewer 修复证据`

### Notes for Reviewers

- 重点核验 reload 失败保留、同会话 generation 固定、MTR reset 的旧结果隔离，以及 mapped IPv4 的 legacy 适配。
- 本 PR 只处理 PR-3，不包含 PR-4 的全局有界 Geo cache。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 DN42 数据提供方，可通过命令行或环境变量选择，并自动启用相应网络模式。
  - DN42 查询支持本地 GeoFeed 与 PTR 数据，覆盖追踪、MTU、Nali、地理信息查询等场景。
  - IP 地理数据源支持运行期间刷新，MTR 重置后可加载最新信息。
- **改进**
  - DN42 模式下可正确解析保留地址，提升网络信息标注准确性。
  - 优化 GeoFeed 匹配与加载性能，并增强失败时保留有效数据的稳定性。
- **文档**
  - 更新中英文 README，补充 DN42 提供方及命令行用法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->