### PR TITLE
perf(geo): 限制共享缓存并隔离查询结果

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -846,7 +846,9 @@ func runFastTraceModeWithRuntime(ctx context.Context, dn42 bool, dataOrigin *str
 	defer closeNextTraceAPIV3WebSocket(nextTraceAPIV3WS)
 	params.RuntimePrepared = runtimePrepared
 	params.DataProvider = *dataOrigin
-	params.IPGeoSource = ipgeo.GetSource(*dataOrigin)
+	descriptor := ipgeo.GetSourceDescriptorWithGeoDNS(*dataOrigin, params.Dot)
+	params.IPGeoSource = trace.CachedGeoSource(descriptor)
+	params.IPGeoDescriptor = func() ipgeo.SourceDescriptor { return descriptor }
 	params.DN42 = isDN42Provider(*dataOrigin)
 	return maybeRunFastTraceMode(from, fastTraceFlag, file, params, method)
 }
@@ -1049,7 +1051,8 @@ func buildTraceConfig(
 	disableMPLS bool,
 ) trace.Config {
 	dn42 = dn42 || isDN42Provider(dataOrigin)
-	session := ipgeo.GetSourceSession(dataOrigin)
+	descriptorSession := ipgeo.GetSourceDescriptorSession(dataOrigin)
+	session := trace.CachedGeoSourceSession(descriptorSession)
 	return trace.Config{
 		OSType:             osType,
 		ICMPMode:           icmpMode,
@@ -1070,6 +1073,7 @@ func buildTraceConfig(
 		RDNS:               !noRDNS,
 		AlwaysWaitRDNS:     alwaysRDNS,
 		IPGeoSource:        session.Source,
+		IPGeoDescriptor:    descriptorSession.Current,
 		RefreshIPGeoSource: session.Refresh,
 		Timeout:            time.Duration(timeout) * time.Millisecond,
 		PktSize:            packetSize,
@@ -1656,7 +1660,7 @@ func Execute() {
 			!*norDNS,
 			*alwaysrDNS,
 			isDN42Provider(*dataOrigin),
-			ipgeo.GetSource(*dataOrigin),
+			trace.CachedGeoSource(ipgeo.GetSourceDescriptorWithGeoDNS(*dataOrigin, *dot)),
 			*lang,
 		)
 		if err := runStandaloneMTUMode(conf, *jsonPrint); err != nil {
@@ -1713,6 +1717,21 @@ func Execute() {
 		}
 	}
 
+	globalpingConfig := trace.Config{
+		Context:         rootCtx,
+		OSType:          osType,
+		DN42:            *dn42 || isDN42Provider(*dataOrigin),
+		NumMeasurements: *numMeasurements,
+		Lang:            *lang,
+		RDNS:            !*norDNS,
+		AlwaysWaitRDNS:  *alwaysrDNS,
+		Timeout:         time.Duration(*timeout) * time.Millisecond,
+	}
+	if *from != "" {
+		globalpingDescriptor := ipgeo.GetSourceDescriptorWithGeoDNS(*dataOrigin, *dot)
+		globalpingConfig.IPGeoSource = trace.CachedGeoSource(globalpingDescriptor)
+		globalpingConfig.IPGeoDescriptor = func() ipgeo.SourceDescriptor { return globalpingDescriptor }
+	}
 	if maybeHandleGlobalping(
 		*from,
 		&trace.GlobalpingOptions{
@@ -1735,17 +1754,7 @@ func Execute() {
 			JSONPrint:    *jsonPrint,
 			ClearScreen:  stdoutIsTTY,
 		},
-		&trace.Config{
-			Context:         rootCtx,
-			OSType:          osType,
-			DN42:            *dn42 || isDN42Provider(*dataOrigin),
-			NumMeasurements: *numMeasurements,
-			Lang:            *lang,
-			RDNS:            !*norDNS,
-			AlwaysWaitRDNS:  *alwaysrDNS,
-			IPGeoSource:     ipgeo.GetSource(*dataOrigin),
-			Timeout:         time.Duration(*timeout) * time.Millisecond,
-		},
+		&globalpingConfig,
 	) {
 		return
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -513,8 +513,11 @@ func TestBuildTraceConfigPinsAndRefreshesDN42Source(t *testing.T) {
 		30, 50, 300, 3, 3, 18, "en", true, false, "DN42", 1000,
 		0, false, 0, false,
 	)
-	if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.RefreshIPGeoSource == nil {
+	if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.IPGeoDescriptor == nil || cfg.RefreshIPGeoSource == nil {
 		t.Fatalf("DN42 config = %+v", cfg)
+	}
+	if descriptor := cfg.IPGeoDescriptor(); descriptor.Namespace != ipgeo.SourceNamespaceDN42 || !descriptor.HasGeneration {
+		t.Fatalf("DN42 descriptor = %+v", descriptor)
 	}
 	first, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
 	if err != nil || first.City != "First" {

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -253,6 +253,7 @@ func normalizeMTRReportConfig(conf trace.Config, wide bool) trace.Config {
 	}
 
 	normalized.IPGeoSource = nil
+	normalized.IPGeoDescriptor = nil
 	normalized.RefreshIPGeoSource = nil
 	if normalized.RDNS {
 		normalized.AlwaysWaitRDNS = true

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -438,8 +438,11 @@ func TestNormalizeMTRReportConfig_NonWideDisablesGeoAndKeepsRDNS(t *testing.T) {
 		return &ipgeo.IPGeoData{}, nil
 	}
 	original := trace.Config{
-		TTLInterval:        1200,
-		IPGeoSource:        geoSource,
+		TTLInterval: 1200,
+		IPGeoSource: geoSource,
+		IPGeoDescriptor: func() ipgeo.SourceDescriptor {
+			return ipgeo.SourceDescriptor{Source: geoSource, Namespace: ipgeo.SourceNamespaceIPInfo}
+		},
 		RefreshIPGeoSource: func() {},
 		RDNS:               true,
 		AlwaysWaitRDNS:     false,
@@ -456,6 +459,9 @@ func TestNormalizeMTRReportConfig_NonWideDisablesGeoAndKeepsRDNS(t *testing.T) {
 	if normalized.IPGeoSource != nil {
 		t.Fatal("non-wide report should disable IPGeoSource")
 	}
+	if normalized.IPGeoDescriptor != nil {
+		t.Fatal("non-wide report should disable IPGeoDescriptor")
+	}
 	if normalized.RefreshIPGeoSource != nil {
 		t.Fatal("non-wide report should disable RefreshIPGeoSource")
 	}
@@ -468,7 +474,7 @@ func TestNormalizeMTRReportConfig_NonWideDisablesGeoAndKeepsRDNS(t *testing.T) {
 	if normalized.PacketInterval != original.PacketInterval || normalized.Timeout != original.Timeout || normalized.MaxHops != original.MaxHops {
 		t.Fatalf("unexpected mutation of other fields: %+v", normalized)
 	}
-	if original.IPGeoSource == nil || original.RefreshIPGeoSource == nil || original.TTLInterval != 1200 || original.AlwaysWaitRDNS {
+	if original.IPGeoSource == nil || original.IPGeoDescriptor == nil || original.RefreshIPGeoSource == nil || original.TTLInterval != 1200 || original.AlwaysWaitRDNS {
 		t.Fatalf("original config was modified in place: %+v", original)
 	}
 }
@@ -478,8 +484,11 @@ func TestNormalizeMTRReportConfig_NonWideRespectsNoRDNS(t *testing.T) {
 		return &ipgeo.IPGeoData{}, nil
 	}
 	original := trace.Config{
-		TTLInterval:    1200,
-		IPGeoSource:    geoSource,
+		TTLInterval: 1200,
+		IPGeoSource: geoSource,
+		IPGeoDescriptor: func() ipgeo.SourceDescriptor {
+			return ipgeo.SourceDescriptor{Source: geoSource, Namespace: ipgeo.SourceNamespaceIPInfo}
+		},
 		RDNS:           false,
 		AlwaysWaitRDNS: false,
 	}
@@ -488,6 +497,9 @@ func TestNormalizeMTRReportConfig_NonWideRespectsNoRDNS(t *testing.T) {
 
 	if normalized.IPGeoSource != nil {
 		t.Fatal("non-wide report should disable IPGeoSource")
+	}
+	if normalized.IPGeoDescriptor != nil {
+		t.Fatal("non-wide report should disable IPGeoDescriptor")
 	}
 	if normalized.RDNS {
 		t.Fatal("non-wide report should preserve RDNS=false")
@@ -503,8 +515,11 @@ func TestNormalizeMTRReportConfig_WidePreservesGeoSettings(t *testing.T) {
 	}
 	refreshCalls := 0
 	original := trace.Config{
-		TTLInterval:        1200,
-		IPGeoSource:        geoSource,
+		TTLInterval: 1200,
+		IPGeoSource: geoSource,
+		IPGeoDescriptor: func() ipgeo.SourceDescriptor {
+			return ipgeo.SourceDescriptor{Source: geoSource, Namespace: ipgeo.SourceNamespaceIPInfo}
+		},
 		RefreshIPGeoSource: func() { refreshCalls++ },
 		RDNS:               true,
 		AlwaysWaitRDNS:     false,
@@ -519,6 +534,9 @@ func TestNormalizeMTRReportConfig_WidePreservesGeoSettings(t *testing.T) {
 	if normalized.IPGeoSource == nil {
 		t.Fatal("wide report should preserve IPGeoSource")
 	}
+	if normalized.IPGeoDescriptor == nil || normalized.IPGeoDescriptor().Namespace != ipgeo.SourceNamespaceIPInfo {
+		t.Fatal("wide report should preserve IPGeoDescriptor")
+	}
 	if normalized.RefreshIPGeoSource == nil {
 		t.Fatal("wide report should preserve RefreshIPGeoSource")
 	}
@@ -532,7 +550,7 @@ func TestNormalizeMTRReportConfig_WidePreservesGeoSettings(t *testing.T) {
 	if normalized.AlwaysWaitRDNS != original.AlwaysWaitRDNS {
 		t.Fatalf("wide report should preserve AlwaysWaitRDNS, got %v want %v", normalized.AlwaysWaitRDNS, original.AlwaysWaitRDNS)
 	}
-	if original.IPGeoSource == nil || original.RefreshIPGeoSource == nil || original.TTLInterval != 1200 {
+	if original.IPGeoSource == nil || original.IPGeoDescriptor == nil || original.RefreshIPGeoSource == nil || original.TTLInterval != 1200 {
 		t.Fatalf("original config was modified in place: %+v", original)
 	}
 }

--- a/cmd/nali_mode.go
+++ b/cmd/nali_mode.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nxtrace/NTrace-core/internal/nali"
 	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace"
 )
 
 func registerNaliFlag(parser *argparse.Parser) *bool {
@@ -235,7 +236,7 @@ func runNaliMode(ctx context.Context, opts naliRunOptions) error {
 		family = nali.Family6
 	}
 	return nali.Run(ctx, nali.Config{
-		Source:  ipgeo.GetSourceWithGeoDNS(opts.data, opts.dot),
+		Source:  trace.CachedGeoSource(ipgeo.GetSourceDescriptorWithGeoDNS(opts.data, opts.dot)),
 		Timeout: time.Duration(opts.timeoutMs) * time.Millisecond,
 		Lang:    opts.lang,
 		Family:  family,

--- a/docs/performance/go127-geo-cache.md
+++ b/docs/performance/go127-geo-cache.md
@@ -1,0 +1,160 @@
+# Go 1.27 Geo 缓存边界与隔离证据
+
+## 范围与结论
+
+本轮只调整 Geo 数据源身份、进程级缓存和内建调用点：
+
+- `ipgeo.SourceDescriptor` 明确 Source、canonical namespace/backend 和可选
+  generation；旧 `GetSource`、`GetSourceSession`、`LookupIPGeo` API 保留。
+- 内建 CLI、REST/WS、service/MCP、MTR、FastTrace、MTU、nali 和 speedtest 使用
+  descriptor；无 namespace 的外部自定义 Source 绕过进程缓存和 singleflight。
+- 全局缓存固定为 4096 项、15 分钟绝对 TTL、FIFO 淘汰；命中不续期、不改变
+  FIFO 顺序，错误和 nil 结果不缓存。
+- `ClearCaches` 增加 epoch 屏障。清理前的 flight 不能与清理后的请求合并，也不能
+  在清理后回填旧结果。
+- 缓存存储和每个调用方都获得独立 `IPGeoData` 副本，包含 `Router` map/slice
+  深拷贝，避免 renderer 或调用方修改共享对象造成污染和 data race。
+
+PR-4 没有数值性能合并门槛。旧实现只是无界 `sync.Map[string]*IPGeoData`，直接返回
+共享指针；新实现承担 key 规范化、容量/TTL/FIFO/epoch 管理和返回值隔离，因此串行
+命中成本明确增加。完整 lookup 的中位数仍为 137.8 ns/op，并发命中为 58.33 ns/op。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `e1338fc54c672386877b1576af684295fbd4dba7` |
+| descriptor commit | `20d027771e09c32df4ec0c2d294555c800dac8de` |
+| implementation/profile head | `c865f0c436f0b5ce839c293763773f5af4b3ab24` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每组 10 次，每次 1 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+
+## 调用链变化
+
+### 旧路径
+
+普通非 DN42 查询执行：
+
+`Hop.fetchIPData -> sync.Map(IP text) -> global singleflight(IP text) -> Source`
+
+缓存 key 只有原始 IP 文本，不区分 provider、NextTrace v3/v4 backend、语言或
+maptrace。缓存无容量和 TTL，返回同一个可变指针。DN42 和部分 direct/service 路径
+则绕过该缓存，内建入口之间没有统一身份。
+
+### 新路径
+
+内建入口先建立 descriptor/session，再执行：
+
+`request/session -> Config.IPGeoDescriptor -> bounded Geo cache -> descriptor.Source`
+
+key 包含：
+
+- `netip.Addr.Unmap()` 后的地址；
+- canonical namespace 和实际 backend；
+- trim/lower 后的 language；
+- maptrace；
+- DN42 的规范化 hostname 与 GeoFeed generation。
+
+cacheable Source 使用与 key 相同的 canonical 地址、language 和 DN42 hostname，避免
+IPv4-mapped 文本或语言大小写由“第一个 miss”决定后续结果。原始自定义 Source 没有
+namespace 时仍收到原始参数，不参与缓存或 singleflight。
+
+NextTrace API v3 WebSocket 与 v4 HTTP 使用不同 backend key。DN42 descriptor 的 Source
+闭包和 generation 来自同一个不可变 GeoFeed 快照；refresh 只发布更高 generation，
+现有 MTR 会话在 reset 边界刷新。
+
+### 取消和清理
+
+descriptor miss 使用 `singleflight.DoChan`，每个等待者用自己的 context/deadline 等待；
+短 deadline follower 可以退出而不取消其他调用方。Source 回调仍必须履行传入的 timeout
+合同，Go 不能强制终止违规回调。
+
+清理时先推进 epoch，再清空 map/FIFO。flight key 包含 epoch，store 也核验发起时 epoch，
+因此旧 flight 只能把结果返回给清理前仍在等待的调用者，不能影响清理后的缓存。
+
+## Benchmark
+
+parent/head 共同的底层子项使用同一命令与环境：
+
+```sh
+GOTOOLCHAIN=go1.27.1 GOEXPERIMENT=nojsonv2 GOMAXPROCS=10 \
+  go test -run '^$' -bench '^BenchmarkGeoCacheAccess$' \
+  -benchmem -benchtime=1s -count=10 ./trace
+```
+
+| 子项 | parent | implementation head | 变化 |
+| --- | ---: | ---: | ---: |
+| Hit | 8.622 ns/op, 0 B, 0 alloc | 86.30 ns/op, 288 B, 1 alloc | +900.99% |
+| Miss | 5.002 ns/op, 0 B, 0 alloc | 45.43 ns/op, 0 B, 0 alloc | +808.24% |
+
+这两个 parent 子项只测无界 `sync.Map` 读取，不包含新合同需要的 typed key、epoch 检查和
+返回值隔离，因此增幅不是同功能回退。新增子项记录最终完整路径：
+
+| 子项 | time/op | B/op | allocs/op |
+| --- | ---: | ---: | ---: |
+| FIFO eviction | 423.7 ns | 702–703 B | 5 |
+| Parallel cache load hit | 48.27 ns | 288 B | 1 |
+| CachedGeoSource lookup hit | 137.8 ns | 288 B | 1 |
+| Parallel CachedGeoSource hit | 58.33 ns | 288 B | 1 |
+
+288 B、1 alloc 是每个调用方独立 `IPGeoData` 的固定浅结构副本；只有非 nil Router 时
+才额外复制 map 和内部 slice。测试同时覆盖 32 个 singleflight waiter，确认每个 waiter
+获得不同指针且相互修改不可见。
+
+## Profile
+
+固定 10 秒 profile 覆盖 Hit、Miss、Eviction、Parallel、LookupHit 和
+ParallelLookupHit。CPU profile 中 `geoCacheRuntime.load` 累积占 30.71%，typed-key
+`runtime.typehash` 占 11.24%；heap alloc-space 的 95.74% 来自
+`cloneGeoCacheValue`。这与 benchmark 的 1 alloc/op 一致，且分配用于调用方隔离，
+不是隐藏的缓存增长。
+
+原始 CPU/heap `.pprof` 和完整 benchmark 输出只作为本地/CI evidence 保存，不提交仓库。
+
+## 产物大小
+
+Darwin arm64 产物使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`，
+`MACOSX_DEPLOYMENT_TARGET=13.0`，两侧均为 `nojsonv2` 未压缩产物：
+
+| Flavor | parent | implementation head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,044,018 B | 30,093,618 B | +49,600 B / +0.1651% |
+| nexttrace-tiny | 10,983,874 B | 11,016,978 B | +33,104 B / +0.3014% |
+| ntr | 10,983,874 B | 11,016,978 B | +33,104 B / +0.3014% |
+
+implementation head 的 Darwin arm64 产物 `LC_BUILD_VERSION` 为 `minos 13.0`。
+
+## 验证
+
+新增回归覆盖：
+
+- provider alias、NextTrace v3/v4 backend、language、maptrace、DN42 hostname 与
+  generation key 隔离；
+- IPv6 等价文本、IPv4-mapped IPv6 与 canonical Source 输入；
+- 15 分钟绝对 TTL、hit 不续期、FIFO 不提升、4096 默认容量；
+- 错误/nil 不缓存、同 key 32 并发只调用一次 Source；
+- 无 namespace Source 不缓存且不 singleflight；
+- clear 与旧/新 flight 并发时的 epoch 屏障；
+- 每个 hit/waiter 的 scalar、Router map 和 Router slice 深隔离；
+- follower 自有 deadline、direct/descriptor caller cancellation 和 MTR metadata 有界收尾；
+- CLI、server、service/MCP、FastTrace、MTU、nali、speedtest 的 descriptor 传播，
+  以及 non-wide MTR report 同时清除 Source/descriptor/refresh。
+
+implementation head 的定向普通/race 测试、20 次并发压力、全仓 `nojsonv2` 测试、
+相关 vet 和 Web 前端 15 项 Node 测试均通过。全仓 `nojsonv2` 测试墙钟为 parent
+32.57 秒、implementation head 18.51 秒；两次构建缓存状态不同，只作为完成耗时记录，
+不作性能改善结论。紧随其后的证据提交只修改本 Markdown 文件，不改变 Go 源码或
+构建输入；PR exact-head CI 仍需通过默认 JSON/nojsonv2、全仓 race、build、vet、lint、
+三 flavor 和跨平台矩阵后才允许合并。
+
+## 平台风险与回退
+
+缓存最多保留 4096 个深拷贝结果；Router 数据较大时，内存上限还取决于单项大小。
+绝对 TTL 不因命中续期。第一个同 key flight 的 Source timeout 仍是兼容兜底，等待者
+自己的 context 决定其总等待预算。
+
+新增状态只在进程内，不涉及配置、JSON、协议或持久数据迁移。如需回退，可逆序撤销
+缓存实现和 descriptor 提交；旧导出 API 未删除或改签名，调用方无需迁移数据。

--- a/fast_trace/fast_trace ipv6.go
+++ b/fast_trace/fast_trace ipv6.go
@@ -52,6 +52,7 @@ func (f *FastTracer) tracert_v6(location string, ispCollection ISPCollection) {
 		PacketInterval:   100,
 		TTLInterval:      500,
 		IPGeoSource:      fastTraceGeoSource(f.ParamsFastTrace),
+		IPGeoDescriptor:  f.ParamsFastTrace.IPGeoDescriptor,
 		Timeout:          f.ParamsFastTrace.Timeout,
 		SrcAddr:          f.ParamsFastTrace.SrcAddr,
 		SourceDevice:     f.ParamsFastTrace.SrcDev,

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -55,6 +55,7 @@ type ParamsFastTrace struct {
 	RuntimePrepared bool
 	DataProvider    string
 	IPGeoSource     ipgeo.Source
+	IPGeoDescriptor func() ipgeo.SourceDescriptor
 	DN42            bool
 }
 
@@ -79,7 +80,7 @@ func fastTraceGeoSource(params ParamsFastTrace) ipgeo.Source {
 	if params.IPGeoSource != nil {
 		return params.IPGeoSource
 	}
-	return ipgeo.GetSource(fastTraceDataProvider(params))
+	return trace.CachedGeoSource(ipgeo.GetSourceDescriptorWithGeoDNS(fastTraceDataProvider(params), params.Dot))
 }
 
 func fastTraceDataProvider(params ParamsFastTrace) string {
@@ -98,9 +99,12 @@ func fastTraceDN42(params ParamsFastTrace) bool {
 }
 
 func pinFastTraceGeoSource(params ParamsFastTrace) ParamsFastTrace {
-	if params.IPGeoSource == nil {
-		params.IPGeoSource = fastTraceGeoSource(params)
+	if params.IPGeoSource != nil {
+		return params
 	}
+	descriptor := ipgeo.GetSourceDescriptorWithGeoDNS(fastTraceDataProvider(params), params.Dot)
+	params.IPGeoSource = trace.CachedGeoSource(descriptor)
+	params.IPGeoDescriptor = func() ipgeo.SourceDescriptor { return descriptor }
 	return params
 }
 
@@ -295,6 +299,7 @@ func buildFileTraceConfig(params ParamsFastTrace, tracerouteMethod trace.Method,
 		PacketInterval:   100,
 		TTLInterval:      500,
 		IPGeoSource:      fastTraceGeoSource(params),
+		IPGeoDescriptor:  params.IPGeoDescriptor,
 		Timeout:          params.Timeout,
 		SrcAddr:          params.SrcAddr,
 		SourceDevice:     params.SrcDev,
@@ -450,6 +455,7 @@ func (f *FastTracer) tracert(location string, ispCollection ISPCollection) {
 		PacketInterval:   100,
 		TTLInterval:      500,
 		IPGeoSource:      fastTraceGeoSource(f.ParamsFastTrace),
+		IPGeoDescriptor:  f.ParamsFastTrace.IPGeoDescriptor,
 		Timeout:          f.ParamsFastTrace.Timeout,
 		SrcAddr:          f.ParamsFastTrace.SrcAddr,
 		SourceDevice:     f.ParamsFastTrace.SrcDev,

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -327,6 +327,9 @@ func TestBuildFileTraceConfigUsesPinnedDN42Source(t *testing.T) {
 	if !cfg.DN42 || cfg.IPGeoSource == nil {
 		t.Fatalf("DN42 config = %+v", cfg)
 	}
+	if cfg.IPGeoDescriptor != nil {
+		t.Fatal("custom IPGeoSource should not receive a process-cache descriptor")
+	}
 	if _, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false); err != nil {
 		t.Fatalf("pinned source returned error: %v", err)
 	}
@@ -363,8 +366,11 @@ func TestPinFastTraceGeoSourceUsesEffectiveDN42Provider(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			params := pinFastTraceGeoSource(tt.params)
-			if params.IPGeoSource == nil || !fastTraceDN42(params) {
+			if params.IPGeoSource == nil || params.IPGeoDescriptor == nil || !fastTraceDN42(params) {
 				t.Fatalf("pinned params = %+v", params)
+			}
+			if descriptor := params.IPGeoDescriptor(); descriptor.Namespace != ipgeo.SourceNamespaceDN42 || !descriptor.HasGeneration {
+				t.Fatalf("pinned descriptor = %+v", descriptor)
 			}
 			geo, err := params.IPGeoSource("10.0.0.1", time.Second, "en", false)
 			if err != nil || geo.City != "DN42 City" {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -69,8 +69,7 @@ var (
 	ensureNextTraceAPIV3ConnectionFn = ensureNextTraceAPIV3Connection
 	prepareNextTraceAPIV4FastIPFn    = ipgeo.PrepareNextTraceAPIV4FastIP
 	tracerouteWithContextFn          = trace.TracerouteWithContext
-	lookupIPGeoFn                    = trace.LookupIPGeo
-	lookupIPGeoWithSessionFn         = trace.LookupIPGeoWithSession
+	lookupIPGeoWithDescriptorFn      = trace.LookupIPGeoWithDescriptor
 	runMTRFn                         = trace.RunMTR
 	runMTRRawFn                      = trace.RunMTRRaw
 	runMTUTraceFn                    = mtutrace.Run
@@ -292,13 +291,15 @@ func (s *Service) AnnotateIPs(ctx context.Context, req AnnotateIPsRequest) (Anno
 	timeout := positiveOrDefault(req.TimeoutMs, defaultTimeoutMs)
 	provider, needsNextTraceAPIV3 := resolveStandaloneDataProvider(req.DataProvider)
 	return withServiceRuntime(ctx, runtimeOptions{NeedsNextTraceAPIV3: needsNextTraceAPIV3}, func() (AnnotateIPsResponse, error) {
-		session := ipgeo.GetSourceSession(provider)
+		descriptorSession := ipgeo.GetSourceDescriptorSession(provider)
+		descriptor := descriptorSession.Current()
+		session := trace.CachedGeoSourceSession(descriptorSession)
 		annotator := nali.New(nali.Config{
 			Source:  session.Source,
 			Timeout: time.Duration(timeout) * time.Millisecond,
 			Lang:    normalizeLanguage(req.Language),
 			Family:  family,
-			DN42:    session.Refresh != nil,
+			DN42:    descriptor.Namespace == ipgeo.SourceNamespaceDN42,
 		})
 		return AnnotateIPsResponse{
 			Text: annotator.AnnotateLine(ctx, req.Text),
@@ -316,14 +317,8 @@ func (s *Service) GeoLookup(ctx context.Context, req GeoLookupRequest) (GeoLooku
 	}
 	provider, needsNextTraceAPIV3 := resolveStandaloneDataProvider(req.DataProvider)
 	return withServiceRuntime(ctx, runtimeOptions{NeedsNextTraceAPIV3: needsNextTraceAPIV3}, func() (GeoLookupResponse, error) {
-		session := ipgeo.GetSourceSession(provider)
-		var geo *ipgeo.IPGeoData
-		var err error
-		if session.Refresh != nil {
-			geo, err = lookupIPGeoWithSessionFn(ctx, session, normalizeLanguage(req.Language), false, defaultQueries, query)
-		} else {
-			geo, err = lookupIPGeoFn(ctx, session.Source, normalizeLanguage(req.Language), false, defaultQueries, query)
-		}
+		descriptor := ipgeo.GetSourceDescriptor(provider)
+		geo, err := lookupIPGeoWithDescriptorFn(ctx, descriptor, normalizeLanguage(req.Language), false, defaultQueries, query)
 		if err != nil {
 			return GeoLookupResponse{}, err
 		}
@@ -416,7 +411,9 @@ func (s *Service) buildMTUConfig(ctx context.Context, req MTUTraceRequest) (mtut
 		port = 33494
 	}
 	provider, _ := resolveMTUDataProvider(req.DataProvider)
-	session := ipgeo.GetSourceSessionWithGeoDNS(provider, req.DotServer)
+	descriptorSession := ipgeo.GetSourceDescriptorSessionWithGeoDNS(provider, req.DotServer)
+	descriptor := descriptorSession.Current()
+	session := trace.CachedGeoSourceSession(descriptorSession)
 	return mtutrace.Config{
 		Target:         target,
 		DstIP:          ip,
@@ -433,7 +430,7 @@ func (s *Service) buildMTUConfig(ctx context.Context, req MTUTraceRequest) (mtut
 		AlwaysWaitRDNS: req.AlwaysRDNS,
 		IPGeoSource:    session.Source,
 		Lang:           normalizeLanguage(req.Language),
-		DN42:           session.Refresh != nil,
+		DN42:           descriptor.Namespace == ipgeo.SourceNamespaceDN42,
 	}, nil
 }
 
@@ -580,7 +577,9 @@ func buildTraceConfig(req TraceRequest, method trace.Method, ip net.IP, provider
 	if req.TOS != nil {
 		tos = *req.TOS
 	}
-	session := ipgeo.GetSourceSessionWithGeoDNS(provider, req.DotServer)
+	descriptorSession := ipgeo.GetSourceDescriptorSessionWithGeoDNS(provider, req.DotServer)
+	descriptor := descriptorSession.Current()
+	session := trace.CachedGeoSourceSession(descriptorSession)
 	return trace.Config{
 		OSType:             resolveOSType(),
 		ICMPMode:           req.ICMPMode,
@@ -596,13 +595,14 @@ func buildTraceConfig(req TraceRequest, method trace.Method, ip net.IP, provider
 		DstIP:              ip,
 		DstPort:            port,
 		IPGeoSource:        session.Source,
+		IPGeoDescriptor:    descriptorSession.Current,
 		RefreshIPGeoSource: session.Refresh,
 		RDNS:               !req.DisableRDNS,
 		AlwaysWaitRDNS:     req.AlwaysRDNS,
 		PacketInterval:     positiveOrDefault(req.PacketInterval, defaultPacketIntervalMs),
 		TTLInterval:        positiveOrDefault(req.TTLInterval, defaultTTLIntervalMs),
 		Lang:               normalizeLanguage(req.Language),
-		DN42:               req.DN42 || session.Refresh != nil,
+		DN42:               req.DN42 || descriptor.Namespace == ipgeo.SourceNamespaceDN42,
 		PktSize:            packetSizeSpec.PayloadSize,
 		RandomPacketSize:   packetSizeSpec.Random,
 		TOS:                tos,

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -289,8 +289,11 @@ func TestMTRReportCarriesPinnedDN42SourceAndRefresh(t *testing.T) {
 	})
 
 	runMTRFn = func(_ context.Context, _ trace.Method, cfg trace.Config, _ trace.MTROptions, _ trace.MTROnSnapshot) error {
-		if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.RefreshIPGeoSource == nil {
+		if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.IPGeoDescriptor == nil || cfg.RefreshIPGeoSource == nil {
 			return errors.New("MTR did not receive the DN42 source session")
+		}
+		if descriptor := cfg.IPGeoDescriptor(); descriptor.Namespace != ipgeo.SourceNamespaceDN42 || !descriptor.HasGeneration {
+			return fmt.Errorf("MTR descriptor = %+v", descriptor)
 		}
 		first, err := cfg.IPGeoSource("10.0.0.1", time.Second, "en", false)
 		if err != nil || first.City != "First" {
@@ -374,10 +377,12 @@ func TestAnnotateIPsAndGeoLookupInitializeDefaultNextTraceAPIV3Runtime(t *testin
 	defer restore()
 
 	var ensureCalls int
+	var lookupDescriptor ipgeo.SourceDescriptor
 	ensureNextTraceAPIV3ConnectionFn = func(context.Context) {
 		ensureCalls++
 	}
-	lookupIPGeoFn = func(_ context.Context, _ ipgeo.Source, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+	lookupIPGeoWithDescriptorFn = func(_ context.Context, descriptor ipgeo.SourceDescriptor, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+		lookupDescriptor = descriptor
 		return &ipgeo.IPGeoData{IP: query, Asnumber: "AS13335"}, nil
 	}
 
@@ -390,6 +395,9 @@ func TestAnnotateIPsAndGeoLookupInitializeDefaultNextTraceAPIV3Runtime(t *testin
 	if ensureCalls != 2 {
 		t.Fatalf("ensureNextTraceAPIV3Connection calls = %d, want 2", ensureCalls)
 	}
+	if lookupDescriptor.Namespace != ipgeo.SourceNamespaceNextTraceAPI || lookupDescriptor.Backend != ipgeo.SourceBackendNextTraceAPIV3 {
+		t.Fatalf("GeoLookup descriptor = %+v, want NextTrace API v3", lookupDescriptor)
+	}
 }
 
 func TestGeoLookupUsesNextTraceAPIV4FastIPInsteadOfV3WebSocketWhenTokenConfigured(t *testing.T) {
@@ -399,6 +407,7 @@ func TestGeoLookupUsesNextTraceAPIV4FastIPInsteadOfV3WebSocketWhenTokenConfigure
 
 	var ensureCalls int
 	var prepareCalls int
+	var lookupDescriptor ipgeo.SourceDescriptor
 	ensureNextTraceAPIV3ConnectionFn = func(context.Context) {
 		ensureCalls++
 	}
@@ -412,7 +421,8 @@ func TestGeoLookupUsesNextTraceAPIV4FastIPInsteadOfV3WebSocketWhenTokenConfigure
 		}
 		return nil
 	}
-	lookupIPGeoFn = func(_ context.Context, _ ipgeo.Source, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+	lookupIPGeoWithDescriptorFn = func(_ context.Context, descriptor ipgeo.SourceDescriptor, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+		lookupDescriptor = descriptor
 		return &ipgeo.IPGeoData{IP: query, Asnumber: "AS13335"}, nil
 	}
 
@@ -424,6 +434,9 @@ func TestGeoLookupUsesNextTraceAPIV4FastIPInsteadOfV3WebSocketWhenTokenConfigure
 	}
 	if prepareCalls != 1 {
 		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+	}
+	if lookupDescriptor.Namespace != ipgeo.SourceNamespaceNextTraceAPI || lookupDescriptor.Backend != ipgeo.SourceBackendNextTraceAPIV4 {
+		t.Fatalf("GeoLookup descriptor = %+v, want NextTrace API v4", lookupDescriptor)
 	}
 }
 
@@ -441,7 +454,7 @@ func TestGeoLookupFallsBackToNextTraceAPIV3WebSocketWhenV4FastIPFails(t *testing
 		prepareCalls++
 		return errors.New("fastip unavailable")
 	}
-	lookupIPGeoFn = func(_ context.Context, _ ipgeo.Source, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+	lookupIPGeoWithDescriptorFn = func(_ context.Context, _ ipgeo.SourceDescriptor, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
 		return &ipgeo.IPGeoData{IP: query, Asnumber: "AS13335"}, nil
 	}
 
@@ -464,7 +477,7 @@ func TestAnnotateIPsAndGeoLookupSkipNextTraceAPIRuntimeForDisabledGeoIP(t *testi
 	ensureNextTraceAPIV3ConnectionFn = func(context.Context) {
 		ensureCalls++
 	}
-	lookupIPGeoFn = func(_ context.Context, _ ipgeo.Source, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+	lookupIPGeoWithDescriptorFn = func(_ context.Context, _ ipgeo.SourceDescriptor, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
 		return &ipgeo.IPGeoData{IP: query}, nil
 	}
 
@@ -571,8 +584,7 @@ func stubServiceRuntimeForTests(t *testing.T) func() {
 	oldEnsureNextTraceAPIV3 := ensureNextTraceAPIV3ConnectionFn
 	oldPrepareFastIP := prepareNextTraceAPIV4FastIPFn
 	oldTracerouteWithContext := tracerouteWithContextFn
-	oldLookupIPGeo := lookupIPGeoFn
-	oldLookupIPGeoWithSession := lookupIPGeoWithSessionFn
+	oldLookupIPGeoWithDescriptor := lookupIPGeoWithDescriptorFn
 	oldRunMTR := runMTRFn
 	oldRunMTRRaw := runMTRRawFn
 	oldRunMTU := runMTUTraceFn
@@ -589,8 +601,7 @@ func stubServiceRuntimeForTests(t *testing.T) func() {
 		ensureNextTraceAPIV3ConnectionFn = oldEnsureNextTraceAPIV3
 		prepareNextTraceAPIV4FastIPFn = oldPrepareFastIP
 		tracerouteWithContextFn = oldTracerouteWithContext
-		lookupIPGeoFn = oldLookupIPGeo
-		lookupIPGeoWithSessionFn = oldLookupIPGeoWithSession
+		lookupIPGeoWithDescriptorFn = oldLookupIPGeoWithDescriptor
 		runMTRFn = oldRunMTR
 		runMTRRawFn = oldRunMTRRaw
 		runMTUTraceFn = oldRunMTU

--- a/internal/speedtest/runner/metadata.go
+++ b/internal/speedtest/runner/metadata.go
@@ -63,8 +63,8 @@ func lookupGeoData(ctx context.Context, target string, cfg *speedconfig.Config) 
 	if cfg == nil {
 		return nil, fmt.Errorf("nil speed config")
 	}
-	source := ipgeo.GetSourceWithGeoDNS(defaultSpeedGeoSourceProvider, cfg.DotServer)
-	return trace.LookupIPGeo(ctx, source, cfg.Language, false, defaultSpeedGeoLookupRetryCount, target)
+	descriptor := ipgeo.GetSourceDescriptorWithGeoDNS(defaultSpeedGeoSourceProvider, cfg.DotServer)
+	return trace.LookupIPGeoWithDescriptor(ctx, descriptor, cfg.Language, false, defaultSpeedGeoLookupRetryCount, target)
 }
 
 func formatGeoDescription(ip string, geo *ipgeo.IPGeoData, lang string) string {

--- a/ipgeo/dn42.go
+++ b/ipgeo/dn42.go
@@ -32,23 +32,57 @@ func DN42(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
 	return lookupDN42(index, ip)
 }
 
-func newDN42SourceSession() SourceSession {
-	var index atomic.Pointer[dn42.GeoFeedIndex]
+func newDN42SourceDescriptorSession(dotServer string, withGeoDNS bool) SourceDescriptorSession {
+	return newDN42SourceDescriptorSessionWithLoader(dotServer, withGeoDNS, dn42.LoadGeoFeedIndex)
+}
+
+func newDN42SourceDescriptorSessionWithLoader(
+	dotServer string,
+	withGeoDNS bool,
+	load func() (*dn42.GeoFeedIndex, error),
+) SourceDescriptorSession {
+	var current atomic.Pointer[SourceDescriptor]
+	initialIndex, _ := load()
+	initial := dn42SourceDescriptor(initialIndex, dotServer, withGeoDNS)
+	current.Store(&initial)
+
 	refresh := func() {
-		next, _ := dn42.LoadGeoFeedIndex()
-		if next != nil {
-			index.Store(next)
+		index, _ := load()
+		if index == nil {
+			return
+		}
+		next := dn42SourceDescriptor(index, dotServer, withGeoDNS)
+		for {
+			previous := current.Load()
+			if previous != nil && previous.HasGeneration && previous.Generation >= next.Generation {
+				return
+			}
+			if current.CompareAndSwap(previous, &next) {
+				return
+			}
 		}
 	}
-	refresh()
 
-	return SourceSession{
-		Source: func(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
-			current := index.Load()
-			return lookupDN42(current, ip)
-		},
+	return SourceDescriptorSession{
+		Current: func() SourceDescriptor { return *current.Load() },
 		Refresh: refresh,
 	}
+}
+
+func dn42SourceDescriptor(index *dn42.GeoFeedIndex, dotServer string, withGeoDNS bool) SourceDescriptor {
+	source := Source(func(ip string, _ time.Duration, _ string, _ bool) (*IPGeoData, error) {
+		return lookupDN42(index, ip)
+	})
+	descriptor := SourceDescriptor{
+		Source:    applyGeoDNS(source, dotServer, withGeoDNS),
+		Namespace: SourceNamespaceDN42,
+		Backend:   SourceBackendDN42GeoFeed,
+	}
+	if index != nil {
+		descriptor.Generation = index.Generation()
+		descriptor.HasGeneration = true
+	}
+	return descriptor
 }
 
 func lookupDN42(index *dn42.GeoFeedIndex, ip string) (*IPGeoData, error) {

--- a/ipgeo/dn42_test.go
+++ b/ipgeo/dn42_test.go
@@ -1,13 +1,16 @@
 package ipgeo
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	dn42data "github.com/nxtrace/NTrace-core/dn42"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,6 +69,32 @@ func TestDN42SourceSessionPinsAndRefreshesIndex(t *testing.T) {
 	assertDN42GeoResult(t, GetSource("DN42"), "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
 }
 
+func TestDN42SourceDescriptorSessionPinsSourceAndGeneration(t *testing.T) {
+	geofeedPath := configureDN42GeoFeed(t, dn42GeoFeedA)
+	session := GetSourceDescriptorSessionWithGeoDNS(" dn42 ", "")
+	require.NotNil(t, session.Current)
+	require.NotNil(t, session.Refresh)
+
+	first := session.Current()
+	assert.Equal(t, SourceNamespaceDN42, first.Namespace)
+	assert.Equal(t, SourceBackendDN42GeoFeed, first.Backend)
+	assert.True(t, first.HasGeneration)
+	require.NotZero(t, first.Generation)
+	assertDN42GeoResult(t, first.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+
+	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedB)
+	stillFirst := session.Current()
+	assert.Equal(t, first.Generation, stillFirst.Generation)
+	assertDN42GeoResult(t, stillFirst.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+
+	session.Refresh()
+	second := session.Current()
+	assert.Greater(t, second.Generation, first.Generation)
+	assert.True(t, second.HasGeneration)
+	assertDN42GeoResult(t, second.Source, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
+	assertDN42GeoResult(t, first.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+}
+
 func TestDN42CountryAreaContracts(t *testing.T) {
 	configureDN42GeoFeed(t, "192.0.2.1/32,hk,HK,Hong Kong\n"+
 		"192.0.2.2/32,tw,TW,Taipei\n"+
@@ -102,6 +131,112 @@ func TestDN42SourceSessionFailedRefreshKeepsSnapshot(t *testing.T) {
 	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedB)
 	session.Refresh()
 	assertDN42GeoResult(t, session.Source, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
+}
+
+func TestDN42SourceDescriptorRefreshUsesValidSnapshotReturnedWithError(t *testing.T) {
+	geofeedPath := configureDN42GeoFeed(t, dn42GeoFeedA)
+	firstIndex, err := dn42data.LoadGeoFeedIndex()
+	require.NoError(t, err)
+
+	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedB)
+	secondIndex, err := dn42data.LoadGeoFeedIndex()
+	require.NoError(t, err)
+	require.Greater(t, secondIndex.Generation(), firstIndex.Generation())
+
+	var calls atomic.Int32
+	wantErr := errors.New("reload failed")
+	session := newDN42SourceDescriptorSessionWithLoader("", false, func() (*dn42data.GeoFeedIndex, error) {
+		switch calls.Add(1) {
+		case 1:
+			return firstIndex, nil
+		case 2:
+			return secondIndex, wantErr
+		default:
+			return secondIndex, nil
+		}
+	})
+
+	before := session.Current()
+	session.Refresh()
+	afterRefresh := session.Current()
+	assert.Greater(t, afterRefresh.Generation, before.Generation)
+	assert.Equal(t, secondIndex.Generation(), afterRefresh.Generation)
+	assertDN42GeoResult(t, afterRefresh.Source, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
+}
+
+func TestDN42SourceDescriptorNilRefreshKeepsDescriptor(t *testing.T) {
+	configureDN42GeoFeed(t, dn42GeoFeedA)
+	index, err := dn42data.LoadGeoFeedIndex()
+	require.NoError(t, err)
+
+	var calls atomic.Int32
+	session := newDN42SourceDescriptorSessionWithLoader("", false, func() (*dn42data.GeoFeedIndex, error) {
+		if calls.Add(1) == 1 {
+			return index, nil
+		}
+		return nil, errors.New("no valid snapshot")
+	})
+
+	before := session.Current()
+	session.Refresh()
+	after := session.Current()
+	assert.Equal(t, before.Generation, after.Generation)
+	assertDN42GeoResult(t, after.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+}
+
+func TestDN42SourceDescriptorInitialLoadUsesValidSnapshotReturnedWithError(t *testing.T) {
+	configureDN42GeoFeed(t, dn42GeoFeedA)
+	index, err := dn42data.LoadGeoFeedIndex()
+	require.NoError(t, err)
+
+	session := newDN42SourceDescriptorSessionWithLoader("", false, func() (*dn42data.GeoFeedIndex, error) {
+		return index, errors.New("current file is invalid")
+	})
+	descriptor := session.Current()
+	assert.True(t, descriptor.HasGeneration)
+	assert.Equal(t, index.Generation(), descriptor.Generation)
+	assertDN42GeoResult(t, descriptor.Source, "China", "Hong Kong", "Hong Kong", "AS65000", "Owner A")
+}
+
+func TestDN42SourceDescriptorConcurrentRefreshCannotPublishOlderGeneration(t *testing.T) {
+	geofeedPath := configureDN42GeoFeed(t, dn42GeoFeedA)
+	firstIndex, err := dn42data.LoadGeoFeedIndex()
+	require.NoError(t, err)
+
+	writeDN42GeoFeed(t, geofeedPath, dn42GeoFeedB)
+	secondIndex, err := dn42data.LoadGeoFeedIndex()
+	require.NoError(t, err)
+	require.Greater(t, secondIndex.Generation(), firstIndex.Generation())
+
+	olderRefreshEntered := make(chan struct{})
+	releaseOlderRefresh := make(chan struct{})
+	var calls atomic.Int32
+	session := newDN42SourceDescriptorSessionWithLoader("", false, func() (*dn42data.GeoFeedIndex, error) {
+		switch calls.Add(1) {
+		case 1:
+			return firstIndex, errors.New("initial reload failed")
+		case 2:
+			close(olderRefreshEntered)
+			<-releaseOlderRefresh
+			return firstIndex, errors.New("older reload failed")
+		default:
+			return secondIndex, errors.New("newer reload failed")
+		}
+	})
+
+	olderDone := make(chan struct{})
+	go func() {
+		defer close(olderDone)
+		session.Refresh()
+	}()
+	<-olderRefreshEntered
+	session.Refresh()
+	close(releaseOlderRefresh)
+	<-olderDone
+
+	current := session.Current()
+	assert.Equal(t, secondIndex.Generation(), current.Generation)
+	assertDN42GeoResult(t, current.Source, "China", "Taiwan", "Taipei", "AS650001", "Owner version B")
 }
 
 func TestDN42SourceSessionConcurrentRefresh(t *testing.T) {

--- a/ipgeo/ipgeo.go
+++ b/ipgeo/ipgeo.go
@@ -30,6 +30,23 @@ type IPGeoData struct {
 
 type Source = func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error)
 
+// SourceDescriptor identifies a Source and the backend state that affects its
+// results. Namespace is empty only for descriptors constructed by callers.
+type SourceDescriptor struct {
+	Source        Source
+	Namespace     string
+	Backend       string
+	Generation    uint64
+	HasGeneration bool
+}
+
+// SourceDescriptorSession returns a descriptor whose Source and generation
+// belong to the same provider snapshot. Refresh is nil for static providers.
+type SourceDescriptorSession struct {
+	Current func() SourceDescriptor
+	Refresh func()
+}
+
 // SourceSession pins any provider state used by Source. Refresh is non-nil only
 // for providers whose snapshot can change during a long-lived session.
 type SourceSession struct {
@@ -37,8 +54,38 @@ type SourceSession struct {
 	Refresh func()
 }
 
-// NextTraceAPIProvider is the canonical data-provider value for the official API.
-const NextTraceAPIProvider = "NextTrace-API"
+const (
+	// NextTraceAPIProvider is the canonical user-facing provider value for the official API.
+	NextTraceAPIProvider = "NextTrace-API"
+
+	// SourceNamespaceNextTraceAPI identifies the official NextTrace GeoIP service.
+	SourceNamespaceNextTraceAPI = "nexttrace-api"
+	// SourceNamespaceIPAPI identifies both IPAPI.com and ip-api.com aliases.
+	SourceNamespaceIPAPI = "ip-api.com"
+	// SourceNamespaceIPSB identifies the IP.SB provider.
+	SourceNamespaceIPSB = "ip.sb"
+	// SourceNamespaceIPInsight identifies the IPInsight provider.
+	SourceNamespaceIPInsight = "ipinsight"
+	// SourceNamespaceIPInfo identifies the IPInfo provider.
+	SourceNamespaceIPInfo = "ipinfo"
+	// SourceNamespaceIPInfoLocal identifies the local IPInfo database.
+	SourceNamespaceIPInfoLocal = "ipinfolocal"
+	// SourceNamespaceChunzhen identifies the local Chunzhen database.
+	SourceNamespaceChunzhen = "chunzhen"
+	// SourceNamespaceIPDBOne identifies the IPDB.One provider.
+	SourceNamespaceIPDBOne = "ipdb.one"
+	// SourceNamespaceDisableGeoIP identifies the no-op GeoIP provider.
+	SourceNamespaceDisableGeoIP = "disable-geoip"
+	// SourceNamespaceDN42 identifies the DN42 GeoFeed provider.
+	SourceNamespaceDN42 = "dn42"
+
+	// SourceBackendNextTraceAPIV3 identifies the WebSocket API implementation.
+	SourceBackendNextTraceAPIV3 = "v3-websocket"
+	// SourceBackendNextTraceAPIV4 identifies the HTTP API implementation.
+	SourceBackendNextTraceAPIV4 = "v4-http"
+	// SourceBackendDN42GeoFeed identifies the DN42 GeoFeed implementation.
+	SourceBackendDN42GeoFeed = "geofeed"
+)
 
 // CanonicalizeNextTraceAPIProvider maps current and legacy official API names to the canonical value.
 func CanonicalizeNextTraceAPIProvider(provider string) string {
@@ -56,61 +103,131 @@ func IsNextTraceAPIProvider(provider string) bool {
 }
 
 func GetSource(s string) Source {
-	return GetSourceSession(s).Source
+	return GetSourceDescriptor(s).Source
 }
 
 // GetSourceSession returns a source whose provider state is fixed until Refresh
 // is called.
 func GetSourceSession(s string) SourceSession {
-	var source Source
-	switch strings.ToUpper(CanonicalizeNextTraceAPIProvider(s)) {
-	case "DN42":
-		return newDN42SourceSession()
-	case "NEXTTRACE-API":
-		source = NextTraceAPISource()
-	case "IP.SB":
-		source = IPSB
-	case "IPINSIGHT":
-		source = IPInSight
-	case "IPAPI.COM":
-		source = IPApiCom
-	case "IP-API.COM":
-		source = IPApiCom
-	case "IPINFO":
-		source = IPInfo
-	case "IPINFOLOCAL":
-		source = IPInfoLocal
-	case "CHUNZHEN":
-		source = Chunzhen
-	case "DISABLE-GEOIP":
-		source = disableGeoIP
-	case "IPDB.ONE":
-		source = IPDBOne
-	default:
-		source = NextTraceAPISource()
-	}
-	return SourceSession{Source: source}
+	return sourceSessionFromDescriptorSession(GetSourceDescriptorSession(s))
 }
 
 func GetSourceWithGeoDNS(s string, dotServer string) Source {
-	return GetSourceSessionWithGeoDNS(s, dotServer).Source
+	return GetSourceDescriptorWithGeoDNS(s, dotServer).Source
 }
 
 // GetSourceSessionWithGeoDNS applies a scoped DNS policy without changing the
 // session's refresh behavior.
 func GetSourceSessionWithGeoDNS(s string, dotServer string) SourceSession {
-	session := GetSourceSession(s)
-	base := session.Source
+	return sourceSessionFromDescriptorSession(GetSourceDescriptorSessionWithGeoDNS(s, dotServer))
+}
+
+// GetSourceDescriptor returns the current descriptor for provider s.
+func GetSourceDescriptor(s string) SourceDescriptor {
+	return GetSourceDescriptorSession(s).Current()
+}
+
+// GetSourceDescriptorWithGeoDNS returns the current descriptor with a scoped
+// DNS policy applied to its Source.
+func GetSourceDescriptorWithGeoDNS(s string, dotServer string) SourceDescriptor {
+	return GetSourceDescriptorSessionWithGeoDNS(s, dotServer).Current()
+}
+
+// GetSourceDescriptorSession returns a provider session with canonical cache
+// identity metadata.
+func GetSourceDescriptorSession(s string) SourceDescriptorSession {
+	return getSourceDescriptorSession(s, "", false)
+}
+
+// GetSourceDescriptorSessionWithGeoDNS applies a scoped DNS policy without
+// changing descriptor identity or refresh behavior.
+func GetSourceDescriptorSessionWithGeoDNS(s string, dotServer string) SourceDescriptorSession {
 	dotServer = strings.TrimSpace(strings.ToLower(dotServer))
-	if base == nil {
-		return session
+	return getSourceDescriptorSession(s, dotServer, true)
+}
+
+func getSourceDescriptorSession(s string, dotServer string, withGeoDNS bool) SourceDescriptorSession {
+	if sourceSelector(s) == "DN42" {
+		return newDN42SourceDescriptorSession(dotServer, withGeoDNS)
 	}
-	session.Source = func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
+
+	descriptor := sourceDescriptor(s)
+	descriptor.Source = applyGeoDNS(descriptor.Source, dotServer, withGeoDNS)
+	return SourceDescriptorSession{
+		Current: func() SourceDescriptor { return descriptor },
+	}
+}
+
+func sourceDescriptor(s string) SourceDescriptor {
+	switch sourceSelector(s) {
+	case "NEXTTRACE-API":
+		return nextTraceAPISourceDescriptor()
+	case "IP.SB":
+		return staticSourceDescriptor(IPSB, SourceNamespaceIPSB)
+	case "IPINSIGHT":
+		return staticSourceDescriptor(IPInSight, SourceNamespaceIPInsight)
+	case "IPAPI.COM", "IP-API.COM":
+		return staticSourceDescriptor(IPApiCom, SourceNamespaceIPAPI)
+	case "IPINFO":
+		return staticSourceDescriptor(IPInfo, SourceNamespaceIPInfo)
+	case "IPINFOLOCAL":
+		return staticSourceDescriptor(IPInfoLocal, SourceNamespaceIPInfoLocal)
+	case "CHUNZHEN":
+		return staticSourceDescriptor(Chunzhen, SourceNamespaceChunzhen)
+	case "DISABLE-GEOIP":
+		return staticSourceDescriptor(disableGeoIP, SourceNamespaceDisableGeoIP)
+	case "IPDB.ONE":
+		return staticSourceDescriptor(IPDBOne, SourceNamespaceIPDBOne)
+	default:
+		return nextTraceAPISourceDescriptor()
+	}
+}
+
+func sourceSelector(provider string) string {
+	return strings.ToUpper(strings.TrimSpace(CanonicalizeNextTraceAPIProvider(provider)))
+}
+
+func nextTraceAPISourceDescriptor() SourceDescriptor {
+	if NextTraceAPIV4TokenConfigured() {
+		return SourceDescriptor{
+			Source:    NextTraceAPIV4GeoIP,
+			Namespace: SourceNamespaceNextTraceAPI,
+			Backend:   SourceBackendNextTraceAPIV4,
+		}
+	}
+	return SourceDescriptor{
+		Source:    NextTraceAPIV3GeoIP,
+		Namespace: SourceNamespaceNextTraceAPI,
+		Backend:   SourceBackendNextTraceAPIV3,
+	}
+}
+
+func staticSourceDescriptor(source Source, namespace string) SourceDescriptor {
+	return SourceDescriptor{Source: source, Namespace: namespace, Backend: namespace}
+}
+
+func applyGeoDNS(source Source, dotServer string, enabled bool) Source {
+	if source == nil || !enabled {
+		return source
+	}
+	return func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
 		return util.WithGeoDNSResolver(dotServer, func() (*IPGeoData, error) {
-			return base(ip, timeout, lang, maptrace)
+			return source(ip, timeout, lang, maptrace)
 		})
 	}
-	return session
+}
+
+func sourceSessionFromDescriptorSession(session SourceDescriptorSession) SourceSession {
+	current := session.Current()
+	if session.Refresh == nil {
+		return SourceSession{Source: current.Source}
+	}
+	return SourceSession{
+		Source: func(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
+			return session.Current().Source(ip, timeout, lang, maptrace)
+		},
+		Refresh: session.Refresh,
+	}
 }
 
 func disableGeoIP(string, time.Duration, string, bool) (*IPGeoData, error) {

--- a/ipgeo/ipgeo_test.go
+++ b/ipgeo/ipgeo_test.go
@@ -52,6 +52,45 @@ func TestGetSourceMappings(t *testing.T) {
 	}
 }
 
+func TestGetSourceDescriptorMappings(t *testing.T) {
+	isolateNextTraceAPIV4TokenFiles(t)
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "")
+	tests := []struct {
+		name      string
+		input     string
+		want      Source
+		namespace string
+		backend   string
+	}{
+		{name: "nexttrace api", input: NextTraceAPIProvider, want: NextTraceAPIV3GeoIP, namespace: SourceNamespaceNextTraceAPI, backend: SourceBackendNextTraceAPIV3},
+		{name: "nexttrace legacy alias", input: "leomoeapi", want: NextTraceAPIV3GeoIP, namespace: SourceNamespaceNextTraceAPI, backend: SourceBackendNextTraceAPIV3},
+		{name: "ipsb", input: "ip.sb", want: IPSB, namespace: SourceNamespaceIPSB, backend: SourceNamespaceIPSB},
+		{name: "ipinsight", input: "IPInsight", want: IPInSight, namespace: SourceNamespaceIPInsight, backend: SourceNamespaceIPInsight},
+		{name: "ipapi alias", input: "IPAPI.COM", want: IPApiCom, namespace: SourceNamespaceIPAPI, backend: SourceNamespaceIPAPI},
+		{name: "ip-api alias", input: "ip-api.com", want: IPApiCom, namespace: SourceNamespaceIPAPI, backend: SourceNamespaceIPAPI},
+		{name: "ipinfo", input: "IPInfo", want: IPInfo, namespace: SourceNamespaceIPInfo, backend: SourceNamespaceIPInfo},
+		{name: "ipinfo whitespace", input: "  ipinfo\n", want: IPInfo, namespace: SourceNamespaceIPInfo, backend: SourceNamespaceIPInfo},
+		{name: "ipinfo local", input: "IPInfoLocal", want: IPInfoLocal, namespace: SourceNamespaceIPInfoLocal, backend: SourceNamespaceIPInfoLocal},
+		{name: "chunzhen", input: "ChunZhen", want: Chunzhen, namespace: SourceNamespaceChunzhen, backend: SourceNamespaceChunzhen},
+		{name: "disable geoip", input: "disable-geoip", want: disableGeoIP, namespace: SourceNamespaceDisableGeoIP, backend: SourceNamespaceDisableGeoIP},
+		{name: "ipdb one", input: "IPDB.One", want: IPDBOne, namespace: SourceNamespaceIPDBOne, backend: SourceNamespaceIPDBOne},
+		{name: "unknown fallback", input: "unknown", want: NextTraceAPIV3GeoIP, namespace: SourceNamespaceNextTraceAPI, backend: SourceBackendNextTraceAPIV3},
+		{name: "empty fallback", want: NextTraceAPIV3GeoIP, namespace: SourceNamespaceNextTraceAPI, backend: SourceBackendNextTraceAPIV3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			descriptor := GetSourceDescriptor(tc.input)
+			require.NotNil(t, descriptor.Source)
+			assert.Equal(t, reflect.ValueOf(tc.want).Pointer(), reflect.ValueOf(descriptor.Source).Pointer())
+			assert.Equal(t, tc.namespace, descriptor.Namespace)
+			assert.Equal(t, tc.backend, descriptor.Backend)
+			assert.False(t, descriptor.HasGeneration)
+			assert.Zero(t, descriptor.Generation)
+		})
+	}
+}
+
 func TestGetSourceSessionNonRefreshableProvider(t *testing.T) {
 	session := GetSourceSession("disable-geoip")
 	require.NotNil(t, session.Source)
@@ -98,6 +137,36 @@ func TestGetSourceUsesNextTraceAPIV4WhenTokenConfigured(t *testing.T) {
 	nonNextTrace := GetSource("IPInfo")
 	require.NotNil(t, nonNextTrace)
 	assert.Equal(t, reflect.ValueOf(IPInfo).Pointer(), reflect.ValueOf(nonNextTrace).Pointer())
+
+	descriptor := GetSourceDescriptor("leomoe")
+	assert.Equal(t, SourceNamespaceNextTraceAPI, descriptor.Namespace)
+	assert.Equal(t, SourceBackendNextTraceAPIV4, descriptor.Backend)
+	assert.Equal(t, reflect.ValueOf(NextTraceAPIV4GeoIP).Pointer(), reflect.ValueOf(descriptor.Source).Pointer())
+}
+
+func TestGetSourceDescriptorSessionStaticProvider(t *testing.T) {
+	session := GetSourceDescriptorSession("IPAPI.COM")
+	require.NotNil(t, session.Current)
+	assert.Nil(t, session.Refresh)
+
+	first := session.Current()
+	second := session.Current()
+	assert.Equal(t, SourceNamespaceIPAPI, first.Namespace)
+	assert.Equal(t, SourceNamespaceIPAPI, first.Backend)
+	assert.Equal(t, reflect.ValueOf(IPApiCom).Pointer(), reflect.ValueOf(first.Source).Pointer())
+	assert.Equal(t, reflect.ValueOf(first.Source).Pointer(), reflect.ValueOf(second.Source).Pointer())
+}
+
+func TestGetSourceDescriptorWithGeoDNSPreservesIdentity(t *testing.T) {
+	descriptor := GetSourceDescriptorWithGeoDNS("disable-geoip", " CloudFlare ")
+	require.NotNil(t, descriptor.Source)
+	assert.Equal(t, SourceNamespaceDisableGeoIP, descriptor.Namespace)
+	assert.Equal(t, SourceNamespaceDisableGeoIP, descriptor.Backend)
+	assert.False(t, descriptor.HasGeneration)
+
+	geo, err := descriptor.Source("192.0.2.1", time.Second, "en", false)
+	require.NoError(t, err)
+	assert.Equal(t, &IPGeoData{}, geo)
 }
 
 func TestDeprecatedNextTraceAPIWrappers(t *testing.T) {

--- a/server/trace_handler.go
+++ b/server/trace_handler.go
@@ -405,7 +405,9 @@ func buildTraceConfig(req traceRequest, method trace.Method, ip net.IP, dataProv
 		ostype = 2
 	}
 
-	session := ipgeo.GetSourceSessionWithGeoDNS(dataProvider, req.DotServer)
+	descriptorSession := ipgeo.GetSourceDescriptorSessionWithGeoDNS(dataProvider, req.DotServer)
+	descriptor := descriptorSession.Current()
+	session := trace.CachedGeoSourceSession(descriptorSession)
 	return trace.Config{
 		OSType:             ostype,
 		ICMPMode:           req.ICMPMode,
@@ -421,13 +423,14 @@ func buildTraceConfig(req traceRequest, method trace.Method, ip net.IP, dataProv
 		DstIP:              ip,
 		DstPort:            port,
 		IPGeoSource:        session.Source,
+		IPGeoDescriptor:    descriptorSession.Current,
 		RefreshIPGeoSource: session.Refresh,
 		RDNS:               !req.DisableRDNS,
 		AlwaysWaitRDNS:     alwaysWait,
 		PacketInterval:     req.PacketInterval,
 		TTLInterval:        req.TTLInterval,
 		Lang:               lang,
-		DN42:               req.DN42 || session.Refresh != nil,
+		DN42:               req.DN42 || descriptor.Namespace == ipgeo.SourceNamespaceDN42,
 		PktSize:            packetSizeSpec.PayloadSize,
 		RandomPacketSize:   packetSizeSpec.Random,
 		TOS:                tos,

--- a/server/trace_handler_test.go
+++ b/server/trace_handler_test.go
@@ -239,6 +239,12 @@ func TestBuildTraceConfig_PropagatesSessionScopedFields(t *testing.T) {
 	if cfg.IPGeoSource == nil {
 		t.Fatal("buildTraceConfig IPGeoSource = nil, want wrapped source")
 	}
+	if cfg.IPGeoDescriptor == nil {
+		t.Fatal("buildTraceConfig IPGeoDescriptor = nil")
+	}
+	if descriptor := cfg.IPGeoDescriptor(); descriptor.Namespace != ipgeo.SourceNamespaceIPInfo {
+		t.Fatalf("buildTraceConfig descriptor = %+v, want IPInfo", descriptor)
+	}
 	if cfg.TOS != 0 {
 		t.Fatalf("buildTraceConfig TOS = %d, want 0", cfg.TOS)
 	}
@@ -249,7 +255,7 @@ func TestBuildTraceConfig_DN42CarriesRefreshableSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildTraceConfig returned error: %v", err)
 	}
-	if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.RefreshIPGeoSource == nil {
+	if !cfg.DN42 || cfg.IPGeoSource == nil || cfg.IPGeoDescriptor == nil || cfg.RefreshIPGeoSource == nil {
 		t.Fatalf("DN42 config = %+v", cfg)
 	}
 }

--- a/trace/cache.go
+++ b/trace/cache.go
@@ -86,7 +86,7 @@ func (cache *geoCacheRuntime) lookup(
 	language string,
 	maptrace bool,
 ) (*ipgeo.IPGeoData, error) {
-	return cache.lookupContext(nil, descriptor, query, timeout, language, maptrace)
+	return cache.lookupContext(context.Background(), descriptor, query, timeout, language, maptrace)
 }
 
 func (cache *geoCacheRuntime) lookupContext(

--- a/trace/cache.go
+++ b/trace/cache.go
@@ -1,5 +1,391 @@
 package trace
 
+import (
+	"container/list"
+	"context"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+const (
+	geoCacheCapacity = 4096
+	geoCacheTTL      = 15 * time.Minute
+)
+
+type geoCacheKey struct {
+	namespace     string
+	backend       string
+	addr          netip.Addr
+	language      string
+	maptrace      bool
+	dn42Hostname  string
+	generation    uint64
+	hasGeneration bool
+}
+
+type geoCacheEntry struct {
+	key       geoCacheKey
+	value     *ipgeo.IPGeoData
+	expiresAt time.Time
+	epoch     uint64
+	element   *list.Element
+}
+
+type geoCacheRuntime struct {
+	mu       sync.Mutex
+	entries  sync.Map
+	fifo     list.List
+	size     int
+	epoch    atomic.Uint64
+	capacity int
+	ttl      time.Duration
+	now      func() time.Time
+	flights  singleflight.Group
+}
+
+var geoCache = newGeoCacheRuntime(geoCacheCapacity, geoCacheTTL, time.Now)
+
+func newGeoCacheRuntime(capacity int, ttl time.Duration, now func() time.Time) *geoCacheRuntime {
+	if now == nil {
+		now = time.Now
+	}
+	return &geoCacheRuntime{
+		capacity: capacity,
+		ttl:      ttl,
+		now:      now,
+	}
+}
+
+// ClearCaches invalidates all process-wide trace caches. In-flight Geo
+// lookups from the previous epoch cannot refill the cleared cache.
 func ClearCaches() {
-	geoCache.Clear()
+	geoCache.clear()
+}
+
+func (cache *geoCacheRuntime) clear() {
+	cache.mu.Lock()
+	cache.epoch.Add(1)
+	cache.entries.Clear()
+	cache.fifo.Init()
+	cache.size = 0
+	cache.mu.Unlock()
+}
+
+func (cache *geoCacheRuntime) lookup(
+	descriptor ipgeo.SourceDescriptor,
+	query string,
+	timeout time.Duration,
+	language string,
+	maptrace bool,
+) (*ipgeo.IPGeoData, error) {
+	return cache.lookupContext(nil, descriptor, query, timeout, language, maptrace)
+}
+
+func (cache *geoCacheRuntime) lookupContext(
+	ctx context.Context,
+	descriptor ipgeo.SourceDescriptor,
+	query string,
+	timeout time.Duration,
+	language string,
+	maptrace bool,
+) (*ipgeo.IPGeoData, error) {
+	if descriptor.Source == nil {
+		return nil, ErrNilGeoSource
+	}
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	key, cacheable := newGeoCacheKey(descriptor, query, language, maptrace)
+	if !cacheable {
+		return callGeoSourceWithContext(ctx, timeout, func() (*ipgeo.IPGeoData, error) {
+			return descriptor.Source(query, timeout, language, maptrace)
+		})
+	}
+	value, epoch, ok := cache.load(key)
+	if ok {
+		return value, nil
+	}
+	flightKey := encodeGeoFlightKey(epoch, key)
+	resultCh := cache.flights.DoChan(flightKey, func() (any, error) {
+		if cached, ok := cache.loadAtEpoch(key, epoch); ok {
+			return cached, nil
+		}
+		geo, lookupErr := descriptor.Source(key.sourceQuery(), timeout, key.language, maptrace)
+		if lookupErr == nil && geo != nil {
+			cache.storeAtEpoch(key, geo, epoch)
+		}
+		return geo, lookupErr
+	})
+	waitCtx, cancel := geoCacheWaitContext(ctx, timeout)
+	defer cancel()
+	select {
+	case <-waitCtx.Done():
+		return nil, waitCtx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		geo, _ := result.Val.(*ipgeo.IPGeoData)
+		return cloneGeoCacheValue(geo), nil
+	}
+}
+
+func (key geoCacheKey) sourceQuery() string {
+	query := key.addr.String()
+	if key.namespace == ipgeo.SourceNamespaceDN42 && key.dn42Hostname != "" {
+		query += "," + key.dn42Hostname
+	}
+	return query
+}
+
+func geoCacheWaitContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= timeout {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func callGeoSourceWithContext(
+	ctx context.Context,
+	timeout time.Duration,
+	lookup func() (*ipgeo.IPGeoData, error),
+) (*ipgeo.IPGeoData, error) {
+	waitCtx, cancel := geoCacheWaitContext(ctx, timeout)
+	defer cancel()
+	if waitCtx.Done() == nil {
+		return lookup()
+	}
+	type result struct {
+		geo *ipgeo.IPGeoData
+		err error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		geo, err := lookup()
+		resultCh <- result{geo: geo, err: err}
+	}()
+	select {
+	case <-waitCtx.Done():
+		return nil, waitCtx.Err()
+	case result := <-resultCh:
+		return result.geo, result.err
+	}
+}
+
+func (cache *geoCacheRuntime) load(key geoCacheKey) (*ipgeo.IPGeoData, uint64, bool) {
+	epoch := cache.epoch.Load()
+	entryValue, ok := cache.entries.Load(key)
+	if !ok {
+		return nil, epoch, false
+	}
+	entry := entryValue.(*geoCacheEntry)
+	currentEpoch := cache.epoch.Load()
+	if entry.epoch != epoch || currentEpoch != epoch {
+		return nil, currentEpoch, false
+	}
+	if cache.now().Before(entry.expiresAt) {
+		if cache.epoch.Load() == epoch {
+			return cloneGeoCacheValue(entry.value), epoch, true
+		}
+		return nil, cache.epoch.Load(), false
+	}
+	value, ok := cache.expireAndReload(key, epoch)
+	return value, epoch, ok
+}
+
+func (cache *geoCacheRuntime) loadAtEpoch(key geoCacheKey, epoch uint64) (*ipgeo.IPGeoData, bool) {
+	if cache.epoch.Load() != epoch {
+		return nil, false
+	}
+	entryValue, ok := cache.entries.Load(key)
+	if !ok {
+		return nil, false
+	}
+	entry := entryValue.(*geoCacheEntry)
+	if entry.epoch != epoch || cache.epoch.Load() != epoch {
+		return nil, false
+	}
+	if cache.now().Before(entry.expiresAt) {
+		return cloneGeoCacheValue(entry.value), cache.epoch.Load() == epoch
+	}
+	return cache.expireAndReload(key, epoch)
+}
+
+func (cache *geoCacheRuntime) expireAndReload(key geoCacheKey, epoch uint64) (*ipgeo.IPGeoData, bool) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if cache.epoch.Load() != epoch {
+		return nil, false
+	}
+	entryValue, ok := cache.entries.Load(key)
+	if !ok {
+		return nil, false
+	}
+	entry := entryValue.(*geoCacheEntry)
+	if entry.epoch != epoch {
+		return nil, false
+	}
+	if !cache.now().Before(entry.expiresAt) {
+		cache.deleteLocked(entry)
+		return nil, false
+	}
+	return cloneGeoCacheValue(entry.value), true
+}
+
+func (cache *geoCacheRuntime) storeAtEpoch(key geoCacheKey, value *ipgeo.IPGeoData, epoch uint64) bool {
+	if value == nil || cache.capacity <= 0 || cache.ttl <= 0 {
+		return false
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if cache.epoch.Load() != epoch {
+		return false
+	}
+	if previousValue, ok := cache.entries.Load(key); ok {
+		previous := previousValue.(*geoCacheEntry)
+		if cache.now().Before(previous.expiresAt) {
+			return false
+		}
+		cache.deleteLocked(previous)
+	}
+	for cache.size >= cache.capacity {
+		oldest := cache.fifo.Front()
+		if oldest == nil {
+			break
+		}
+		cache.deleteLocked(oldest.Value.(*geoCacheEntry))
+	}
+	entry := &geoCacheEntry{
+		key:       key,
+		value:     cloneGeoCacheValue(value),
+		expiresAt: cache.now().Add(cache.ttl),
+		epoch:     epoch,
+	}
+	entry.element = cache.fifo.PushBack(entry)
+	cache.entries.Store(key, entry)
+	cache.size++
+	return true
+}
+
+func cloneGeoCacheValue(value *ipgeo.IPGeoData) *ipgeo.IPGeoData {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	if value.Router == nil {
+		return &cloned
+	}
+	cloned.Router = make(map[string][]string, len(value.Router))
+	for asn, route := range value.Router {
+		if route == nil {
+			cloned.Router[asn] = nil
+			continue
+		}
+		clonedRoute := make([]string, len(route))
+		copy(clonedRoute, route)
+		cloned.Router[asn] = clonedRoute
+	}
+	return &cloned
+}
+
+func (cache *geoCacheRuntime) deleteLocked(entry *geoCacheEntry) {
+	if entry == nil {
+		return
+	}
+	current, ok := cache.entries.Load(entry.key)
+	if !ok || current != entry {
+		return
+	}
+	cache.entries.Delete(entry.key)
+	cache.fifo.Remove(entry.element)
+	cache.size--
+}
+
+func newGeoCacheKey(
+	descriptor ipgeo.SourceDescriptor,
+	query string,
+	language string,
+	maptrace bool,
+) (geoCacheKey, bool) {
+	if descriptor.Namespace == "" {
+		return geoCacheKey{}, false
+	}
+
+	ipText := query
+	hostname := ""
+	if descriptor.Namespace == ipgeo.SourceNamespaceDN42 {
+		ipText, hostname, _ = strings.Cut(query, ",")
+		hostname = normalizeDN42CacheHostname(hostname)
+	}
+	addr, err := netip.ParseAddr(strings.TrimSpace(ipText))
+	if err != nil {
+		return geoCacheKey{}, false
+	}
+	return geoCacheKey{
+		namespace:     descriptor.Namespace,
+		backend:       descriptor.Backend,
+		addr:          addr.Unmap(),
+		language:      normalizeGeoCacheLanguage(language),
+		maptrace:      maptrace,
+		dn42Hostname:  hostname,
+		generation:    descriptor.Generation,
+		hasGeneration: descriptor.HasGeneration,
+	}, true
+}
+
+func normalizeGeoCacheLanguage(language string) string {
+	return strings.ToLower(strings.TrimSpace(language))
+}
+
+func normalizeDN42CacheHostname(hostname string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(hostname), "."))
+}
+
+func encodeGeoFlightKey(epoch uint64, key geoCacheKey) string {
+	var encoded strings.Builder
+	encoded.WriteString(strconv.FormatUint(epoch, 10))
+	encoded.WriteByte('|')
+	appendGeoFlightKeyPart(&encoded, key.namespace)
+	appendGeoFlightKeyPart(&encoded, key.backend)
+	appendGeoFlightKeyPart(&encoded, key.addr.String())
+	appendGeoFlightKeyPart(&encoded, key.language)
+	if key.maptrace {
+		encoded.WriteByte('1')
+	} else {
+		encoded.WriteByte('0')
+	}
+	appendGeoFlightKeyPart(&encoded, key.dn42Hostname)
+	encoded.WriteString(strconv.FormatUint(key.generation, 10))
+	encoded.WriteByte('|')
+	if key.hasGeneration {
+		encoded.WriteByte('1')
+	} else {
+		encoded.WriteByte('0')
+	}
+	return encoded.String()
+}
+
+func appendGeoFlightKeyPart(encoded *strings.Builder, value string) {
+	encoded.WriteString(strconv.Itoa(len(value)))
+	encoded.WriteByte(':')
+	encoded.WriteString(value)
+	encoded.WriteByte('|')
 }

--- a/trace/cache_test.go
+++ b/trace/cache_test.go
@@ -1,0 +1,681 @@
+package trace
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+type fakeGeoCacheClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *fakeGeoCacheClock) current() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *fakeGeoCacheClock) advance(delta time.Duration) {
+	clock.mu.Lock()
+	clock.now = clock.now.Add(delta)
+	clock.mu.Unlock()
+}
+
+func TestGeoCacheDefaults(t *testing.T) {
+	if geoCacheCapacity != 4096 {
+		t.Fatalf("geo cache capacity = %d, want 4096", geoCacheCapacity)
+	}
+	if geoCacheTTL != 15*time.Minute {
+		t.Fatalf("geo cache TTL = %s, want 15m", geoCacheTTL)
+	}
+}
+
+func TestGeoCacheRuntimeDefaultCapacityEvictsFirstEntry(t *testing.T) {
+	cache := newGeoCacheRuntime(geoCacheCapacity, time.Hour, time.Now)
+	descriptor := geoCacheTestDescriptor(nil)
+	data := &ipgeo.IPGeoData{Asnumber: "64512"}
+	firstKey := benchmarkGeoCacheKey(0)
+	for i := range geoCacheCapacity + 1 {
+		key := benchmarkGeoCacheKey(uint32(i))
+		if !cache.storeAtEpoch(key, data, 0) {
+			t.Fatalf("store %d failed", i)
+		}
+	}
+	if cache.size != geoCacheCapacity {
+		t.Fatalf("cache size = %d, want %d", cache.size, geoCacheCapacity)
+	}
+	if _, _, ok := cache.load(firstKey); ok {
+		t.Fatal("first entry remained after default-capacity FIFO eviction")
+	}
+	lastKey := mustGeoCacheKey(t, descriptor, "0.0.16.0")
+	if _, _, ok := cache.load(lastKey); !ok {
+		t.Fatal("newest entry missing after default-capacity FIFO eviction")
+	}
+}
+
+func TestGeoCacheKeyIncludesAllResultDimensions(t *testing.T) {
+	descriptor := ipgeo.SourceDescriptor{
+		Namespace:     ipgeo.SourceNamespaceIPSB,
+		Backend:       ipgeo.SourceNamespaceIPSB,
+		Generation:    7,
+		HasGeneration: true,
+	}
+	base, ok := newGeoCacheKey(descriptor, "192.0.2.1", " EN ", false)
+	if !ok {
+		t.Fatal("newGeoCacheKey() rejected valid descriptor")
+	}
+	mapped, ok := newGeoCacheKey(descriptor, "::ffff:192.0.2.1", "en", false)
+	if !ok || mapped != base {
+		t.Fatalf("mapped IPv4 key = (%+v, %v), want %+v", mapped, ok, base)
+	}
+	ipv6Expanded, ok := newGeoCacheKey(descriptor, "2001:0db8:0000:0000:0000:0000:0000:0001", "en", false)
+	if !ok {
+		t.Fatal("newGeoCacheKey() rejected expanded IPv6")
+	}
+	ipv6Compressed, ok := newGeoCacheKey(descriptor, "2001:db8::1", "en", false)
+	if !ok || ipv6Compressed != ipv6Expanded {
+		t.Fatalf("equivalent IPv6 keys = (%+v, %+v, %v), want equal", ipv6Expanded, ipv6Compressed, ok)
+	}
+
+	tests := []struct {
+		name       string
+		descriptor ipgeo.SourceDescriptor
+		language   string
+		maptrace   bool
+	}{
+		{name: "namespace", descriptor: withGeoCacheDescriptorNamespace(descriptor, ipgeo.SourceNamespaceIPInfo), language: "en"},
+		{name: "backend", descriptor: withGeoCacheDescriptorBackend(descriptor, "other"), language: "en"},
+		{name: "language", descriptor: descriptor, language: "cn"},
+		{name: "maptrace", descriptor: descriptor, language: "en", maptrace: true},
+		{name: "generation", descriptor: withGeoCacheDescriptorGeneration(descriptor, 8, true), language: "en"},
+		{name: "generation-presence", descriptor: withGeoCacheDescriptorGeneration(descriptor, 7, false), language: "en"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, valid := newGeoCacheKey(test.descriptor, "192.0.2.1", test.language, test.maptrace)
+			if !valid || got == base {
+				t.Fatalf("newGeoCacheKey() = (%+v, %v), want key distinct from %+v", got, valid, base)
+			}
+		})
+	}
+
+	dn42Descriptor := ipgeo.SourceDescriptor{
+		Namespace:     ipgeo.SourceNamespaceDN42,
+		Backend:       ipgeo.SourceBackendDN42GeoFeed,
+		Generation:    7,
+		HasGeneration: true,
+	}
+	dn42A, ok := newGeoCacheKey(dn42Descriptor, "172.20.0.1,router-a.dn42", "en", false)
+	if !ok {
+		t.Fatal("newGeoCacheKey() rejected DN42 query")
+	}
+	dn42Equivalent, ok := newGeoCacheKey(dn42Descriptor, "172.20.0.1, ROUTER-A.DN42. ", "en", false)
+	if !ok || dn42Equivalent != dn42A {
+		t.Fatalf("equivalent DN42 hostname key = (%+v, %v), want %+v", dn42Equivalent, ok, dn42A)
+	}
+	dn42B, ok := newGeoCacheKey(dn42Descriptor, "172.20.0.1,router-b.dn42", "en", false)
+	if !ok || dn42A == dn42B {
+		t.Fatalf("DN42 hostname keys = (%+v, %+v, %v), want distinct", dn42A, dn42B, ok)
+	}
+}
+
+func TestGeoCacheKeyUsesCanonicalProviderAliasAndBackend(t *testing.T) {
+	cache := newGeoCacheRuntime(4, time.Hour, time.Now)
+	var aliasCalls atomic.Int32
+	aliasSource := func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		aliasCalls.Add(1)
+		return &ipgeo.IPGeoData{IP: query}, nil
+	}
+	ipAPICom := ipgeo.GetSourceDescriptor("IPAPI.COM")
+	ipDashAPICom := ipgeo.GetSourceDescriptor("ip-api.com")
+	ipAPICom.Source = aliasSource
+	ipDashAPICom.Source = aliasSource
+	aliasKey, ok := newGeoCacheKey(ipAPICom, "1.1.1.1", "en", false)
+	if !ok {
+		t.Fatal("newGeoCacheKey() rejected IPAPI.COM descriptor")
+	}
+	canonicalKey, ok := newGeoCacheKey(ipDashAPICom, "1.1.1.1", "en", false)
+	if !ok || canonicalKey != aliasKey {
+		t.Fatalf("provider alias keys = (%+v, %+v, %v), want equal", aliasKey, canonicalKey, ok)
+	}
+	mustGeoCacheLookup(t, cache, ipAPICom, "1.1.1.1")
+	mustGeoCacheLookup(t, cache, ipDashAPICom, "1.1.1.1")
+	if got := aliasCalls.Load(); got != 1 {
+		t.Fatalf("provider alias source calls = %d, want 1", got)
+	}
+
+	var backendCalls atomic.Int32
+	backendSource := func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		return &ipgeo.IPGeoData{IP: query, Asnumber: strconv.Itoa(int(backendCalls.Add(1)))}, nil
+	}
+	v3 := ipgeo.SourceDescriptor{
+		Source:    backendSource,
+		Namespace: ipgeo.SourceNamespaceNextTraceAPI,
+		Backend:   ipgeo.SourceBackendNextTraceAPIV3,
+	}
+	v4 := v3
+	v4.Backend = ipgeo.SourceBackendNextTraceAPIV4
+	v3Key, ok := newGeoCacheKey(v3, "1.1.1.1", "en", false)
+	if !ok {
+		t.Fatal("newGeoCacheKey() rejected NextTrace v3 descriptor")
+	}
+	v4Key, ok := newGeoCacheKey(v4, "1.1.1.1", "en", false)
+	if !ok || v4Key == v3Key {
+		t.Fatalf("NextTrace backend keys = (%+v, %+v, %v), want distinct", v3Key, v4Key, ok)
+	}
+	v3Geo := mustGeoCacheLookup(t, cache, v3, "1.1.1.1")
+	v4Geo := mustGeoCacheLookup(t, cache, v4, "1.1.1.1")
+	if backendCalls.Load() != 2 || v3Geo.Asnumber == v4Geo.Asnumber {
+		t.Fatalf("backend results = (%+v, %+v), calls %d; want distinct lookups", v3Geo, v4Geo, backendCalls.Load())
+	}
+}
+
+func TestGeoCacheRuntimeCanonicalizesDN42SourceInputs(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	var gotQuery string
+	var gotLanguage string
+	var calls atomic.Int32
+	descriptor := ipgeo.SourceDescriptor{
+		Source: func(query string, _ time.Duration, language string, _ bool) (*ipgeo.IPGeoData, error) {
+			calls.Add(1)
+			gotQuery = query
+			gotLanguage = language
+			return &ipgeo.IPGeoData{IP: query}, nil
+		},
+		Namespace:     ipgeo.SourceNamespaceDN42,
+		Backend:       ipgeo.SourceBackendDN42GeoFeed,
+		Generation:    1,
+		HasGeneration: true,
+	}
+	first, err := cache.lookup(descriptor, "::ffff:172.20.0.1, ROUTER.DN42. ", time.Second, " CN ", false)
+	if err != nil {
+		t.Fatalf("cache lookup error = %v", err)
+	}
+	if gotQuery != "172.20.0.1,router.dn42" || gotLanguage != "cn" {
+		t.Fatalf("source inputs = (%q, %q), want canonical DN42 query and language", gotQuery, gotLanguage)
+	}
+	second, err := cache.lookup(descriptor, "172.20.0.1,router.dn42", time.Second, "cn", false)
+	if err != nil {
+		t.Fatalf("equivalent cache lookup error = %v", err)
+	}
+	if first.IP != "172.20.0.1,router.dn42" || second.IP != first.IP {
+		t.Fatalf("lookup IPs = (%q, %q), want identical canonical query", first.IP, second.IP)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("source calls = %d, want equivalent inputs to share one key", got)
+	}
+}
+
+func TestGeoCacheRuntimeCanonicalizesSourceAddress(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{IP: query}, nil
+	})
+
+	first := mustGeoCacheLookup(t, cache, descriptor, "::ffff:192.0.2.1")
+	second := mustGeoCacheLookup(t, cache, descriptor, "192.0.2.1")
+	if first.IP != "192.0.2.1" || second.IP != first.IP {
+		t.Fatalf("lookup IPs = (%q, %q), want identical canonical address", first.IP, second.IP)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("source calls = %d, want mapped and canonical addresses to share one lookup", got)
+	}
+}
+
+func TestGeoCacheRuntimeAbsoluteTTL(t *testing.T) {
+	clock := &fakeGeoCacheClock{now: time.Unix(1_700_000_000, 0)}
+	cache := newGeoCacheRuntime(2, 15*time.Minute, clock.current)
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{IP: query}, nil
+	})
+
+	mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	clock.advance(14 * time.Minute)
+	mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	clock.advance(time.Minute)
+	mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("source calls = %d, want 2 after absolute TTL expiry", got)
+	}
+}
+
+func TestGeoCacheRuntimeFIFOHitDoesNotPromote(t *testing.T) {
+	clock := &fakeGeoCacheClock{now: time.Unix(1_700_000_000, 0)}
+	cache := newGeoCacheRuntime(2, time.Hour, clock.current)
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{IP: query}, nil
+	})
+
+	mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	mustGeoCacheLookup(t, cache, descriptor, "8.8.8.8")
+	mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	mustGeoCacheLookup(t, cache, descriptor, "9.9.9.9")
+	mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("source calls = %d, want 4 when hit does not promote FIFO entry", got)
+	}
+}
+
+func TestGeoCacheRuntimeDuplicateStoreDoesNotRefreshTTLOrFIFO(t *testing.T) {
+	clock := &fakeGeoCacheClock{now: time.Unix(1_700_000_000, 0)}
+	cache := newGeoCacheRuntime(2, 15*time.Minute, clock.current)
+	descriptor := geoCacheTestDescriptor(nil)
+	keyA := mustGeoCacheKey(t, descriptor, "1.1.1.1")
+	keyB := mustGeoCacheKey(t, descriptor, "8.8.8.8")
+	keyC := mustGeoCacheKey(t, descriptor, "9.9.9.9")
+	old := &ipgeo.IPGeoData{Asnumber: "OLD"}
+	newValue := &ipgeo.IPGeoData{Asnumber: "NEW"}
+	if !cache.storeAtEpoch(keyA, old, 0) || !cache.storeAtEpoch(keyB, old, 0) {
+		t.Fatal("initial cache store failed")
+	}
+	clock.advance(14 * time.Minute)
+	if cache.storeAtEpoch(keyA, newValue, 0) {
+		t.Fatal("duplicate store replaced a live entry")
+	}
+	if !cache.storeAtEpoch(keyC, old, 0) {
+		t.Fatal("third cache store failed")
+	}
+	if _, _, ok := cache.load(keyA); ok {
+		t.Fatal("duplicate store promoted the oldest FIFO entry")
+	}
+}
+
+func TestGeoCacheRuntimeDuplicateStoreDoesNotRenewAbsoluteTTL(t *testing.T) {
+	clock := &fakeGeoCacheClock{now: time.Unix(1_700_000_000, 0)}
+	cache := newGeoCacheRuntime(1, 15*time.Minute, clock.current)
+	key := mustGeoCacheKey(t, geoCacheTestDescriptor(nil), "1.1.1.1")
+	if !cache.storeAtEpoch(key, &ipgeo.IPGeoData{Asnumber: "OLD"}, 0) {
+		t.Fatal("initial cache store failed")
+	}
+	clock.advance(14 * time.Minute)
+	if cache.storeAtEpoch(key, &ipgeo.IPGeoData{Asnumber: "NEW"}, 0) {
+		t.Fatal("duplicate store replaced a live entry")
+	}
+	clock.advance(time.Minute)
+	if _, _, ok := cache.load(key); ok {
+		t.Fatal("duplicate store renewed absolute TTL")
+	}
+}
+
+func TestGeoCacheRuntimeDoesNotCacheErrorOrNil(t *testing.T) {
+	wantErr := errors.New("lookup failed")
+	for _, test := range []struct {
+		name  string
+		first func() (*ipgeo.IPGeoData, error)
+	}{
+		{name: "error", first: func() (*ipgeo.IPGeoData, error) { return nil, wantErr }},
+		{name: "nil", first: func() (*ipgeo.IPGeoData, error) { return nil, nil }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+			var calls atomic.Int32
+			descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+				if calls.Add(1) == 1 {
+					return test.first()
+				}
+				return &ipgeo.IPGeoData{IP: query}, nil
+			})
+
+			_, _ = cache.lookup(descriptor, "1.1.1.1", time.Second, "en", false)
+			mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+			if got := calls.Load(); got != 2 {
+				t.Fatalf("source calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestGeoCacheRuntimeReturnsIndependentCopies(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{
+			IP:       query,
+			Asnumber: "64512",
+			Router:   map[string][]string{"64512": {"64513", "64514"}},
+		}, nil
+	})
+
+	first := mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	first.Asnumber = "MUTATED"
+	first.Router["64512"][0] = "MUTATED"
+	first.Router["other"] = []string{"MUTATED"}
+
+	second := mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	if first == second {
+		t.Fatal("cache hit returned the first caller's pointer")
+	}
+	if second.Asnumber != "64512" {
+		t.Fatalf("cached scalar = %q, want 64512", second.Asnumber)
+	}
+	if got := second.Router["64512"]; len(got) != 2 || got[0] != "64513" || got[1] != "64514" {
+		t.Fatalf("cached router = %#v, want independent original route", second.Router)
+	}
+	if _, ok := second.Router["other"]; ok {
+		t.Fatalf("cached router inherited caller mutation: %#v", second.Router)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("source calls = %d, want 1", got)
+	}
+}
+
+func TestGeoCacheRuntimeEmptyNamespaceBypassesCacheAndSingleflight(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var calls atomic.Int32
+	descriptor := ipgeo.SourceDescriptor{Source: func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		return &ipgeo.IPGeoData{IP: query}, nil
+	}}
+
+	done := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := cache.lookup(descriptor, "1.1.1.1", time.Second, "en", false)
+			done <- err
+		}()
+	}
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("unnamespaced source calls joined singleflight")
+		}
+	}
+	close(release)
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatalf("lookup error = %v", err)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("source calls = %d, want 2", got)
+	}
+}
+
+func TestGeoCacheRuntimeCoalesces32ConcurrentLookups(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return &ipgeo.IPGeoData{
+			IP:     query,
+			Router: map[string][]string{"64512": {"64513"}},
+		}, nil
+	})
+
+	const concurrency = 32
+	ready := make(chan struct{}, concurrency)
+	begin := make(chan struct{})
+	type lookupResult struct {
+		geo *ipgeo.IPGeoData
+		err error
+	}
+	done := make(chan lookupResult, concurrency)
+	for range concurrency {
+		go func() {
+			ready <- struct{}{}
+			<-begin
+			geo, err := cache.lookup(descriptor, "1.1.1.1", time.Second, "en", false)
+			done <- lookupResult{geo: geo, err: err}
+		}()
+	}
+	for range concurrency {
+		<-ready
+	}
+	close(begin)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("source lookup did not start")
+	}
+	close(release)
+	results := make([]*ipgeo.IPGeoData, 0, concurrency)
+	seen := make(map[*ipgeo.IPGeoData]struct{}, concurrency)
+	for range concurrency {
+		result := <-done
+		if result.err != nil {
+			t.Fatalf("concurrent lookup error = %v", result.err)
+		}
+		if result.geo == nil {
+			t.Fatal("concurrent lookup result = nil")
+		}
+		if _, ok := seen[result.geo]; ok {
+			t.Fatal("concurrent singleflight waiters shared an IPGeoData pointer")
+		}
+		seen[result.geo] = struct{}{}
+		results = append(results, result.geo)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("source calls = %d, want 1 for 32 concurrent lookups", got)
+	}
+	results[0].Router["64512"][0] = "MUTATED"
+	results[0].Router["other"] = []string{"MUTATED"}
+	for i, geo := range results[1:] {
+		if got := geo.Router["64512"]; len(got) != 1 || got[0] != "64513" {
+			t.Fatalf("waiter %d router = %#v, want independent route", i+1, geo.Router)
+		}
+		if _, ok := geo.Router["other"]; ok {
+			t.Fatalf("waiter %d router inherited map mutation: %#v", i+1, geo.Router)
+		}
+	}
+}
+
+func TestGeoCacheRuntimeClearIsEpochBarrier(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	started := make(chan int32, 2)
+	releaseOld := make(chan struct{})
+	releaseNew := make(chan struct{})
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		call := calls.Add(1)
+		started <- call
+		if call == 1 {
+			<-releaseOld
+		} else {
+			<-releaseNew
+		}
+		return &ipgeo.IPGeoData{IP: query, Asnumber: strconv.Itoa(int(call))}, nil
+	})
+
+	oldDone := make(chan *ipgeo.IPGeoData, 1)
+	go func() {
+		geo, _ := cache.lookup(descriptor, "1.1.1.1", time.Second, "en", false)
+		oldDone <- geo
+	}()
+	if call := <-started; call != 1 {
+		t.Fatalf("first source call = %d, want 1", call)
+	}
+
+	cache.clear()
+	newDone := make(chan *ipgeo.IPGeoData, 1)
+	go func() {
+		geo, _ := cache.lookup(descriptor, "1.1.1.1", time.Second, "en", false)
+		newDone <- geo
+	}()
+	select {
+	case call := <-started:
+		if call != 2 {
+			t.Fatalf("post-clear source call = %d, want 2", call)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("post-clear lookup joined pre-clear flight")
+	}
+
+	close(releaseNew)
+	if geo := <-newDone; geo == nil || geo.Asnumber != "2" {
+		t.Fatalf("post-clear result = %+v, want call 2", geo)
+	}
+	close(releaseOld)
+	if geo := <-oldDone; geo == nil || geo.Asnumber != "1" {
+		t.Fatalf("pre-clear result = %+v, want call 1", geo)
+	}
+	geo := mustGeoCacheLookup(t, cache, descriptor, "1.1.1.1")
+	if geo.Asnumber != "2" {
+		t.Fatalf("cached result after old flight completed = %+v, want call 2", geo)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("source calls = %d, want 2", got)
+	}
+}
+
+func TestGeoCacheRuntimeFollowerUsesOwnDeadline(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return &ipgeo.IPGeoData{IP: query}, nil
+	})
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := cache.lookupContext(context.Background(), descriptor, "1.1.1.1", time.Hour, "en", false)
+		firstDone <- err
+	}()
+	<-started
+
+	followerCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	_, err := cache.lookupContext(followerCtx, descriptor, "1.1.1.1", time.Hour, "en", false)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("follower error = %v, want context.DeadlineExceeded", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("source calls = %d, want follower to join one flight", got)
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first lookup error = %v", err)
+	}
+}
+
+func TestGeoCacheRuntimeHitDoesNotStartSource(t *testing.T) {
+	cache := newGeoCacheRuntime(2, time.Hour, time.Now)
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return nil, errors.New("source must not run")
+	})
+	key := mustGeoCacheKey(t, descriptor, "1.1.1.1")
+	if !cache.storeAtEpoch(key, &ipgeo.IPGeoData{IP: "1.1.1.1"}, 0) {
+		t.Fatal("cache seed failed")
+	}
+	geo, err := cache.lookupContext(t.Context(), descriptor, "1.1.1.1", time.Second, "en", false)
+	if err != nil || geo == nil || geo.IP != "1.1.1.1" {
+		t.Fatalf("cache hit = (%+v, %v), want seeded value", geo, err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("source calls = %d, want 0 on cache hit", got)
+	}
+}
+
+func TestCachedGeoSourceSessionReadsCurrentDescriptor(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var generation atomic.Uint64
+	generation.Store(1)
+	var calls atomic.Int32
+	source := func(query string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{IP: query, Asnumber: strconv.FormatUint(generation.Load(), 10)}, nil
+	}
+	session := CachedGeoSourceSession(ipgeo.SourceDescriptorSession{
+		Current: func() ipgeo.SourceDescriptor {
+			return ipgeo.SourceDescriptor{
+				Source:        source,
+				Namespace:     ipgeo.SourceNamespaceDN42,
+				Backend:       ipgeo.SourceBackendDN42GeoFeed,
+				Generation:    generation.Load(),
+				HasGeneration: true,
+			}
+		},
+		Refresh: func() { generation.Add(1) },
+	})
+
+	first, err := session.Source("172.20.0.1,router.dn42", time.Second, "en", false)
+	if err != nil {
+		t.Fatalf("first lookup error = %v", err)
+	}
+	session.Refresh()
+	second, err := session.Source("172.20.0.1,router.dn42", time.Second, "en", false)
+	if err != nil {
+		t.Fatalf("second lookup error = %v", err)
+	}
+	if first.Asnumber != "1" || second.Asnumber != "2" || calls.Load() != 2 {
+		t.Fatalf("session results = (%+v, %+v), calls %d; want generations 1 and 2", first, second, calls.Load())
+	}
+}
+
+func geoCacheTestDescriptor(source ipgeo.Source) ipgeo.SourceDescriptor {
+	return ipgeo.SourceDescriptor{
+		Source:    source,
+		Namespace: ipgeo.SourceNamespaceIPSB,
+		Backend:   ipgeo.SourceNamespaceIPSB,
+	}
+}
+
+func withGeoCacheDescriptorNamespace(descriptor ipgeo.SourceDescriptor, namespace string) ipgeo.SourceDescriptor {
+	descriptor.Namespace = namespace
+	return descriptor
+}
+
+func withGeoCacheDescriptorBackend(descriptor ipgeo.SourceDescriptor, backend string) ipgeo.SourceDescriptor {
+	descriptor.Backend = backend
+	return descriptor
+}
+
+func withGeoCacheDescriptorGeneration(descriptor ipgeo.SourceDescriptor, generation uint64, present bool) ipgeo.SourceDescriptor {
+	descriptor.Generation = generation
+	descriptor.HasGeneration = present
+	return descriptor
+}
+
+func mustGeoCacheLookup(t *testing.T, cache *geoCacheRuntime, descriptor ipgeo.SourceDescriptor, query string) *ipgeo.IPGeoData {
+	t.Helper()
+	geo, err := cache.lookup(descriptor, query, time.Second, "en", false)
+	if err != nil {
+		t.Fatalf("cache lookup error = %v", err)
+	}
+	if geo == nil {
+		t.Fatal("cache lookup result = nil")
+	}
+	return geo
+}
+
+func mustGeoCacheKey(t testing.TB, descriptor ipgeo.SourceDescriptor, query string) geoCacheKey {
+	t.Helper()
+	key, ok := newGeoCacheKey(descriptor, query, "en", false)
+	if !ok {
+		t.Fatalf("newGeoCacheKey(%q) rejected valid query", query)
+	}
+	return key
+}

--- a/trace/geo_cache_benchmark_test.go
+++ b/trace/geo_cache_benchmark_test.go
@@ -1,63 +1,154 @@
 package trace
 
 import (
+	"net/netip"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 )
 
 var (
-	benchmarkGeoCacheDataSink  *ipgeo.IPGeoData
-	benchmarkGeoCacheValueSink any
-	benchmarkGeoCacheOKSink    bool
+	benchmarkGeoCacheDataSink *ipgeo.IPGeoData
+	benchmarkGeoCacheOKSink   bool
 )
 
 func BenchmarkGeoCacheAccess(b *testing.B) {
-	const (
-		hitKey  = "benchmark-geo-cache-hit"
-		missKey = "benchmark-geo-cache-miss"
-	)
-	geoCache.Store(hitKey, &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335"})
-	geoCache.Delete(missKey)
-	b.Cleanup(func() {
-		geoCache.Delete(hitKey)
-		geoCache.Delete(missKey)
-	})
+	const epoch = 0
+	now := time.Unix(1_700_000_000, 0)
+	descriptor := geoCacheTestDescriptor(nil)
+	hitKey := mustGeoCacheKey(b, descriptor, "1.1.1.1")
+	missKey := mustGeoCacheKey(b, descriptor, "8.8.8.8")
+	data := &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335"}
 
 	b.Run("Hit", func(b *testing.B) {
+		cache := newGeoCacheRuntime(geoCacheCapacity, geoCacheTTL, func() time.Time { return now })
+		cache.storeAtEpoch(hitKey, data, epoch)
 		b.ReportAllocs()
-		var (
-			data *ipgeo.IPGeoData
-			ok   bool
-		)
+		var value *ipgeo.IPGeoData
+		var ok bool
 		for b.Loop() {
-			value, loaded := geoCache.Load(hitKey)
-			if loaded {
-				data, ok = value.(*ipgeo.IPGeoData)
-			} else {
-				data, ok = nil, false
-			}
+			value, _, ok = cache.load(hitKey)
 		}
-		if !ok || data == nil {
+		if !ok || value == nil {
 			b.Fatal("geo cache hit benchmark did not load the seeded value")
 		}
-		benchmarkGeoCacheDataSink = data
+		benchmarkGeoCacheDataSink = value
 		benchmarkGeoCacheOKSink = ok
 	})
 
 	b.Run("Miss", func(b *testing.B) {
+		cache := newGeoCacheRuntime(geoCacheCapacity, geoCacheTTL, func() time.Time { return now })
 		b.ReportAllocs()
-		var (
-			value any
-			ok    bool
-		)
+		var value *ipgeo.IPGeoData
+		var ok bool
 		for b.Loop() {
-			value, ok = geoCache.Load(missKey)
+			value, _, ok = cache.load(missKey)
 		}
 		if ok {
 			b.Fatal("geo cache miss benchmark unexpectedly loaded a value")
 		}
-		benchmarkGeoCacheValueSink = value
+		benchmarkGeoCacheDataSink = value
 		benchmarkGeoCacheOKSink = ok
 	})
+
+	b.Run("Eviction", func(b *testing.B) {
+		cache := newGeoCacheRuntime(geoCacheCapacity, geoCacheTTL, func() time.Time { return now })
+		keys := make([]geoCacheKey, geoCacheCapacity*2)
+		for i := range keys {
+			keys[i] = benchmarkGeoCacheKey(uint32(i))
+		}
+		b.ReportAllocs()
+		index := 0
+		for b.Loop() {
+			cache.storeAtEpoch(keys[index], data, epoch)
+			index++
+			if index == len(keys) {
+				index = 0
+			}
+		}
+	})
+
+	b.Run("Parallel", func(b *testing.B) {
+		cache := newGeoCacheRuntime(geoCacheCapacity, geoCacheTTL, func() time.Time { return now })
+		cache.storeAtEpoch(hitKey, data, epoch)
+		b.ReportAllocs()
+		b.RunParallel(func(parallel *testing.PB) {
+			for parallel.Next() {
+				cache.load(hitKey)
+			}
+		})
+		b.StopTimer()
+		benchmarkGeoCacheDataSink, _, benchmarkGeoCacheOKSink = cache.load(hitKey)
+	})
+
+	b.Run("LookupHit", func(b *testing.B) {
+		ClearCaches()
+		b.Cleanup(ClearCaches)
+		lookupDescriptor := descriptor
+		lookupDescriptor.Source = func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			return data, nil
+		}
+		source := CachedGeoSource(lookupDescriptor)
+		if _, err := source("1.1.1.1", time.Second, "en", false); err != nil {
+			b.Fatalf("seed geo cache: %v", err)
+		}
+		b.ReportAllocs()
+		var value *ipgeo.IPGeoData
+		var err error
+		for b.Loop() {
+			value, err = source("1.1.1.1", time.Second, "en", false)
+		}
+		if err != nil || value == nil {
+			b.Fatalf("cached source hit = (%+v, %v), want value", value, err)
+		}
+		benchmarkGeoCacheDataSink = value
+	})
+
+	b.Run("ParallelLookupHit", func(b *testing.B) {
+		ClearCaches()
+		b.Cleanup(ClearCaches)
+		lookupDescriptor := descriptor
+		lookupDescriptor.Source = func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			return data, nil
+		}
+		source := CachedGeoSource(lookupDescriptor)
+		if _, err := source("1.1.1.1", time.Second, "en", false); err != nil {
+			b.Fatalf("seed geo cache: %v", err)
+		}
+		b.ReportAllocs()
+		var failed atomic.Bool
+		b.RunParallel(func(parallel *testing.PB) {
+			for parallel.Next() {
+				value, err := source("1.1.1.1", time.Second, "en", false)
+				if err != nil || value == nil {
+					failed.Store(true)
+				}
+			}
+		})
+		b.StopTimer()
+		if failed.Load() {
+			b.Fatal("cached source parallel hit failed")
+		}
+		var err error
+		benchmarkGeoCacheDataSink, err = source("1.1.1.1", time.Second, "en", false)
+		if err != nil {
+			b.Fatalf("cached source final hit: %v", err)
+		}
+	})
+}
+
+func benchmarkGeoCacheKey(value uint32) geoCacheKey {
+	return geoCacheKey{
+		namespace: ipgeo.SourceNamespaceIPSB,
+		backend:   ipgeo.SourceNamespaceIPSB,
+		addr: netip.AddrFrom4([4]byte{
+			byte(value >> 24),
+			byte(value >> 16),
+			byte(value >> 8),
+			byte(value),
+		}),
+		language: "en",
+	}
 }

--- a/trace/geo_lookup.go
+++ b/trace/geo_lookup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 )
@@ -16,18 +17,78 @@ var (
 	ErrNotIPGeoQuery = errors.New("geo lookup target is not an IP address")
 )
 
-// LookupIPGeo reuses traceroute's shared GeoIP cache/retry path for direct IP metadata lookups.
+// LookupIPGeo performs a direct IP metadata lookup. A bare Source has no safe
+// cross-call identity and therefore bypasses process-wide cache and singleflight.
 func LookupIPGeo(ctx context.Context, source ipgeo.Source, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
 	return lookupIPGeo(ctx, ipgeo.SourceSession{Source: source}, lang, maptrace, numMeasurements, query)
 }
 
+// LookupIPGeoWithDescriptor performs a direct lookup with descriptor-scoped
+// caching and request coalescing.
+func LookupIPGeoWithDescriptor(ctx context.Context, descriptor ipgeo.SourceDescriptor, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
+	return lookupIPGeoSource(
+		ctx,
+		descriptor.Source,
+		func() ipgeo.SourceDescriptor { return descriptor },
+		lang,
+		maptrace,
+		numMeasurements,
+		query,
+		descriptor.Namespace == ipgeo.SourceNamespaceDN42,
+	)
+}
+
+// CachedGeoSource adds process-wide caching only when descriptor has a
+// canonical namespace. Sources without a namespace retain direct-call
+// semantics and never join another source's in-flight lookup.
+func CachedGeoSource(descriptor ipgeo.SourceDescriptor) ipgeo.Source {
+	if descriptor.Source == nil {
+		return nil
+	}
+	if descriptor.Namespace == "" {
+		return descriptor.Source
+	}
+	return func(query string, timeout time.Duration, language string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		return geoCache.lookup(descriptor, query, timeout, language, maptrace)
+	}
+}
+
+// CachedGeoSourceSession adapts a descriptor session to the legacy session
+// surface while reading the current descriptor for every lookup.
+func CachedGeoSourceSession(session ipgeo.SourceDescriptorSession) ipgeo.SourceSession {
+	if session.Current == nil {
+		return ipgeo.SourceSession{Refresh: session.Refresh}
+	}
+	return ipgeo.SourceSession{
+		Source: func(query string, timeout time.Duration, language string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			return geoCache.lookup(session.Current(), query, timeout, language, maptrace)
+		},
+		Refresh: session.Refresh,
+	}
+}
+
 // LookupIPGeoWithSession reuses a source session for direct IP metadata lookups.
-// Sessions with a refresh hook bypass process-wide filtering, caching, and singleflight.
+// Legacy sessions do not provide a cache namespace, so their sources bypass
+// process-wide caching and singleflight. A refresh hook continues to mark a
+// session whose reserved-address filtering must be handled by its source.
 func LookupIPGeoWithSession(ctx context.Context, session ipgeo.SourceSession, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
 	return lookupIPGeo(ctx, session, lang, maptrace, numMeasurements, query)
 }
 
 func lookupIPGeo(ctx context.Context, session ipgeo.SourceSession, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
+	return lookupIPGeoSource(ctx, session.Source, nil, lang, maptrace, numMeasurements, query, session.Refresh != nil)
+}
+
+func lookupIPGeoSource(
+	ctx context.Context,
+	source ipgeo.Source,
+	descriptor func() ipgeo.SourceDescriptor,
+	lang string,
+	maptrace bool,
+	numMeasurements int,
+	query string,
+	bypassFilter bool,
+) (*ipgeo.IPGeoData, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return nil, ErrEmptyGeoQuery
@@ -38,25 +99,23 @@ func lookupIPGeo(ctx context.Context, session ipgeo.SourceSession, lang string, 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if session.Source == nil {
+	if source == nil {
 		return nil, ErrNilGeoSource
 	}
 	if ip := net.ParseIP(query); ip == nil {
 		return nil, fmt.Errorf("%w: %q", ErrNotIPGeoQuery, query)
 	}
-	uncached := session.Refresh != nil
-	if !uncached {
+	if !bypassFilter {
 		if geo, ok := ipgeo.Filter(query); ok {
-			geoCache.Store(query, geo)
 			return geo, nil
 		}
 	}
 	return lookupGeoWithRetry(Config{
-		Context:            ctx,
-		IPGeoSource:        session.Source,
-		RefreshIPGeoSource: session.Refresh,
-		Lang:               lang,
-		Maptrace:           maptrace,
-		NumMeasurements:    numMeasurements,
-	}, query, query, uncached)
+		Context:         ctx,
+		IPGeoSource:     source,
+		IPGeoDescriptor: descriptor,
+		Lang:            lang,
+		Maptrace:        maptrace,
+		NumMeasurements: numMeasurements,
+	}, query, query, bypassFilter)
 }

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -13,20 +13,28 @@ import (
 )
 
 func TestClearCachesRemovesAllEntries(t *testing.T) {
-	geoCache.Store("198.51.100.1", &ipgeo.IPGeoData{IP: "198.51.100.1"})
-	geoCache.Store("2001:db8::1", &ipgeo.IPGeoData{IP: "2001:db8::1"})
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(ip string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{IP: ip}, nil
+	})
+	if _, err := LookupIPGeoWithDescriptor(context.Background(), descriptor, "en", false, 1, "8.8.8.8"); err != nil {
+		t.Fatalf("initial LookupIPGeoWithDescriptor() error = %v", err)
+	}
 
 	ClearCaches()
 
-	if _, ok := geoCache.Load("198.51.100.1"); ok {
-		t.Fatal("IPv4 cache entry remained after ClearCaches")
+	if _, err := LookupIPGeoWithDescriptor(context.Background(), descriptor, "en", false, 1, "8.8.8.8"); err != nil {
+		t.Fatalf("post-clear LookupIPGeoWithDescriptor() error = %v", err)
 	}
-	if _, ok := geoCache.Load("2001:db8::1"); ok {
-		t.Fatal("IPv6 cache entry remained after ClearCaches")
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("source calls = %d, want 2 after ClearCaches", got)
 	}
 }
 
-func TestLookupIPGeoCachesResults(t *testing.T) {
+func TestLookupIPGeoBareSourceBypassesProcessCache(t *testing.T) {
 	ClearCaches()
 	t.Cleanup(ClearCaches)
 
@@ -53,8 +61,60 @@ func TestLookupIPGeoCachesResults(t *testing.T) {
 		}
 	}
 
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("geo source calls = %d, want 2 for unnamespaced source", got)
+	}
+}
+
+func TestLookupIPGeoWithDescriptorCachesResults(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var calls atomic.Int32
+	descriptor := geoCacheTestDescriptor(func(ip string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{IP: ip, Asnumber: "13335"}, nil
+	})
+	for range 2 {
+		geo, err := LookupIPGeoWithDescriptor(context.Background(), descriptor, "en", false, 1, "1.1.1.1")
+		if err != nil {
+			t.Fatalf("LookupIPGeoWithDescriptor() error = %v", err)
+		}
+		if geo == nil || geo.Asnumber != "13335" {
+			t.Fatalf("LookupIPGeoWithDescriptor() geo = %+v, want ASN 13335", geo)
+		}
+	}
 	if got := calls.Load(); got != 1 {
-		t.Fatalf("geo source calls = %d, want 1 due to shared cache", got)
+		t.Fatalf("geo source calls = %d, want 1 due to descriptor cache", got)
+	}
+}
+
+func TestLookupIPGeoWithDescriptorDN42BypassesFilterAndCaches(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var calls atomic.Int32
+	descriptor := ipgeo.SourceDescriptor{
+		Source: func(ip string, _ time.Duration, _ string, _ bool) (*ipgeo.IPGeoData, error) {
+			calls.Add(1)
+			return &ipgeo.IPGeoData{IP: ip, Asnumber: "4242420001"}, nil
+		},
+		Namespace:     ipgeo.SourceNamespaceDN42,
+		Backend:       ipgeo.SourceBackendDN42GeoFeed,
+		Generation:    1,
+		HasGeneration: true,
+	}
+	for range 2 {
+		geo, err := LookupIPGeoWithDescriptor(context.Background(), descriptor, "en", false, 1, "10.23.0.1")
+		if err != nil {
+			t.Fatalf("LookupIPGeoWithDescriptor() error = %v", err)
+		}
+		if geo == nil || geo.Asnumber != "4242420001" {
+			t.Fatalf("LookupIPGeoWithDescriptor() geo = %+v, want DN42 result", geo)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("DN42 source calls = %d, want 1", got)
 	}
 }
 
@@ -71,46 +131,75 @@ func TestLookupIPGeoRejectsNonIPTargets(t *testing.T) {
 	}
 }
 
-func TestLookupIPGeoHonorsContextCancellationDuringRetry(t *testing.T) {
-	ClearCaches()
-	t.Cleanup(ClearCaches)
+func TestLookupIPGeoHonorsContextCancellationDuringSourceCall(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		started := make(chan struct{})
+		release := make(chan struct{})
+		sourceDone := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			_, err := LookupIPGeo(ctx, func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+				close(started)
+				<-release
+				close(sourceDone)
+				return &ipgeo.IPGeoData{}, nil
+			}, "en", false, 1, "8.8.8.8")
+			done <- err
+		}()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	sourceEntered := make(chan struct{}, 1)
-	source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		<-started
+		cancel()
+		synctest.Wait()
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("LookupIPGeo() error = %v, want context.Canceled", err)
+		}
 		select {
-		case sourceEntered <- struct{}{}:
+		case <-sourceDone:
+			t.Fatal("blocked source finished before release")
 		default:
 		}
-		time.Sleep(200 * time.Millisecond)
-		return nil, context.DeadlineExceeded
-	}
+		close(release)
+		synctest.Wait()
+		<-sourceDone
+	})
+}
 
-	done := make(chan error, 1)
-	start := time.Now()
-	go func() {
-		_, err := LookupIPGeo(ctx, source, "en", false, 3, "8.8.8.8")
-		done <- err
-	}()
+func TestLookupIPGeoWithDescriptorHonorsContextCancellation(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		started := make(chan struct{})
+		release := make(chan struct{})
+		sourceDone := make(chan struct{})
+		done := make(chan error, 1)
+		descriptor := geoCacheTestDescriptor(func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			close(started)
+			<-release
+			close(sourceDone)
+			return &ipgeo.IPGeoData{}, nil
+		})
+		go func() {
+			_, err := LookupIPGeoWithDescriptor(ctx, descriptor, "en", false, 1, "8.8.8.8")
+			done <- err
+		}()
 
-	select {
-	case <-sourceEntered:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for geo lookup attempt to start")
-	}
-	cancel()
-
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("LookupIPGeo() error = nil, want cancellation")
+		<-started
+		cancel()
+		synctest.Wait()
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("LookupIPGeoWithDescriptor() error = %v, want context.Canceled", err)
 		}
-		if time.Since(start) >= 150*time.Millisecond {
-			t.Fatalf("LookupIPGeo() returned too slowly after cancellation: %v", time.Since(start))
+		select {
+		case <-sourceDone:
+			t.Fatal("blocked descriptor source finished before release")
+		default:
 		}
-	case <-time.After(time.Second):
-		t.Fatal("LookupIPGeo() did not return after cancellation")
-	}
+		close(release)
+		synctest.Wait()
+		<-sourceDone
+	})
 }
 
 func TestLookupGeoWithRetryExpiredDeadlineReturnsDeadlineExceeded(t *testing.T) {
@@ -164,29 +253,27 @@ func TestLookupGeoWithRetryDN42BypassesCache(t *testing.T) {
 	t.Cleanup(ClearCaches)
 
 	const key = "172.20.0.1,dn42.example"
-	stale := &ipgeo.IPGeoData{Asnumber: "STALE"}
-	geoCache.Store(key, stale)
-
 	var calls atomic.Int32
 	fresh := &ipgeo.IPGeoData{Asnumber: "FRESH"}
-	geo, err := lookupGeoWithRetry(Config{
-		IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
-			calls.Add(1)
-			return fresh, nil
-		},
+	source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return fresh, nil
+	}
+	config := Config{
+		IPGeoSource:     source,
 		NumMeasurements: 1,
-	}, key, key, true)
-	if err != nil {
-		t.Fatalf("lookupGeoWithRetry() error = %v", err)
 	}
-	if geo != fresh {
-		t.Fatalf("lookupGeoWithRetry() geo = %+v, want fresh result", geo)
+	for range 2 {
+		geo, err := lookupGeoWithRetry(config, key, key, true)
+		if err != nil {
+			t.Fatalf("lookupGeoWithRetry() error = %v", err)
+		}
+		if geo != fresh {
+			t.Fatalf("lookupGeoWithRetry() geo = %+v, want fresh result", geo)
+		}
 	}
-	if got := calls.Load(); got != 1 {
-		t.Fatalf("DN42 source calls = %d, want 1", got)
-	}
-	if cached, ok := geoCache.Load(key); !ok || cached != stale {
-		t.Fatalf("DN42 lookup changed shared cache: got %#v, want original stale entry", cached)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("DN42 source calls = %d, want 2 for bare source", got)
 	}
 }
 
@@ -299,7 +386,6 @@ func TestLookupIPGeoWithSessionBypassesFilterAndCacheWithoutRefreshing(t *testin
 	t.Cleanup(ClearCaches)
 
 	const query = "10.23.0.1"
-	geoCache.Store(query, &ipgeo.IPGeoData{Asnumber: "STALE"})
 
 	var state atomic.Int32
 	state.Store(1)
@@ -334,8 +420,5 @@ func TestLookupIPGeoWithSessionBypassesFilterAndCacheWithoutRefreshing(t *testin
 	}
 	if got := refreshCalls.Load(); got != 0 {
 		t.Fatalf("LookupIPGeoWithSession invoked Refresh %d times, want 0", got)
-	}
-	if cached, ok := geoCache.Load(query); !ok || cached.(*ipgeo.IPGeoData).Asnumber != "STALE" {
-		t.Fatalf("session lookup changed shared cache: %#v", cached)
 	}
 }

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -222,6 +222,46 @@ func TestLookupGeoWithRetryExpiredDeadlineReturnsDeadlineExceeded(t *testing.T) 
 	}
 }
 
+func TestLookupGeoWithRetryContinuesAfterAttemptDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		timeouts := make(chan time.Duration, 2)
+		var calls atomic.Int32
+		sourceDone := make(chan struct{})
+		source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			timeouts <- timeout
+			if calls.Add(1) == 1 {
+				time.Sleep(timeout + time.Second)
+				close(sourceDone)
+				return nil, context.DeadlineExceeded
+			}
+			return &ipgeo.IPGeoData{IP: ip, Asnumber: "64515"}, nil
+		}
+
+		geo, err := lookupGeoWithRetry(Config{
+			IPGeoSource:     source,
+			NumMeasurements: 2,
+		}, "203.0.113.10", "203.0.113.10", false)
+		if err != nil {
+			t.Fatalf("lookupGeoWithRetry() error = %v", err)
+		}
+		if geo == nil || geo.Asnumber != "64515" {
+			t.Fatalf("lookupGeoWithRetry() geo = %+v, want ASN 64515", geo)
+		}
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("geo source calls = %d, want 2", got)
+		}
+		if got := <-timeouts; got != 2*time.Second {
+			t.Fatalf("first geo timeout = %s, want 2s", got)
+		}
+		if got := <-timeouts; got != 3*time.Second {
+			t.Fatalf("second geo timeout = %s, want 3s", got)
+		}
+
+		synctest.Wait()
+		<-sourceDone
+	})
+}
+
 func TestLookupGeoWithRetryClampsLargeOffset(t *testing.T) {
 	ClearCaches()
 	t.Cleanup(ClearCaches)

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1087,6 +1087,9 @@ func TestScheduler_AsyncMetadataSnapshotsBeforeGeoCompletes(t *testing.T) {
 }
 
 func TestScheduler_AsyncMetadataDedupesAndCachesByIP(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
 	var lookupCount int32
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
@@ -1109,11 +1112,11 @@ func TestScheduler_AsyncMetadataDedupesAndCachesByIP(t *testing.T) {
 		FillGeo:          true,
 		AsyncMetadata:    true,
 		BaseConfig: Config{
-			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+			IPGeoSource: CachedGeoSource(geoCacheTestDescriptor(func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
 				atomic.AddInt32(&lookupCount, 1)
 				time.Sleep(50 * time.Millisecond)
 				return &ipgeo.IPGeoData{Asnumber: "64513"}, nil
-			},
+			})),
 			Timeout: time.Second,
 		},
 	}, nil, nil)
@@ -1396,8 +1399,15 @@ func TestScheduler_AsyncMetadataUsesGeoCacheWithoutSourceLookup(t *testing.T) {
 	t.Cleanup(ClearCaches)
 
 	const ip = "8.8.8.82"
-	geoCache.Store(ip, &ipgeo.IPGeoData{Asnumber: "CACHE"})
 	var lookupCount int32
+	geoSource := CachedGeoSource(geoCacheTestDescriptor(func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		atomic.AddInt32(&lookupCount, 1)
+		return &ipgeo.IPGeoData{Asnumber: "CACHE"}, nil
+	}))
+	if _, err := geoSource(ip, time.Second, "", false); err != nil {
+		t.Fatalf("seed geo cache: %v", err)
+	}
+	atomic.StoreInt32(&lookupCount, 0)
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			return mtrProbeResult{
@@ -1420,11 +1430,8 @@ func TestScheduler_AsyncMetadataUsesGeoCacheWithoutSourceLookup(t *testing.T) {
 		FillGeo:          true,
 		AsyncMetadata:    true,
 		BaseConfig: Config{
-			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
-				atomic.AddInt32(&lookupCount, 1)
-				return nil, errors.New("should use cache")
-			},
-			Timeout: time.Second,
+			IPGeoSource: geoSource,
+			Timeout:     time.Second,
 		},
 	}, nil, nil)
 	if err != nil {
@@ -2096,6 +2103,14 @@ func TestLookupMTRMetadataDN42BypassesRFCFilter(t *testing.T) {
 }
 
 func TestScheduler_AsyncMetadataNaturalCompletionUsesBoundedContext(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	slowSource := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		time.Sleep(geoTimeoutForAttempt(0) + time.Second)
+		return &ipgeo.IPGeoData{Asnumber: "64514"}, nil
+	}
+	descriptor := geoCacheTestDescriptor(slowSource)
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
 			return mtrProbeResult{
@@ -2118,11 +2133,9 @@ func TestScheduler_AsyncMetadataNaturalCompletionUsesBoundedContext(t *testing.T
 		FillGeo:          true,
 		AsyncMetadata:    true,
 		BaseConfig: Config{
-			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
-				time.Sleep(geoTimeoutForAttempt(0) + time.Second)
-				return &ipgeo.IPGeoData{Asnumber: "64514"}, nil
-			},
-			Timeout: 80 * time.Millisecond,
+			IPGeoSource:     slowSource,
+			IPGeoDescriptor: func() ipgeo.SourceDescriptor { return descriptor },
+			Timeout:         80 * time.Millisecond,
 		},
 	}, nil, nil)
 	if err != nil {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1310,12 +1310,13 @@ func lookupGeoWithRetry(c Config, _ string, query string, dn42 bool) (*ipgeo.IPG
 		attemptErr := attemptCtx.Err()
 		cancel()
 		if err != nil {
-			lastErr = err
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
 			if attemptErr != nil {
-				return nil, attemptErr
+				lastErr = attemptErr
+			} else {
+				lastErr = err
 			}
 			continue
 		}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -15,7 +15,6 @@ import (
 
 	"golang.org/x/net/idna"
 	"golang.org/x/sync/semaphore"
-	"golang.org/x/sync/singleflight"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace/internal"
@@ -27,8 +26,6 @@ var (
 	errInvalidMethod      = errors.New("invalid method")
 	errNaturalDone        = errors.New("trace natural done")
 	errTracerouteExecuted = errors.New("traceroute already executed")
-	geoCache              = sync.Map{}
-	ipGeoSF               singleflight.Group
 )
 
 type Config struct {
@@ -48,6 +45,9 @@ type Config struct {
 	DstPort          int
 	Quic             bool
 	IPGeoSource      ipgeo.Source
+	// IPGeoDescriptor returns the current canonical source identity for
+	// context-aware process cache lookups. Nil preserves legacy Source behavior.
+	IPGeoDescriptor func() ipgeo.SourceDescriptor
 
 	// RefreshIPGeoSource marks a refreshable source session and refreshes it at reset boundaries.
 	RefreshIPGeoSource func()
@@ -1218,22 +1218,6 @@ func geoTimeoutForAttempt(attempt int) time.Duration {
 	return time.Duration(timeout) * time.Second
 }
 
-func lookupGeoSourceWithContext(ctx context.Context, cacheKey string, fn func() (any, error)) (any, error) {
-	if ctx == nil || ctx.Done() == nil {
-		v, err, _ := ipGeoSF.Do(cacheKey, fn)
-		return v, err
-	}
-
-	resultCh := ipGeoSF.DoChan(cacheKey, fn)
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case result := <-resultCh:
-		return result.Val, result.Err
-	}
-}
-
 func lookupGeoSourceDirectWithContext(ctx context.Context, fn func() (any, error)) (any, error) {
 	// Source callbacks must honor their timeout argument. Running fn in a detached
 	// goroutine cannot stop a blocked callback and adds overhead to in-memory sources.
@@ -1247,21 +1231,34 @@ func lookupGeoSourceDirectWithContext(ctx context.Context, fn func() (any, error
 	return value, err
 }
 
-func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPGeoData, error) {
-	if !dn42 {
-		if cacheVal, ok := geoCache.Load(cacheKey); ok {
-			if g, ok := cacheVal.(*ipgeo.IPGeoData); ok && g != nil {
-				return g, nil
-			}
-		}
+func lookupGeoSourceWithContext(ctx context.Context, fn func() (any, error)) (any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+	type result struct {
+		value any
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		value, err := fn()
+		resultCh <- result{value: value, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		return result.value, result.err
+	}
+}
 
+func lookupGeoWithRetry(c Config, _ string, query string, dn42 bool) (*ipgeo.IPGeoData, error) {
 	ctx := c.Context
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	typeErr := "ipgeo: nil or bad type from singleflight"
+	typeErr := "ipgeo: nil or bad type from source"
 	lookupErr := "ipgeo: lookup failed without specific error"
 	if dn42 {
 		typeErr += " (DN42)"
@@ -1289,21 +1286,36 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 			}
 		}
 		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
-		lookup := func() (any, error) {
-			return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
-		}
 		var v any
 		var err error
-		if dn42 {
-			v, err = lookupGeoSourceDirectWithContext(attemptCtx, lookup)
+		if c.IPGeoDescriptor != nil {
+			v, err = geoCache.lookupContext(
+				attemptCtx,
+				c.IPGeoDescriptor(),
+				query,
+				timeout,
+				c.Lang,
+				c.Maptrace,
+			)
 		} else {
-			v, err = lookupGeoSourceWithContext(attemptCtx, cacheKey, lookup)
+			lookup := func() (any, error) {
+				return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
+			}
+			if dn42 {
+				v, err = lookupGeoSourceDirectWithContext(attemptCtx, lookup)
+			} else {
+				v, err = lookupGeoSourceWithContext(attemptCtx, lookup)
+			}
 		}
+		attemptErr := attemptCtx.Err()
 		cancel()
 		if err != nil {
 			lastErr = err
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
+			}
+			if attemptErr != nil {
+				return nil, attemptErr
 			}
 			continue
 		}
@@ -1314,9 +1326,6 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 			continue
 		}
 
-		if !dn42 {
-			geoCache.Store(cacheKey, geo)
-		}
 		return geo, nil
 	}
 

--- a/trace/trace_stop_test.go
+++ b/trace/trace_stop_test.go
@@ -650,13 +650,8 @@ func TestLateMetadataCannotOverwritePromotedTerminalHop(t *testing.T) {
 	oldIP := net.ParseIP("8.8.4.101")
 	destinationIP := net.ParseIP("8.8.4.102")
 	oldKey := oldIP.String()
-	destinationKey := destinationIP.String()
-	geoCache.Delete(oldKey)
-	geoCache.Delete(destinationKey)
-	t.Cleanup(func() {
-		geoCache.Delete(oldKey)
-		geoCache.Delete(destinationKey)
-	})
+	ClearCaches()
+	t.Cleanup(ClearCaches)
 
 	oldStarted := make(chan struct{}, 1)
 	releaseOld := make(chan struct{})


### PR DESCRIPTION
## 问题

旧 Geo 缓存使用无界 `sync.Map[string]*IPGeoData`：

- key 仅包含原始 IP 文本，无法隔离 provider、NextTrace v3/v4 backend、language、maptrace、DN42 hostname 和 GeoFeed generation。
- 缓存无容量与 TTL，且直接返回共享可变指针，renderer 或调用方修改结果时可能造成污染或 data race。
- DN42、service 等部分入口绕过缓存，内建调用点缺少统一的数据源身份。

## 前后调用链

旧路径：

`Hop.fetchIPData -> sync.Map(IP text) -> global singleflight(IP text) -> Source`

新路径：

`request/session -> Config.IPGeoDescriptor -> bounded Geo cache -> descriptor.Source`

新 key 包含 `netip.Addr.Unmap()` 后的地址、canonical namespace、实际 backend、规范化 language、maptrace，以及 DN42 hostname/GeoFeed generation。

全局缓存固定为 4096 项、15 分钟绝对 TTL、FIFO 淘汰；命中不续期、不改变淘汰顺序，错误与 nil 结果不缓存。`ClearCaches` 使用 epoch 屏障，清理前的 flight 不会回填或与清理后的请求合并。

缓存写入和每次返回都会复制 `IPGeoData`，包括 `Router` map 与内部 slice。无 namespace 的外部自定义 Source 继续接收原始参数，并绕过进程级缓存与 singleflight。

## 兼容性

- 保留现有 `GetSource`、`GetSourceSession`、`LookupIPGeo` 等导出 API 和签名；descriptor/session/cache 均为增量接口。
- CLI flags、退出码、JSON schema、协议布局和持久数据格式不变。
- NextTrace API v3 WebSocket 与 v4 HTTP 使用不同 backend key。
- DN42 descriptor 的 Source 与 generation 来自同一不可变快照；现有 MTR 会话只在 reset 边界刷新。
- descriptor follower 使用自身 context/deadline 等待；Source 回调仍须履行传入的 timeout 合同。

## 测试与门禁

PR exact head：`f60814c91ce8849d20aeec3727c1a358c16e6058`

本地 exact-head 已通过：

- 默认 JSON 与 `GOEXPERIMENT=nojsonv2`：`go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go build ./...`
- `go vet ./...`
- 实现 head `82b7635` 的 golangci-lint v2.13.2 `--new-from-rev=e1338fc54c672386877b1576af684295fbd4dba7`：0 issues；最新 head PR lint 同样通过
- 全仓原样 lint 的 78 项均可在 parent 复现，不属于本 PR 新增问题
- full/tiny/ntr 六组专项测试与默认/nojsonv2 构建
- 实现 head `82b7635`：Linux amd64、Windows amd64、Darwin amd64/arm64 × full/tiny/ntr × default/nojsonv2，共 24 个 release-style 产物；最新 head 的 GitHub 现有跨平台三 flavor 构建矩阵全绿
- 最新 head：Darwin arm64 三 flavor 均由 `vtool` 与 `otool` 确认恰好一个 `LC_BUILD_VERSION`，`minos 13.0`
- tiny/ntr 依赖图与 16 个跨平台产物均不含 Gin、Globalping CLI、q
- 三 flavor 的 `--help` 边界；default/nojsonv2 输出逐字节一致
- Web 前端 Node 测试 15/15
- `go mod verify`、`go mod tidy -diff`、`gofmt -d`、`git diff --check`
- 关键并发/取消回归连续执行 20 次

## Benchstat

环境：Apple M5、Go 1.27.1、`GOMAXPROCS=10`、`GOEXPERIMENT=nojsonv2`，每组 10 次、每次 1 秒。

| 子项 | parent | 缓存实现 head `82b7635` | 变化 |
| --- | ---: | ---: | ---: |
| Hit | 8.622 ns/op，0 B，0 alloc | 91.905 ns/op，288 B，1 alloc | +966.00% |
| Miss | 5.002 ns/op，0 B，0 alloc | 51.145 ns/op，0 B，0 alloc | +922.49% |

parent 子项只测无界 `sync.Map`，不包含 typed key、TTL/FIFO/epoch 和返回值隔离，因此不是同功能回退。PR-4 没有数值性能合并门槛。

新增缓存实现 head 完整路径中位数：

| 子项 | time/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| FIFO eviction | 491.25 ns | 702–703 B | 5 |
| Parallel cache load hit | 51.325 ns | 288 B | 1 |
| CachedGeoSource lookup hit | 141.65 ns | 288 B | 1 |
| Parallel CachedGeoSource hit | 56.34 ns | 288 B | 1 |

每次命中的 288 B、1 alloc 用于调用方独立副本；测试覆盖 32 个 singleflight waiter，确认返回指针和修改相互隔离。

## Profile

10 秒 CPU/heap profile 基于实现提交 `c865f0c436f0b5ce839c293763773f5af4b3ab24`；后续提交只修复非 nil context lint 与 Geo 单次超时重试，不改变缓存实现。

- `geoCacheRuntime.load` 占 CPU 累积时间 30.71%。
- typed-key `runtime.typehash` 占 11.24%。
- `cloneGeoCacheValue` 占 heap alloc-space 95.74%，与 1 alloc/op 一致。
- 原始 `.pprof` 与 benchmark 输出作为本地/CI evidence 保存，不提交仓库。

## 产物大小

Darwin arm64、`nojsonv2`、未压缩 exact-head 产物：

| Flavor | parent | exact head | 变化 |
| --- | ---: | ---: | ---: |
| nexttrace | 30,044,018 B | 30,093,538 B | +49,520 B / +0.1648% |
| nexttrace-tiny | 10,983,874 B | 11,016,882 B | +33,008 B / +0.3005% |
| ntr | 10,983,874 B | 11,016,882 B | +33,008 B / +0.3005% |

## 平台风险

- 缓存最多保留 4096 个深拷贝结果；实际内存上限仍受单项 Router 数据大小影响。
- 绝对 TTL 不因命中续期。
- 第一个同 key flight 的 Source timeout 是兼容兜底；每个 waiter 的 context 决定其总等待预算。
- Go 无法强制终止不遵守 timeout 的外部自定义 Source 回调。

## 回退方案

新增状态仅存在于进程内，无配置、协议或持久数据迁移。可按提交逆序回退；旧导出 API 保留，调用方无需迁移数据。

## Commit 列表

1. `20d027771e09c32df4ec0c2d294555c800dac8de` `feat(ipgeo): 描述 Geo 数据源缓存身份`
2. `c865f0c436f0b5ce839c293763773f5af4b3ab24` `perf(geo): 限制共享缓存并隔离查询`
3. `bacd0d4712d99c1417b73046a28663a0327a7f6d` `docs(perf): 记录 Geo 缓存边界证据`
4. `82b76353ea0721f3288dbd94369873f53300557a` `fix(geo): 避免向缓存传入空 context`
5. `f60814c91ce8849d20aeec3727c1a358c16e6058` `fix(geo): 保留单次超时后的递增重试`
