### PR TITLE
perf(mtr): 缓存聚合快照并按 TTL 复制预览

### DIFF
--- a/docs/performance/go127-mtr-aggregator.md
+++ b/docs/performance/go127-mtr-aggregator.md
@@ -1,0 +1,134 @@
+# Go 1.27 MTR 聚合器优化证据
+
+## 范围与结论
+
+本轮只修改 active trace aggregator，未触碰无生产调用者的
+`server/mtr.go` legacy aggregator。TTL 数据改为可增长 slice，bucket 保持首次
+观测顺序并使用 comparable identity 索引；快照按版本缓存，preview clone 只在
+修改受影响 TTL 时 copy-on-write。
+
+导出的 `MTRAggregator` API、MTR 统计公式、unknown 单路径归并、JSON schema、
+CLI/TTY 输出和三 flavor 依赖边界保持不变。同 TTL multipath 顺序固定为首次观测
+顺序。正式 10 轮 benchmark 的三个合并门槛全部通过。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `7fb7f633513fec40f71949b20f3314bfa4c24225` |
+| benchmark/profile head | `18c7f6a80b5785273d5882e0dca3c280fa6f20fc` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每次 1 秒，10 次 |
+| profile | `GOMAXPROCS=10`，每个目标 30 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+
+报告提交只增加本文档，不改变被测 Go 源码、测试 fixture 或 benchmark harness。
+PR 性能工作流会在 exact head 另存 Linux cross-reference artifact。
+
+## 调用链变化
+
+### Update 与顺序
+
+旧实现先把一轮 attempts 分组到 map，再遍历 map 合并并在每次 Snapshot 时排序。
+新实现按输入顺序直接聚合到 `buckets[ttl-1]` 的稳定 rows，并用 identity 到 row
+下标的 map 做查找。IP identity 使用 `netip.Addr.Unmap()`，非 IP 地址使用
+`Network()` 与 `String()`；unknown 和 host-only identity 保留原语义。
+
+同 TTL 新路径只追加到既有 rows 尾部。metadata patch 只补空字段，不改变统计或
+行位置。unknown 仍只在恰好一个已知路径时归并，multipath 下继续保留独立行。
+
+### Snapshot 与 preview
+
+每个 bucket 按 version 缓存不可变统计行，聚合器再按全局 version 缓存 TTL 升序
+快照。对外每次仍返回隔离副本，并深复制 `Geo.Router`、MPLS 与非 nil Response，
+调用方不能改写后续快照。
+
+`Clone` 只复制 bucket slot、owner 状态和不可变缓存。原聚合器与 clone 随后都把
+共享 bucket 视为只读；Update、PatchMetadata 和 MigrateStats 首次改写某个 TTL
+时只复制该 bucket。Reset 可复用外层 slice 容量，但不会改写已发布快照或 clone。
+
+## Benchmark
+
+parent 与 head 使用同一 harness 各运行 10 次，结果均由 benchstat 判为显著：
+
+| Benchmark | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| Update 64x4 | 80.68 us | 44.19 us | -45.22% |
+| Clone 64x4 | 36.838 us | 0.407 us | -98.90% |
+| Snapshot 64x4 | 26.678 us | 5.990 us | -77.55% |
+| preview Clone+Update 64x4 | 67.54 us | 11.33 us | -83.22% |
+
+| Benchmark | parent B/op | head B/op | 变化 | parent allocs/op | head allocs/op | 变化 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Update 64x4 | 225,328 | 143,360 | -36.38% | 1,866 | 834 | -55.31% |
+| Clone 64x4 | 121,200 | 3,408 | -97.19% | 901 | 4 | -99.56% |
+| Snapshot 64x4 | 106,544 | 49,152 | -53.87% | 458 | 257 | -43.89% |
+| preview Clone+Update 64x4 | 229,600 | 97,008 | -57.75% | 1,381 | 283 | -79.51% |
+
+门槛核验：Snapshot allocs/op 需降低至少 25%，实测降低 43.89%；Snapshot ns/op
+需降低至少 15%，实测降低 77.55%；preview B/op 需降低至少 50%，实测降低
+57.75%。无需增加到 20 次。
+
+## Profile
+
+30 秒 profile 使用与 benchmark 相同的 fixture：
+
+| 目标 | parent | head |
+| --- | ---: | ---: |
+| Snapshot ns/op | 26,332 | 5,584 |
+| Snapshot B/op / allocs | 106,544 / 458 | 49,152 / 257 |
+| preview ns/op | 66,959 | 10,462 |
+| preview B/op / allocs | 229,600 / 1,381 | 97,008 / 283 |
+
+parent Snapshot 的 alloc space 主要来自每次重建：`snapshotLocked` 90.62%、
+`buildMTRHopStat` 7.44%、稳定排序辅助 1.94%。head 中 bucket 构造与排序已退出热
+路径，alloc space 集中到保证调用方隔离的 `cloneMTRStats`。
+
+parent preview 的 `Clone` 占 52.49% alloc space，完整 Snapshot 重建占 42.16%。
+head 中直接 Clone 降至 3.52%，仅受影响 TTL 的 `cloneMTRBucket` 为 2.71%；其余
+主要分配来自最终对外快照复制。
+
+## 产物大小
+
+Darwin arm64 产物使用
+`-buildvcs=false -trimpath -ldflags '-s -w -buildid='`；Darwin 不执行 UPX。
+
+| Flavor | parent | head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,093,618 B | 30,110,146 B | +0.055% |
+| nexttrace-tiny | 11,016,978 B | 11,016,962 B | -16 B |
+| ntr | 11,016,978 B | 11,016,962 B | -16 B |
+
+full 实测增加 16,528 B；tiny/ntr 没有引入新的 WebUI、MCP 或 full-only 依赖。
+本轮不把小幅二进制变化单独归因于源码体积或链接布局。
+
+## 验证
+
+parent 与 head 的 `nojsonv2` 完整 Go 测试墙钟时间分别为 24.58 秒和 23.89 秒；
+head 默认 JSON 为 23.87 秒。head 还通过：
+
+- 默认 JSON 与 `nojsonv2` 的 `go test -count=1 ./...`。
+- `go test -race -count=1 ./...`。
+- 新合同测试 100 次重复及定向 race。
+- `go build ./...`、`go vet ./...`。
+- default/nojsonv2 下 tiny、ntr 专项测试及三 flavor 构建。
+- Linux amd64、Windows amd64、Darwin arm64 的三 flavor 构建。
+- 三个 Darwin release-style 产物各恰有一个 `LC_BUILD_VERSION minos 13.0`。
+- Web 前端 15 项 Node 测试。
+- `go mod verify`、空的 `go mod tidy -diff`。
+- `golangci-lint v2.13.2 --new-from-rev main`，0 个新增问题。
+- `git diff --check` 和独立只读合同审计。
+
+仓库当前的无范围限制 `golangci-lint run` 会报告 78 个既存问题；CI 使用
+`only-new-issues`，本 PR 未修改或掩盖这些基线问题。
+
+## 风险与回退
+
+主要风险是 COW ownership 或缓存失效遗漏。测试覆盖 Update、Reset、ClearHop、
+ClearAbove、MigrateStats 的 move/merge、PatchMetadata、published Snapshot、Clone
+双向隔离、Geo.Router/MPLS/Response 深拷贝和 preview 等价；race 未发现共享写。
+
+如需回退，可撤销实现与合同测试提交。没有配置、JSON、持久数据或导出 API
+迁移。原始 benchmark、profile 和二进制不入库，由 CI artifact 保存。

--- a/trace/mtr_stats.go
+++ b/trace/mtr_stats.go
@@ -1,16 +1,13 @@
 package trace
 
 import (
+	"net/netip"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 )
-
-// ---------------------------------------------------------------------------
-// MTR 聚合统计模型（公共层，CLI 和 Server 均可使用）
-// ---------------------------------------------------------------------------
 
 // MTRHopStat 表示 MTR 输出中一行统计数据。
 type MTRHopStat struct {
@@ -36,39 +33,78 @@ type MTRSnapshot struct {
 	Stats     []MTRHopStat `json:"stats"`
 }
 
-// ---------------------------------------------------------------------------
-// 内部累加器
-// ---------------------------------------------------------------------------
+type mtrHopIdentityKind uint8
+
+const (
+	mtrHopUnknown mtrHopIdentityKind = iota
+	mtrHopIP
+	mtrHopHost
+	mtrHopFallback
+)
+
+// mtrHopIdentity contains only comparable fields. Unmapped addresses make
+// ordinary and IPv4-mapped observations share one row.
+type mtrHopIdentity struct {
+	kind    mtrHopIdentityKind
+	addr    netip.Addr
+	network string
+	value   string
+}
 
 type mtrHopAccum struct {
-	ttl      int
-	key      string
-	host     string
-	ip       string
-	sent     int
-	received int
-	sum      float64
-	sumSq    float64 // Σ(rtt²)，用于在线方差
-	last     float64
-	best     float64
-	worst    float64
-	geo      *ipgeo.IPGeoData
-	order    int
-	mplsSet  map[string]struct{}
+	identity   mtrHopIdentity
+	host       string
+	ip         string
+	sent       int
+	received   int
+	sum        float64
+	sumSq      float64 // Σ(rtt²)，用于在线方差
+	last       float64
+	best       float64
+	worst      float64
+	geo        *ipgeo.IPGeoData
+	order      uint64
+	mplsSet    map[string]struct{}
+	seenUpdate uint64
+	geoUpdate  uint64
+}
+
+// mtrTTLBucket keeps rows in first-observation order. index points into rows,
+// so growing the slice never invalidates an identity lookup.
+type mtrTTLBucket struct {
+	rows    []mtrHopAccum
+	index   map[mtrHopIdentity]int
+	version uint64
+}
+
+// Snapshots belong to an aggregator rather than a potentially shared bucket,
+// allowing cloned aggregators to snapshot concurrently without shared writes.
+type mtrBucketSnapshot struct {
+	bucket  *mtrTTLBucket
+	version uint64
+	rows    []MTRHopStat
 }
 
 // MTRAggregator 跨轮次聚合 hop 统计。线程安全。
 type MTRAggregator struct {
-	mu        sync.Mutex
-	stats     map[int]map[string]*mtrHopAccum // [ttl][key]
-	nextOrder int
+	mu sync.Mutex
+
+	buckets         []*mtrTTLBucket // index = TTL - 1
+	owned           []bool          // false means copy before mutation
+	bucketSnapshots []mtrBucketSnapshot
+
+	nextOrder uint64
+	updateSeq uint64
+	version   uint64
+
+	snapshotVersion uint64
+	snapshotValid   bool
+	snapshot        []MTRHopStat
 }
 
 // NewMTRAggregator 创建新的聚合器。
 func NewMTRAggregator() *MTRAggregator {
-	return &MTRAggregator{
-		stats: make(map[int]map[string]*mtrHopAccum),
-	}
+	return &MTRAggregator{}
 }
 
 // Update 接收一轮 traceroute 的 Result 并更新统计，返回当前快照。
@@ -81,17 +117,24 @@ func (agg *MTRAggregator) Update(res *Result, queries int) []MTRHopStat {
 	}
 
 	_ = queries
-
+	agg.updateSeq++
+	mutated := false
 	for idx, attempts := range res.Hops {
 		if len(attempts) == 0 {
 			continue
 		}
+
 		ttl := idx + 1
-		accMap := agg.accMapForTTLLocked(ttl)
-		for key, group := range groupMTRHopAttempts(attempts) {
-			agg.mergeGroupedHopLocked(ttl, accMap, key, group)
+		bucket := agg.writableBucketLocked(ttl)
+		for _, attempt := range attempts {
+			agg.includeAttemptLocked(bucket, attempt)
 		}
-		mergeUnknownIntoSingleKnown(accMap)
+		mergeUnknownIntoSingleKnown(bucket)
+		agg.markBucketDirtyLocked(ttl, bucket)
+		mutated = true
+	}
+	if mutated {
+		agg.markDirtyLocked()
 	}
 
 	return agg.snapshotLocked()
@@ -101,27 +144,55 @@ func (agg *MTRAggregator) Update(res *Result, queries int) []MTRHopStat {
 func (agg *MTRAggregator) Reset() {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
-	agg.stats = make(map[int]map[string]*mtrHopAccum)
+
+	clear(agg.buckets)
+	agg.buckets = agg.buckets[:0]
+	clear(agg.owned)
+	agg.owned = agg.owned[:0]
+	clear(agg.bucketSnapshots)
+	agg.bucketSnapshots = agg.bucketSnapshots[:0]
 	agg.nextOrder = 0
+	agg.updateSeq = 0
+	agg.markDirtyLocked()
 }
 
 // ClearHop 删除指定 TTL 上的所有聚合数据。
-// 用于 per-hop 调度器中 knownFinalTTL 下调时，擦除旧 finalTTL 的过期统计，
-// 避免 ghost row，同时不会把旧 final 的 Snt 合并到新 final（防止 Snt 膨胀）。
 func (agg *MTRAggregator) ClearHop(ttl int) {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
-	delete(agg.stats, ttl)
+
+	slot := ttl - 1
+	if slot < 0 || slot >= len(agg.buckets) || agg.buckets[slot] == nil {
+		return
+	}
+	agg.buckets[slot] = nil
+	agg.owned[slot] = false
+	agg.bucketSnapshots[slot] = mtrBucketSnapshot{}
+	agg.trimTrailingSlotsLocked()
+	agg.markDirtyLocked()
 }
 
 // ClearAbove removes statistics beyond a confirmed sticky destination edge.
 func (agg *MTRAggregator) ClearAbove(ttl int) {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
-	for hop := range agg.stats {
-		if hop > ttl {
-			delete(agg.stats, hop)
+
+	start := max(ttl, 0)
+	if start >= len(agg.buckets) {
+		return
+	}
+	changed := false
+	for slot := start; slot < len(agg.buckets); slot++ {
+		if agg.buckets[slot] != nil {
+			changed = true
 		}
+		agg.buckets[slot] = nil
+		agg.owned[slot] = false
+		agg.bucketSnapshots[slot] = mtrBucketSnapshot{}
+	}
+	agg.trimTrailingSlotsLocked()
+	if changed {
+		agg.markDirtyLocked()
 	}
 }
 
@@ -136,61 +207,86 @@ func filterMTRStatsAtPathEnd(stats []MTRHopStat, ttl int) []MTRHopStat {
 }
 
 // MigrateStats 将 fromTTL 上所有累加器迁移合并到 toTTL，然后删除 fromTTL。
-// 用于 knownFinalTTL 下调时把旧 finalTTL 上已入账的 dst-ip 统计搬到新 finalTTL。
-// maxPerHop > 0 时，合并后对每个累加器的 sent/received 做上限裁剪，
-// 保证 Snt 不超过预算。
 func (agg *MTRAggregator) MigrateStats(fromTTL, toTTL, maxPerHop int) {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
 
-	fromMap := agg.stats[fromTTL]
-	if len(fromMap) == 0 {
+	if fromTTL <= 0 || toTTL <= 0 || fromTTL == toTTL {
+		return
+	}
+	fromSlot := fromTTL - 1
+	if fromSlot >= len(agg.buckets) || agg.buckets[fromSlot] == nil {
 		return
 	}
 
-	toMap := agg.accMapForTTLLocked(toTTL)
+	agg.ensureSlotLocked(toTTL)
+	toSlot := toTTL - 1
+	from := agg.buckets[fromSlot]
+	if agg.buckets[toSlot] == nil {
+		agg.buckets[toSlot] = from
+		agg.owned[toSlot] = agg.owned[fromSlot]
+		agg.buckets[fromSlot] = nil
+		agg.owned[fromSlot] = false
+		agg.bucketSnapshots[fromSlot] = mtrBucketSnapshot{}
+		agg.bucketSnapshots[toSlot] = mtrBucketSnapshot{}
 
-	for key, src := range fromMap {
-		dst := toMap[key]
-		if dst == nil {
-			src.ttl = toTTL
-			toMap[key] = src
-			continue
+		if maxPerHop > 0 {
+			to := agg.writableBucketLocked(toTTL)
+			for i := range to.rows {
+				capMTRHopAccum(&to.rows[i], maxPerHop)
+			}
+			agg.markBucketDirtyLocked(toTTL, to)
 		}
-		mergeMTRHopAccum(dst, src)
+	} else {
+		to := agg.writableBucketLocked(toTTL)
+		for i := range from.rows {
+			src := &from.rows[i]
+			if dstIndex, ok := to.index[src.identity]; ok {
+				mergeMTRHopAccum(&to.rows[dstIndex], src)
+				continue
+			}
+			to.index[src.identity] = len(to.rows)
+			to.rows = append(to.rows, cloneMTRHopAccum(*src))
+		}
+		sort.SliceStable(to.rows, func(i, j int) bool {
+			return to.rows[i].order < to.rows[j].order
+		})
+		rebuildMTRBucketIndex(to)
+		for i := range to.rows {
+			capMTRHopAccum(&to.rows[i], maxPerHop)
+		}
+		agg.markBucketDirtyLocked(toTTL, to)
+
+		agg.buckets[fromSlot] = nil
+		agg.owned[fromSlot] = false
+		agg.bucketSnapshots[fromSlot] = mtrBucketSnapshot{}
 	}
 
-	for _, acc := range toMap {
-		capMTRHopAccum(acc, maxPerHop)
-	}
-
-	delete(agg.stats, fromTTL)
+	agg.trimTrailingSlotsLocked()
+	agg.markDirtyLocked()
 }
 
-// Clone 返回深拷贝的聚合器，用于流式预览（不影响原始数据）。
+// Clone returns a copy-on-write aggregator for streaming previews. Only a TTL
+// changed through the clone gets a private bucket.
 func (agg *MTRAggregator) Clone() *MTRAggregator {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
 
 	c := &MTRAggregator{
-		stats:     make(map[int]map[string]*mtrHopAccum, len(agg.stats)),
-		nextOrder: agg.nextOrder,
+		buckets:         append([]*mtrTTLBucket(nil), agg.buckets...),
+		owned:           make([]bool, len(agg.buckets)),
+		bucketSnapshots: append([]mtrBucketSnapshot(nil), agg.bucketSnapshots...),
+		nextOrder:       agg.nextOrder,
+		updateSeq:       agg.updateSeq,
+		version:         agg.version,
+		snapshotVersion: agg.snapshotVersion,
+		snapshotValid:   agg.snapshotValid,
+		snapshot:        agg.snapshot,
 	}
-	for ttl, accMap := range agg.stats {
-		cMap := make(map[string]*mtrHopAccum, len(accMap))
-		for key, acc := range accMap {
-			dup := *acc // 浅拷贝
-			dup.mplsSet = make(map[string]struct{}, len(acc.mplsSet))
-			for k := range acc.mplsSet {
-				dup.mplsSet[k] = struct{}{}
-			}
-			if acc.geo != nil {
-				geoCopy := *acc.geo
-				dup.geo = &geoCopy
-			}
-			cMap[key] = &dup
+	for slot, bucket := range agg.buckets {
+		if bucket != nil {
+			agg.owned[slot] = false
 		}
-		c.stats[ttl] = cMap
 	}
 	return c
 }
@@ -202,8 +298,7 @@ func (agg *MTRAggregator) Snapshot() []MTRHopStat {
 	return agg.snapshotLocked()
 }
 
-// PatchMetadataByIP updates existing rows for the given IP with late-arriving
-// host/geo data without affecting sent/received/RTT statistics.
+// PatchMetadataByIP updates existing rows without changing statistics or row order.
 func (agg *MTRAggregator) PatchMetadataByIP(ip, host string, geo *ipgeo.IPGeoData) bool {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
@@ -213,104 +308,73 @@ func (agg *MTRAggregator) PatchMetadataByIP(ip, host string, geo *ipgeo.IPGeoDat
 	if ip == "" || (host == "" && geo == nil) {
 		return false
 	}
+	targetAddr, hasTargetAddr := parseMTRAddr(ip)
 
 	changed := false
-	for _, accMap := range agg.stats {
-		for _, acc := range accMap {
-			if strings.TrimSpace(acc.ip) != ip {
+	var geoCopy *ipgeo.IPGeoData
+	for slot, readBucket := range agg.buckets {
+		if !mtrBucketNeedsMetadataPatch(readBucket, ip, targetAddr, hasTargetAddr, host, geo) {
+			continue
+		}
+		bucket := agg.writableBucketLocked(slot + 1)
+		bucketChanged := false
+		for i := range bucket.rows {
+			acc := &bucket.rows[i]
+			if !mtrAccumMatchesIP(acc, ip, targetAddr, hasTargetAddr) {
 				continue
 			}
 			if host != "" && acc.host == "" {
 				acc.host = host
-				changed = true
+				bucketChanged = true
 			}
 			if geo != nil && acc.geo == nil {
-				geoCopy := *geo
-				acc.geo = &geoCopy
-				changed = true
+				if geoCopy == nil {
+					geoCopy = cloneMTRGeo(geo)
+				}
+				acc.geo = geoCopy
+				bucketChanged = true
 			}
 		}
+		if bucketChanged {
+			agg.markBucketDirtyLocked(slot+1, bucket)
+			changed = true
+		}
+	}
+	if changed {
+		agg.markDirtyLocked()
 	}
 	return changed
 }
 
 func (agg *MTRAggregator) snapshotLocked() []MTRHopStat {
-	// 收集 TTL 列表并排序
-	ttls := make([]int, 0, len(agg.stats))
-	for ttl := range agg.stats {
-		ttls = append(ttls, ttl)
-	}
-	sort.Ints(ttls)
-
-	var rows []MTRHopStat
-	for _, ttl := range ttls {
-		accMap := agg.stats[ttl]
-		if len(accMap) == 0 {
-			continue
-		}
-
-		// 按 order 稳定排序
-		accs := make([]*mtrHopAccum, 0, len(accMap))
-		for _, acc := range accMap {
-			accs = append(accs, acc)
-		}
-		sort.SliceStable(accs, func(i, j int) bool {
-			if accs[i].order == accs[j].order {
-				return accs[i].ip < accs[j].ip
+	if !agg.snapshotValid || agg.snapshotVersion != agg.version {
+		rowCount := 0
+		for _, bucket := range agg.buckets {
+			if bucket != nil {
+				rowCount += len(bucket.rows)
 			}
-			return accs[i].order < accs[j].order
-		})
-
-		for _, acc := range accs {
-			rows = append(rows, buildMTRHopStat(acc))
 		}
-	}
-	return rows
-}
-
-// mtrUnknownKey 是 timeout / 无地址 hop 的聚合键。
-const mtrUnknownKey = "unknown"
-
-func mtrHopKey(ip, host string) string {
-	ip = strings.TrimSpace(ip)
-	host = strings.TrimSpace(host)
-	if ip != "" {
-		return "ip:" + ip
-	}
-	if host != "" {
-		return "host:" + strings.ToLower(host)
-	}
-	return mtrUnknownKey
-}
-
-// mergeUnknownIntoSingleKnown 在同一 TTL 的 accMap 中，
-// 如果恰好只有 1 条非 unknown 路径，则将 unknown 累加器归并到该路径，
-// 避免同一跳同时出现 "(waiting for reply)" 和真实 IP 两行。
-//
-// 多路径场景（非 unknown ≥ 2 或 == 0）不归并，防止误归因。
-func mergeUnknownIntoSingleKnown(accMap map[string]*mtrHopAccum) {
-	unk, ok := accMap[mtrUnknownKey]
-	if !ok {
-		return
-	}
-
-	// 收集非 unknown 累加器
-	var known *mtrHopAccum
-	knownCount := 0
-	for k, acc := range accMap {
-		if k == mtrUnknownKey {
-			continue
+		var rows []MTRHopStat
+		if rowCount > 0 {
+			rows = make([]MTRHopStat, 0, rowCount)
 		}
-		known = acc
-		knownCount++
-		if knownCount > 1 {
-			break // 多路径，不归并
+		for slot, bucket := range agg.buckets {
+			if bucket == nil || len(bucket.rows) == 0 {
+				continue
+			}
+			cached := &agg.bucketSnapshots[slot]
+			if cached.bucket != bucket || cached.version != bucket.version {
+				bucketRows := make([]MTRHopStat, len(bucket.rows))
+				for i := range bucket.rows {
+					bucketRows[i] = buildMTRHopStat(&bucket.rows[i], slot+1)
+				}
+				*cached = mtrBucketSnapshot{bucket: bucket, version: bucket.version, rows: bucketRows}
+			}
+			rows = append(rows, cached.rows...)
 		}
+		agg.snapshot = rows
+		agg.snapshotVersion = agg.version
+		agg.snapshotValid = true
 	}
-	if knownCount != 1 || known == nil {
-		return
-	}
-
-	mergeMTRHopAccum(known, unk)
-	delete(accMap, mtrUnknownKey)
+	return cloneMTRStats(agg.snapshot)
 }

--- a/trace/mtr_stats.go
+++ b/trace/mtr_stats.go
@@ -151,6 +151,7 @@ func (agg *MTRAggregator) Reset() {
 	agg.owned = agg.owned[:0]
 	clear(agg.bucketSnapshots)
 	agg.bucketSnapshots = agg.bucketSnapshots[:0]
+	agg.snapshot = nil
 	agg.nextOrder = 0
 	agg.updateSeq = 0
 	agg.markDirtyLocked()

--- a/trace/mtr_stats_helpers.go
+++ b/trace/mtr_stats_helpers.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"math"
+	"net/netip"
 	"sort"
 	"strings"
 	"time"
@@ -9,121 +10,146 @@ import (
 	"github.com/nxtrace/NTrace-core/ipgeo"
 )
 
-type mtrHopGroup struct {
-	host     string
-	ip       string
-	geo      *ipgeo.IPGeoData
-	sum      float64
-	sumSq    float64
-	last     float64
-	best     float64
-	worst    float64
-	received int
-	count    int
-	mpls     map[string]struct{}
-}
-
-func newMTRHopGroup(host, ip string) *mtrHopGroup {
-	return &mtrHopGroup{
-		host: host,
-		ip:   ip,
-		best: math.MaxFloat64,
+func (agg *MTRAggregator) ensureSlotLocked(ttl int) int {
+	slot := ttl - 1
+	if slot < len(agg.buckets) {
+		return slot
 	}
+	need := slot + 1 - len(agg.buckets)
+	agg.buckets = append(agg.buckets, make([]*mtrTTLBucket, need)...)
+	agg.owned = append(agg.owned, make([]bool, need)...)
+	agg.bucketSnapshots = append(agg.bucketSnapshots, make([]mtrBucketSnapshot, need)...)
+	return slot
 }
 
-func groupMTRHopAttempts(attempts []Hop) map[string]*mtrHopGroup {
-	groups := make(map[string]*mtrHopGroup)
-	for _, attempt := range attempts {
-		host := strings.TrimSpace(attempt.Hostname)
-		ip := strings.TrimSpace(mtrAddrString(attempt.Address))
-		key := mtrHopKey(ip, host)
-		group := groups[key]
-		if group == nil {
-			group = newMTRHopGroup(host, ip)
-			groups[key] = group
+func (agg *MTRAggregator) writableBucketLocked(ttl int) *mtrTTLBucket {
+	slot := agg.ensureSlotLocked(ttl)
+	bucket := agg.buckets[slot]
+	if bucket == nil {
+		bucket = &mtrTTLBucket{index: make(map[mtrHopIdentity]int)}
+		agg.buckets[slot] = bucket
+		agg.owned[slot] = true
+		return bucket
+	}
+	if !agg.owned[slot] {
+		bucket = cloneMTRBucket(bucket)
+		agg.buckets[slot] = bucket
+		agg.owned[slot] = true
+	}
+	return bucket
+}
+
+func cloneMTRBucket(src *mtrTTLBucket) *mtrTTLBucket {
+	dst := &mtrTTLBucket{
+		rows:    make([]mtrHopAccum, len(src.rows)),
+		index:   make(map[mtrHopIdentity]int, len(src.index)),
+		version: src.version,
+	}
+	for i, acc := range src.rows {
+		dst.rows[i] = cloneMTRHopAccum(acc)
+	}
+	for identity, index := range src.index {
+		dst.index[identity] = index
+	}
+	return dst
+}
+
+func cloneMTRHopAccum(src mtrHopAccum) mtrHopAccum {
+	src.mplsSet = cloneMTRLabelSet(src.mplsSet)
+	return src
+}
+
+func (agg *MTRAggregator) markBucketDirtyLocked(ttl int, bucket *mtrTTLBucket) {
+	bucket.version++
+	agg.bucketSnapshots[ttl-1] = mtrBucketSnapshot{}
+}
+
+func (agg *MTRAggregator) markDirtyLocked() {
+	agg.version++
+	agg.snapshotValid = false
+}
+
+func (agg *MTRAggregator) trimTrailingSlotsLocked() {
+	length := len(agg.buckets)
+	for length > 0 && agg.buckets[length-1] == nil {
+		length--
+	}
+	agg.buckets = agg.buckets[:length]
+	agg.owned = agg.owned[:length]
+	agg.bucketSnapshots = agg.bucketSnapshots[:length]
+}
+
+func (agg *MTRAggregator) includeAttemptLocked(bucket *mtrTTLBucket, attempt Hop) {
+	identity, host, ip := mtrHopIdentityForAttempt(attempt)
+	index, ok := bucket.index[identity]
+	if !ok {
+		index = len(bucket.rows)
+		bucket.index[identity] = index
+		bucket.rows = append(bucket.rows, mtrHopAccum{
+			identity: identity,
+			best:     math.MaxFloat64,
+			order:    agg.nextOrder,
+		})
+		agg.nextOrder++
+	}
+	acc := &bucket.rows[index]
+	if acc.seenUpdate != agg.updateSeq {
+		acc.seenUpdate = agg.updateSeq
+		if ip != "" {
+			acc.ip = ip
 		}
-		group.includeAttempt(attempt)
+		if host != "" {
+			acc.host = host
+		}
 	}
-	return groups
-}
-
-func (g *mtrHopGroup) includeAttempt(attempt Hop) {
-	g.count++
-	if g.geo == nil && attempt.Geo != nil {
-		g.geo = attempt.Geo
+	if attempt.Geo != nil && acc.geoUpdate != agg.updateSeq {
+		acc.geo = cloneMTRGeo(attempt.Geo)
+		acc.geoUpdate = agg.updateSeq
 	}
-	mergeMTRLabels(&g.mpls, attempt.MPLS)
+	acc.sent++
+	mergeMTRLabels(&acc.mplsSet, attempt.MPLS)
 	if !attempt.Success {
 		return
 	}
 
 	rttMs := float64(attempt.RTT) / float64(time.Millisecond)
-	g.sum += rttMs
-	g.sumSq += rttMs * rttMs
-	g.received++
-	g.last = rttMs
-	if rttMs > g.worst {
-		g.worst = rttMs
+	acc.sum += rttMs
+	acc.sumSq += rttMs * rttMs
+	acc.received++
+	acc.last = rttMs
+	if rttMs > acc.worst {
+		acc.worst = rttMs
 	}
-	if rttMs > 0 && rttMs < g.best {
-		g.best = rttMs
+	if rttMs > 0 && rttMs < acc.best {
+		acc.best = rttMs
 	}
 }
 
-func (agg *MTRAggregator) accMapForTTLLocked(ttl int) map[string]*mtrHopAccum {
-	accMap := agg.stats[ttl]
-	if accMap == nil {
-		accMap = make(map[string]*mtrHopAccum)
-		agg.stats[ttl] = accMap
-	}
-	return accMap
-}
-
-func (agg *MTRAggregator) newHopAccum(ttl int, key string) *mtrHopAccum {
-	acc := &mtrHopAccum{
-		ttl:     ttl,
-		key:     key,
-		best:    math.MaxFloat64,
-		order:   agg.nextOrder,
-		mplsSet: make(map[string]struct{}),
-	}
-	agg.nextOrder++
-	return acc
-}
-
-func (agg *MTRAggregator) mergeGroupedHopLocked(ttl int, accMap map[string]*mtrHopAccum, key string, group *mtrHopGroup) {
-	acc := accMap[key]
-	if acc == nil {
-		acc = agg.newHopAccum(ttl, key)
-		accMap[key] = acc
-	}
-	mergeMTRHopGroupIntoAccum(acc, group)
-}
-
-func mergeMTRHopGroupIntoAccum(acc *mtrHopAccum, group *mtrHopGroup) {
-	if group.ip != "" {
-		acc.ip = group.ip
-	}
-	if group.host != "" {
-		acc.host = group.host
-	}
-	if group.geo != nil {
-		acc.geo = group.geo
-	}
-	acc.sent += group.count
-	if group.received > 0 {
-		acc.sum += group.sum
-		acc.sumSq += group.sumSq
-		acc.received += group.received
-		acc.last = group.last
-		if group.best > 0 && (acc.best == math.MaxFloat64 || group.best < acc.best) {
-			acc.best = group.best
-		}
-		if group.worst > acc.worst {
-			acc.worst = group.worst
+func mtrHopIdentityForAttempt(attempt Hop) (mtrHopIdentity, string, string) {
+	host := strings.TrimSpace(attempt.Hostname)
+	if ip := mtrAddrToIP(attempt.Address); ip != nil {
+		if addr, ok := netip.AddrFromSlice(ip); ok {
+			addr = addr.Unmap()
+			return mtrHopIdentity{kind: mtrHopIP, addr: addr}, host, addr.String()
 		}
 	}
-	mergeMTRLabelSet(acc.mplsSet, group.mpls)
+	if attempt.Address != nil {
+		network := strings.TrimSpace(attempt.Address.Network())
+		value := strings.TrimSpace(attempt.Address.String())
+		return mtrHopIdentity{kind: mtrHopFallback, network: network, value: value}, host, value
+	}
+	if host != "" {
+		return mtrHopIdentity{kind: mtrHopHost, value: strings.ToLower(host)}, host, ""
+	}
+	return mtrHopIdentity{kind: mtrHopUnknown}, "", ""
+}
+
+func parseMTRAddr(value string) (netip.Addr, bool) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(value))
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr.Unmap(), true
 }
 
 func mergeMTRHopAccum(dst, src *mtrHopAccum) {
@@ -149,7 +175,7 @@ func mergeMTRHopAccum(dst, src *mtrHopAccum) {
 	if dst.ip == "" && src.ip != "" {
 		dst.ip = src.ip
 	}
-	mergeMTRLabelSet(dst.mplsSet, src.mplsSet)
+	mergeMTRLabelSet(&dst.mplsSet, src.mplsSet)
 }
 
 func mergeMTRLabels(dst *map[string]struct{}, labels []string) {
@@ -167,10 +193,27 @@ func mergeMTRLabels(dst *map[string]struct{}, labels []string) {
 	}
 }
 
-func mergeMTRLabelSet(dst, src map[string]struct{}) {
+func mergeMTRLabelSet(dst *map[string]struct{}, src map[string]struct{}) {
+	if len(src) == 0 {
+		return
+	}
+	if *dst == nil {
+		*dst = make(map[string]struct{}, len(src))
+	}
+	for label := range src {
+		(*dst)[label] = struct{}{}
+	}
+}
+
+func cloneMTRLabelSet(src map[string]struct{}) map[string]struct{} {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]struct{}, len(src))
 	for label := range src {
 		dst[label] = struct{}{}
 	}
+	return dst
 }
 
 func capMTRHopAccum(acc *mtrHopAccum, maxPerHop int) {
@@ -205,7 +248,7 @@ func capMTRHopAccum(acc *mtrHopAccum, maxPerHop int) {
 	acc.received = acc.sent
 }
 
-func buildMTRHopStat(acc *mtrHopAccum) MTRHopStat {
+func buildMTRHopStat(acc *mtrHopAccum, ttl int) MTRHopStat {
 	lossCount := acc.sent - acc.received
 	lossPct := 0.0
 	if acc.sent > 0 {
@@ -241,7 +284,7 @@ func buildMTRHopStat(acc *mtrHopAccum) MTRHopStat {
 	}
 
 	return MTRHopStat{
-		TTL:      acc.ttl,
+		TTL:      ttl,
 		Host:     acc.host,
 		IP:       acc.ip,
 		Loss:     lossPct,
@@ -255,4 +298,89 @@ func buildMTRHopStat(acc *mtrHopAccum) MTRHopStat {
 		MPLS:     mpls,
 		Received: acc.received,
 	}
+}
+
+func cloneMTRStats(src []MTRHopStat) []MTRHopStat {
+	if src == nil {
+		return nil
+	}
+	dst := make([]MTRHopStat, len(src))
+	for i, stat := range src {
+		dst[i] = stat
+		dst[i].Geo = cloneMTRGeo(stat.Geo)
+		if stat.MPLS != nil {
+			dst[i].MPLS = make([]string, len(stat.MPLS))
+			copy(dst[i].MPLS, stat.MPLS)
+		}
+		dst[i].Response = cloneMTRProbeResponse(stat.Response)
+	}
+	return dst
+}
+
+func cloneMTRGeo(src *ipgeo.IPGeoData) *ipgeo.IPGeoData {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	if src.Router != nil {
+		dst.Router = make(map[string][]string, len(src.Router))
+		for asn, route := range src.Router {
+			if route == nil {
+				dst.Router[asn] = nil
+				continue
+			}
+			dst.Router[asn] = make([]string, len(route))
+			copy(dst.Router[asn], route)
+		}
+	}
+	return &dst
+}
+
+// mergeUnknownIntoSingleKnown folds timeouts into the only observed path at a
+// TTL. With zero or multiple known paths, the unknown row stays independent.
+func mergeUnknownIntoSingleKnown(bucket *mtrTTLBucket) {
+	unknownIdentity := mtrHopIdentity{kind: mtrHopUnknown}
+	unknownIndex, ok := bucket.index[unknownIdentity]
+	if !ok || len(bucket.rows) != 2 {
+		return
+	}
+	knownIndex := 1 - unknownIndex
+	mergeMTRHopAccum(&bucket.rows[knownIndex], &bucket.rows[unknownIndex])
+	bucket.rows = append(bucket.rows[:unknownIndex], bucket.rows[unknownIndex+1:]...)
+	rebuildMTRBucketIndex(bucket)
+}
+
+func rebuildMTRBucketIndex(bucket *mtrTTLBucket) {
+	clear(bucket.index)
+	for i := range bucket.rows {
+		bucket.index[bucket.rows[i].identity] = i
+	}
+}
+
+func mtrBucketNeedsMetadataPatch(
+	bucket *mtrTTLBucket,
+	ip string,
+	targetAddr netip.Addr,
+	hasTargetAddr bool,
+	host string,
+	geo *ipgeo.IPGeoData,
+) bool {
+	if bucket == nil {
+		return false
+	}
+	for i := range bucket.rows {
+		acc := &bucket.rows[i]
+		if mtrAccumMatchesIP(acc, ip, targetAddr, hasTargetAddr) &&
+			((host != "" && acc.host == "") || (geo != nil && acc.geo == nil)) {
+			return true
+		}
+	}
+	return false
+}
+
+func mtrAccumMatchesIP(acc *mtrHopAccum, ip string, targetAddr netip.Addr, hasTargetAddr bool) bool {
+	if hasTargetAddr && acc.identity.kind == mtrHopIP {
+		return acc.identity.addr == targetAddr
+	}
+	return strings.TrimSpace(acc.ip) == ip
 }

--- a/trace/mtr_stats_modern_test.go
+++ b/trace/mtr_stats_modern_test.go
@@ -1,0 +1,633 @@
+package trace
+
+import (
+	"encoding/json"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+type modernTestAddr struct {
+	network string
+	value   string
+}
+
+func (a modernTestAddr) Network() string { return a.network }
+func (a modernTestAddr) String() string  { return a.value }
+
+func modernTestHop(ttl int, addr net.Addr, host string, rtt time.Duration) Hop {
+	return Hop{
+		Success:  true,
+		Address:  addr,
+		Hostname: host,
+		TTL:      ttl,
+		RTT:      rtt,
+	}
+}
+
+func modernTestIPHop(ttl int, ip string, rtt time.Duration) Hop {
+	return modernTestHop(ttl, &net.IPAddr{IP: net.ParseIP(ip)}, "", rtt)
+}
+
+func modernTestResult(hopsByTTL map[int][]Hop) *Result {
+	maxTTL := 0
+	for ttl := range hopsByTTL {
+		if ttl > maxTTL {
+			maxTTL = ttl
+		}
+	}
+	res := &Result{Hops: make([][]Hop, maxTTL)}
+	for ttl, hops := range hopsByTTL {
+		res.Hops[ttl-1] = hops
+	}
+	return res
+}
+
+func modernTestSnapshotJSON(t *testing.T, stats []MTRHopStat) string {
+	t.Helper()
+	b, err := json.Marshal(stats)
+	if err != nil {
+		t.Fatalf("marshal MTR snapshot: %v", err)
+	}
+	return string(b)
+}
+
+func modernTestOrder(stats []MTRHopStat) []string {
+	order := make([]string, len(stats))
+	for i, stat := range stats {
+		order[i] = strings.Join([]string{
+			strconv.Itoa(stat.TTL),
+			stat.IP,
+		}, "|")
+	}
+	return order
+}
+
+func modernTestFindIP(t *testing.T, stats []MTRHopStat, ip string) MTRHopStat {
+	t.Helper()
+	for _, stat := range stats {
+		if stat.IP == ip {
+			return stat
+		}
+	}
+	t.Fatalf("missing MTR row for IP %q: %+v", ip, stats)
+	return MTRHopStat{}
+}
+
+func modernTestFindTTLIP(t *testing.T, stats []MTRHopStat, ttl int, ip string) MTRHopStat {
+	t.Helper()
+	for _, stat := range stats {
+		if stat.TTL == ttl && stat.IP == ip {
+			return stat
+		}
+	}
+	t.Fatalf("missing MTR row for TTL %d and IP %q: %+v", ttl, ip, stats)
+	return MTRHopStat{}
+}
+
+func TestMTRAggregatorModernStableObservationOrder(t *testing.T) {
+	agg := NewMTRAggregator()
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {
+			modernTestIPHop(1, "192.0.2.2", 12*time.Millisecond),
+			modernTestIPHop(1, "192.0.2.1", 11*time.Millisecond),
+		},
+		2: {modernTestIPHop(2, "198.51.100.8", 20*time.Millisecond)},
+		3: {
+			modernTestIPHop(3, "203.0.113.4", 34*time.Millisecond),
+			modernTestIPHop(3, "203.0.113.5", 35*time.Millisecond),
+		},
+	}), 2)
+
+	wantInitial := []string{
+		"1|192.0.2.2",
+		"1|192.0.2.1",
+		"2|198.51.100.8",
+		"3|203.0.113.4",
+		"3|203.0.113.5",
+	}
+	if got := modernTestOrder(agg.Snapshot()); !reflect.DeepEqual(got, wantInitial) {
+		t.Fatalf("initial order = %q, want %q", got, wantInitial)
+	}
+
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {
+			modernTestIPHop(1, "192.0.2.1", 21*time.Millisecond),
+			modernTestIPHop(1, "192.0.2.3", 23*time.Millisecond),
+			modernTestIPHop(1, "192.0.2.2", 22*time.Millisecond),
+		},
+		3: {
+			modernTestIPHop(3, "203.0.113.5", 45*time.Millisecond),
+			modernTestIPHop(3, "203.0.113.4", 44*time.Millisecond),
+		},
+	}), 3)
+	wantAfterUpdate := []string{
+		"1|192.0.2.2",
+		"1|192.0.2.1",
+		"1|192.0.2.3",
+		"2|198.51.100.8",
+		"3|203.0.113.4",
+		"3|203.0.113.5",
+	}
+	if got := modernTestOrder(agg.Snapshot()); !reflect.DeepEqual(got, wantAfterUpdate) {
+		t.Fatalf("order after repeated observations = %q, want %q", got, wantAfterUpdate)
+	}
+
+	if !agg.PatchMetadataByIP("192.0.2.1", "patched.example", &ipgeo.IPGeoData{Country: "ZZ"}) {
+		t.Fatal("metadata patch did not update the observed row")
+	}
+	if got := modernTestOrder(agg.Snapshot()); !reflect.DeepEqual(got, wantAfterUpdate) {
+		t.Fatalf("metadata patch changed row order: got %q, want %q", got, wantAfterUpdate)
+	}
+}
+
+func TestMTRAggregatorModernComparableIdentities(t *testing.T) {
+	mappedIPv4 := &net.IPAddr{IP: net.ParseIP("::ffff:192.0.2.10")}
+	plainIPv4 := &net.TCPAddr{IP: net.IP{192, 0, 2, 10}, Port: 33434}
+	ipv6Compressed := &net.IPAddr{IP: net.ParseIP("2001:db8::10")}
+	ipv6Expanded := &net.UDPAddr{IP: net.ParseIP("2001:0db8:0:0:0:0:0:10"), Port: 33434}
+
+	agg := NewMTRAggregator()
+	stats := agg.Update(modernTestResult(map[int][]Hop{
+		1: {
+			modernTestHop(1, mappedIPv4, "", 1*time.Millisecond),
+			modernTestHop(1, plainIPv4, "", 2*time.Millisecond),
+			modernTestHop(1, ipv6Compressed, "", 3*time.Millisecond),
+			modernTestHop(1, ipv6Expanded, "", 4*time.Millisecond),
+			{Success: false, TTL: 1},
+			{Success: false, TTL: 1},
+			modernTestHop(1, nil, "Router.Local", 5*time.Millisecond),
+			modernTestHop(1, nil, "router.local", 6*time.Millisecond),
+			modernTestHop(1, modernTestAddr{network: "alpha", value: "edge"}, "alpha-host", 7*time.Millisecond),
+			modernTestHop(1, modernTestAddr{network: "beta", value: "edge"}, "beta-host", 8*time.Millisecond),
+		},
+	}), 10)
+
+	if len(stats) != 6 {
+		t.Fatalf("identity rows = %d, want 6: %+v", len(stats), stats)
+	}
+	if row := modernTestFindIP(t, stats, "192.0.2.10"); row.Snt != 2 || row.Received != 2 {
+		t.Fatalf("IPv4 mapped/plain identity was not merged: %+v", row)
+	}
+	if row := modernTestFindIP(t, stats, "2001:db8::10"); row.Snt != 2 || row.Received != 2 {
+		t.Fatalf("equivalent IPv6 addresses were not merged: %+v", row)
+	}
+
+	unknownRows := 0
+	hostOnlyRows := 0
+	fallbackRows := map[string]int{}
+	for _, row := range stats {
+		switch {
+		case row.IP == "" && row.Host == "":
+			unknownRows++
+			if row.Snt != 2 || row.Received != 0 {
+				t.Fatalf("unknown row = %+v, want Snt=2 Received=0", row)
+			}
+		case row.IP == "" && strings.EqualFold(row.Host, "router.local"):
+			hostOnlyRows++
+			if row.Snt != 2 || row.Received != 2 {
+				t.Fatalf("host-only row = %+v, want Snt=2 Received=2", row)
+			}
+		case row.IP == "edge":
+			fallbackRows[row.Host]++
+		}
+	}
+	if unknownRows != 1 {
+		t.Fatalf("unknown rows = %d, want 1", unknownRows)
+	}
+	if hostOnlyRows != 1 {
+		t.Fatalf("host-only rows = %d, want 1", hostOnlyRows)
+	}
+	if fallbackRows["alpha-host"] != 1 || fallbackRows["beta-host"] != 1 {
+		t.Fatalf("non-IP fallback identities were not isolated by network: %v", fallbackRows)
+	}
+}
+
+func TestMTRAggregatorModernSnapshotDeepIsolation(t *testing.T) {
+	geo := &ipgeo.IPGeoData{
+		Country: "US",
+		Router: map[string][]string{
+			"path": {"left", "right"},
+		},
+	}
+	hop := modernTestIPHop(1, "192.0.2.20", 20*time.Millisecond)
+	hop.Hostname = "original.example"
+	hop.Geo = geo
+	hop.MPLS = []string{"label-a", "label-b"}
+
+	agg := NewMTRAggregator()
+	agg.Update(modernTestResult(map[int][]Hop{1: {hop}}), 1)
+	first := agg.Snapshot()
+	second := agg.Snapshot()
+	if len(first) != 1 || len(second) != 1 || len(first[0].MPLS) != 2 || first[0].Geo == nil ||
+		len(first[0].Geo.Router["path"]) != 2 {
+		t.Fatalf("snapshot lost nested test data: first=%+v second=%+v", first, second)
+	}
+	want := modernTestSnapshotJSON(t, second)
+
+	first[0].Host = "mutated.example"
+	first[0].MPLS[0] = "mutated-label"
+	first[0].Geo.Country = "XX"
+	first[0].Geo.Router["path"][0] = "mutated-path"
+	first[0].Geo.Router["new"] = []string{"new-value"}
+	first[0].Response = &MTRProbeResponse{
+		Kind:        MTRResponseDestination,
+		Description: "caller-attached response",
+		Marker:      "!X",
+	}
+	first[0].Response.Description = "mutated response"
+
+	if got := modernTestSnapshotJSON(t, second); got != want {
+		t.Fatalf("consecutive snapshots share caller-mutable state:\n got %s\nwant %s", got, want)
+	}
+	if got := modernTestSnapshotJSON(t, agg.Snapshot()); got != want {
+		t.Fatalf("caller mutation leaked into aggregator snapshot:\n got %s\nwant %s", got, want)
+	}
+	if second[0].Response != nil {
+		t.Fatalf("caller-attached response leaked into another snapshot: %+v", second[0].Response)
+	}
+}
+
+func TestMTRSchedulerModernResponseSnapshotIsolation(t *testing.T) {
+	agg := NewMTRAggregator()
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {modernTestIPHop(1, "192.0.2.21", 21*time.Millisecond)},
+	}), 1)
+	tracker := newMTRPathTracker(true, 3, nil)
+	tracker.observe(1, mtrProbeResponseWithPeer(&MTRProbeResponse{
+		Kind:        MTRResponseTransit,
+		Description: "ICMP Time Exceeded",
+		Marker:      "!T",
+	}, &net.IPAddr{IP: net.ParseIP("192.0.2.21")}))
+	runtime := &mtrSchedulerRuntime{agg: agg, pathTracker: tracker}
+
+	first := runtime.snapshotStats()
+	second := runtime.snapshotStats()
+	if len(first) != 1 || first[0].Response == nil || len(second) != 1 || second[0].Response == nil {
+		t.Fatalf("scheduler snapshots did not include response: first=%+v second=%+v", first, second)
+	}
+	want := *second[0].Response
+	first[0].Response.Kind = MTRResponseDestination
+	first[0].Response.Description = "mutated response"
+	first[0].Response.Marker = "!X"
+	if got := second[0].Response; *got != want {
+		t.Fatalf("consecutive scheduler snapshots share response: got %+v, want %+v", got, want)
+	}
+	third := runtime.snapshotStats()
+	if len(third) != 1 || third[0].Response == nil || *third[0].Response != want {
+		t.Fatalf("response mutation leaked into later scheduler snapshot: got %+v, want %+v", third, want)
+	}
+}
+
+func TestMTRAggregatorModernPublishedSnapshotSurvivesMutations(t *testing.T) {
+	agg := NewMTRAggregator()
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {modernTestIPHop(1, "192.0.2.30", 30*time.Millisecond)},
+		2: {modernTestIPHop(2, "192.0.2.31", 31*time.Millisecond)},
+		3: {modernTestIPHop(3, "192.0.2.32", 32*time.Millisecond)},
+	}), 1)
+	published := agg.Snapshot()
+	want := modernTestSnapshotJSON(t, published)
+	assertPublishedUnchanged := func(stage string) {
+		t.Helper()
+		if got := modernTestSnapshotJSON(t, published); got != want {
+			t.Fatalf("published snapshot changed after %s:\n got %s\nwant %s", stage, got, want)
+		}
+	}
+
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {modernTestIPHop(1, "192.0.2.30", 40*time.Millisecond)},
+	}), 1)
+	assertPublishedUnchanged("Update")
+	if !agg.PatchMetadataByIP("192.0.2.30", "patched.example", &ipgeo.IPGeoData{
+		Country: "ZZ",
+		Router:  map[string][]string{"path": {"patched"}},
+	}) {
+		t.Fatal("metadata patch did not change the live aggregator")
+	}
+	assertPublishedUnchanged("PatchMetadataByIP")
+	agg.ClearAbove(2)
+	assertPublishedUnchanged("ClearAbove")
+	agg.ClearHop(2)
+	assertPublishedUnchanged("ClearHop")
+	agg.Reset()
+	assertPublishedUnchanged("Reset")
+}
+
+func TestMTRAggregatorModernCloneIsolationByTTL(t *testing.T) {
+	agg := NewMTRAggregator()
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {modernTestIPHop(1, "192.0.2.40", 10*time.Millisecond)},
+		2: {modernTestIPHop(2, "192.0.2.41", 20*time.Millisecond)},
+	}), 1)
+	clone := agg.Clone()
+	cloneBaseline := modernTestSnapshotJSON(t, clone.Snapshot())
+
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {modernTestIPHop(1, "192.0.2.40", 30*time.Millisecond)},
+	}), 1)
+	if got := modernTestSnapshotJSON(t, clone.Snapshot()); got != cloneBaseline {
+		t.Fatalf("original TTL update changed clone:\n got %s\nwant %s", got, cloneBaseline)
+	}
+
+	clone.Update(modernTestResult(map[int][]Hop{
+		2: {modernTestIPHop(2, "192.0.2.41", 40*time.Millisecond)},
+	}), 1)
+	originalStats := agg.Snapshot()
+	if got := modernTestFindIP(t, originalStats, "192.0.2.40").Snt; got != 2 {
+		t.Fatalf("original TTL 1 Snt = %d, want 2", got)
+	}
+	if got := modernTestFindIP(t, originalStats, "192.0.2.41").Snt; got != 1 {
+		t.Fatalf("clone TTL 2 update changed original Snt to %d", got)
+	}
+
+	agg.ClearHop(1)
+	if got := modernTestFindIP(t, clone.Snapshot(), "192.0.2.40").Snt; got != 1 {
+		t.Fatalf("original ClearHop changed clone TTL 1 Snt to %d", got)
+	}
+	preserved := agg.Clone()
+	clone.Reset()
+	if got := clone.Snapshot(); len(got) != 0 {
+		t.Fatalf("clone Reset left %d rows", len(got))
+	}
+	if got := agg.Snapshot(); len(got) != 1 || got[0].IP != "192.0.2.41" {
+		t.Fatalf("clone Reset changed original: %+v", got)
+	}
+	agg.Reset()
+	if got := preserved.Snapshot(); len(got) != 1 || got[0].IP != "192.0.2.41" {
+		t.Fatalf("original Reset changed preserved clone: %+v", got)
+	}
+}
+
+func TestMTRAggregatorModernCloneMetadataPatchIsolation(t *testing.T) {
+	agg := NewMTRAggregator()
+	agg.Update(modernTestResult(map[int][]Hop{
+		1: {modernTestIPHop(1, "192.0.2.42", 10*time.Millisecond)},
+	}), 1)
+	clone := agg.Clone()
+
+	geo := &ipgeo.IPGeoData{
+		Country: "ZZ",
+		Router:  map[string][]string{"path": {"patched"}},
+	}
+	if !clone.PatchMetadataByIP("192.0.2.42", "clone.example", geo) {
+		t.Fatal("clone metadata patch did not update the row")
+	}
+	cloneRow := modernTestFindIP(t, clone.Snapshot(), "192.0.2.42")
+	if cloneRow.Host != "clone.example" || cloneRow.Geo == nil || cloneRow.Geo.Country != "ZZ" {
+		t.Fatalf("clone row was not patched: %+v", cloneRow)
+	}
+	originalRow := modernTestFindIP(t, agg.Snapshot(), "192.0.2.42")
+	if originalRow.Host != "" || originalRow.Geo != nil {
+		t.Fatalf("clone metadata patch changed original row: %+v", originalRow)
+	}
+
+	if !agg.PatchMetadataByIP("192.0.2.42", "original.example", &ipgeo.IPGeoData{Country: "US"}) {
+		t.Fatal("original metadata patch did not update the row")
+	}
+	cloneRow = modernTestFindIP(t, clone.Snapshot(), "192.0.2.42")
+	if cloneRow.Host != "clone.example" || cloneRow.Geo == nil || cloneRow.Geo.Country != "ZZ" {
+		t.Fatalf("original metadata patch changed clone row: %+v", cloneRow)
+	}
+}
+
+func TestMTRAggregatorModernCloneMigrationIsolation(t *testing.T) {
+	t.Run("move into empty TTL", func(t *testing.T) {
+		hop := modernTestIPHop(3, "192.0.2.43", 10*time.Millisecond)
+		hop.MPLS = []string{"label-a"}
+		agg := NewMTRAggregator()
+		agg.Update(modernTestResult(map[int][]Hop{3: {hop}}), 1)
+		clone := agg.Clone()
+
+		clone.MigrateStats(3, 1, 0)
+		clone.Update(modernTestResult(map[int][]Hop{
+			1: {modernTestIPHop(1, "192.0.2.43", 20*time.Millisecond)},
+		}), 1)
+		moved := modernTestFindTTLIP(t, clone.Snapshot(), 1, "192.0.2.43")
+		if moved.Snt != 2 || len(moved.MPLS) != 1 || moved.MPLS[0] != "label-a" {
+			t.Fatalf("moved clone row = %+v, want two probes and preserved MPLS", moved)
+		}
+		original := agg.Snapshot()
+		if len(original) != 1 || original[0].TTL != 3 || original[0].Snt != 1 {
+			t.Fatalf("clone move changed original rows: %+v", original)
+		}
+	})
+
+	t.Run("merge into existing TTL", func(t *testing.T) {
+		base := modernTestIPHop(1, "192.0.2.44", 10*time.Millisecond)
+		base.MPLS = []string{"label-a"}
+		migrated := modernTestIPHop(3, "192.0.2.44", 30*time.Millisecond)
+		migrated.MPLS = []string{"label-b"}
+		migrated.Geo = &ipgeo.IPGeoData{
+			Country: "ZZ",
+			Router:  map[string][]string{"path": {"migrated"}},
+		}
+		agg := NewMTRAggregator()
+		agg.Update(modernTestResult(map[int][]Hop{
+			1: {base},
+			3: {migrated},
+		}), 1)
+		clone := agg.Clone()
+
+		clone.MigrateStats(3, 1, 0)
+		merged := modernTestFindTTLIP(t, clone.Snapshot(), 1, "192.0.2.44")
+		if merged.Snt != 2 || merged.Geo == nil || merged.Geo.Country != "ZZ" ||
+			!reflect.DeepEqual(merged.MPLS, []string{"label-a", "label-b"}) {
+			t.Fatalf("merged clone row = %+v", merged)
+		}
+		original := agg.Snapshot()
+		originalBase := modernTestFindTTLIP(t, original, 1, "192.0.2.44")
+		originalSource := modernTestFindTTLIP(t, original, 3, "192.0.2.44")
+		if originalBase.Snt != 1 || originalBase.Geo != nil ||
+			!reflect.DeepEqual(originalBase.MPLS, []string{"label-a"}) {
+			t.Fatalf("clone merge changed original target: %+v", originalBase)
+		}
+		if originalSource.Snt != 1 || originalSource.Geo == nil ||
+			!reflect.DeepEqual(originalSource.MPLS, []string{"label-b"}) {
+			t.Fatalf("clone merge changed original source: %+v", originalSource)
+		}
+	})
+}
+
+func TestCloneMTRStatsPreservesEmptySliceShape(t *testing.T) {
+	src := []MTRHopStat{{
+		Geo: &ipgeo.IPGeoData{
+			Router: map[string][]string{
+				"empty": make([]string, 0),
+				"nil":   nil,
+			},
+		},
+		MPLS: make([]string, 0),
+	}}
+
+	got := cloneMTRStats(src)
+	if got[0].MPLS == nil {
+		t.Fatal("non-nil empty MPLS became nil")
+	}
+	if got[0].Geo.Router["empty"] == nil {
+		t.Fatal("non-nil empty router path became nil")
+	}
+	if got[0].Geo.Router["nil"] != nil {
+		t.Fatal("nil router path became non-nil")
+	}
+}
+
+func TestMTRAggregatorModernSnapshotCacheInvalidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *MTRAggregator)
+		verify func(*testing.T, []MTRHopStat)
+	}{
+		{
+			name: "Update",
+			mutate: func(_ *testing.T, agg *MTRAggregator) {
+				agg.Update(modernTestResult(map[int][]Hop{
+					1: {modernTestIPHop(1, "192.0.2.50", 50*time.Millisecond)},
+				}), 1)
+			},
+			verify: func(t *testing.T, stats []MTRHopStat) {
+				if got := modernTestFindIP(t, stats, "192.0.2.50").Snt; got != 2 {
+					t.Fatalf("Snt after Update = %d, want 2", got)
+				}
+			},
+		},
+		{
+			name:   "Reset",
+			mutate: func(_ *testing.T, agg *MTRAggregator) { agg.Reset() },
+			verify: func(t *testing.T, stats []MTRHopStat) {
+				if len(stats) != 0 {
+					t.Fatalf("rows after Reset = %d, want 0", len(stats))
+				}
+			},
+		},
+		{
+			name:   "ClearHop",
+			mutate: func(_ *testing.T, agg *MTRAggregator) { agg.ClearHop(2) },
+			verify: func(t *testing.T, stats []MTRHopStat) {
+				for _, stat := range stats {
+					if stat.TTL == 2 {
+						t.Fatalf("ClearHop left TTL 2 row: %+v", stat)
+					}
+				}
+			},
+		},
+		{
+			name:   "ClearAbove",
+			mutate: func(_ *testing.T, agg *MTRAggregator) { agg.ClearAbove(1) },
+			verify: func(t *testing.T, stats []MTRHopStat) {
+				if len(stats) != 1 || stats[0].TTL != 1 {
+					t.Fatalf("rows after ClearAbove = %+v, want only TTL 1", stats)
+				}
+			},
+		},
+		{
+			name:   "MigrateStats",
+			mutate: func(_ *testing.T, agg *MTRAggregator) { agg.MigrateStats(3, 1, 0) },
+			verify: func(t *testing.T, stats []MTRHopStat) {
+				if len(stats) != 3 {
+					t.Fatalf("rows after MigrateStats = %d, want 3: %+v", len(stats), stats)
+				}
+				if row := modernTestFindIP(t, stats, "192.0.2.52"); row.TTL != 1 {
+					t.Fatalf("migrated row TTL = %d, want 1", row.TTL)
+				}
+				for _, stat := range stats {
+					if stat.TTL == 3 {
+						t.Fatalf("MigrateStats left TTL 3 row: %+v", stat)
+					}
+				}
+			},
+		},
+		{
+			name: "PatchMetadataByIP",
+			mutate: func(t *testing.T, agg *MTRAggregator) {
+				t.Helper()
+				if !agg.PatchMetadataByIP("192.0.2.50", "patched.example", &ipgeo.IPGeoData{Country: "ZZ"}) {
+					t.Fatal("metadata patch did not change the live aggregator")
+				}
+			},
+			verify: func(t *testing.T, stats []MTRHopStat) {
+				row := modernTestFindIP(t, stats, "192.0.2.50")
+				if row.Host != "patched.example" || row.Geo == nil || row.Geo.Country != "ZZ" {
+					t.Fatalf("patched row = %+v", row)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agg := NewMTRAggregator()
+			agg.Update(modernTestResult(map[int][]Hop{
+				1: {modernTestIPHop(1, "192.0.2.50", 10*time.Millisecond)},
+				2: {modernTestIPHop(2, "192.0.2.51", 20*time.Millisecond)},
+				3: {modernTestIPHop(3, "192.0.2.52", 30*time.Millisecond)},
+			}), 1)
+			published := agg.Snapshot()
+			before := modernTestSnapshotJSON(t, published)
+			if got := modernTestSnapshotJSON(t, agg.Snapshot()); got != before {
+				t.Fatalf("unchanged consecutive snapshot = %s, want %s", got, before)
+			}
+
+			tc.mutate(t, agg)
+			after := agg.Snapshot()
+			tc.verify(t, after)
+			if got := modernTestSnapshotJSON(t, after); got == before {
+				t.Fatalf("%s did not invalidate published snapshot", tc.name)
+			}
+			if got := modernTestSnapshotJSON(t, published); got != before {
+				t.Fatalf("%s mutated the previously published snapshot", tc.name)
+			}
+		})
+	}
+}
+
+func TestMTRAggregatorModernPreviewMatchesIndependentReplay(t *testing.T) {
+	baseRounds := []*Result{
+		modernTestResult(map[int][]Hop{
+			1: {
+				modernTestIPHop(1, "192.0.2.60", 10*time.Millisecond),
+				modernTestIPHop(1, "192.0.2.61", 11*time.Millisecond),
+			},
+			2: {modernTestIPHop(2, "192.0.2.62", 20*time.Millisecond)},
+			3: {modernTestIPHop(3, "192.0.2.63", 30*time.Millisecond)},
+		}),
+		modernTestResult(map[int][]Hop{
+			1: {
+				modernTestIPHop(1, "192.0.2.61", 12*time.Millisecond),
+				modernTestIPHop(1, "192.0.2.60", 13*time.Millisecond),
+			},
+			3: {modernTestIPHop(3, "192.0.2.63", 31*time.Millisecond)},
+		}),
+	}
+	partial := modernTestResult(map[int][]Hop{
+		2: {
+			modernTestIPHop(2, "192.0.2.62", 22*time.Millisecond),
+			modernTestIPHop(2, "192.0.2.64", 24*time.Millisecond),
+		},
+	})
+
+	original := NewMTRAggregator()
+	for _, round := range baseRounds {
+		original.Update(round, 2)
+	}
+	originalBefore := modernTestSnapshotJSON(t, original.Snapshot())
+	preview := original.Clone()
+	got := preview.Update(partial, 2)
+
+	replayed := NewMTRAggregator()
+	for _, round := range baseRounds {
+		replayed.Update(round, 2)
+	}
+	want := replayed.Update(partial, 2)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("clone+partial preview differs from independent replay:\n got  %+v\nwant %+v", got, want)
+	}
+	if after := modernTestSnapshotJSON(t, original.Snapshot()); after != originalBefore {
+		t.Fatalf("preview update changed original:\n got %s\nwant %s", after, originalBefore)
+	}
+}

--- a/trace/mtr_stats_modern_test.go
+++ b/trace/mtr_stats_modern_test.go
@@ -146,6 +146,29 @@ func TestMTRAggregatorModernStableObservationOrder(t *testing.T) {
 	}
 }
 
+func TestMTRAggregatorModernFirstAttemptMetadataWinsWithinUpdate(t *testing.T) {
+	agg := NewMTRAggregator()
+	first := modernTestIPHop(1, "192.0.2.6", 10*time.Millisecond)
+	second := modernTestIPHop(1, "192.0.2.6", 11*time.Millisecond)
+	second.Hostname = "later.example"
+
+	row := modernTestFindIP(t, agg.Update(modernTestResult(map[int][]Hop{
+		1: {first, second},
+	}), 2), "192.0.2.6")
+	if row.Host != "" {
+		t.Fatalf("host = %q, want first observation's empty metadata", row.Host)
+	}
+
+	first.Hostname = "first.example"
+	second.Hostname = "last.example"
+	row = modernTestFindIP(t, agg.Update(modernTestResult(map[int][]Hop{
+		1: {first, second},
+	}), 2), "192.0.2.6")
+	if row.Host != "first.example" {
+		t.Fatalf("host = %q, want first observation metadata", row.Host)
+	}
+}
+
 func TestMTRAggregatorModernComparableIdentities(t *testing.T) {
 	mappedIPv4 := &net.IPAddr{IP: net.ParseIP("::ffff:192.0.2.10")}
 	plainIPv4 := &net.TCPAddr{IP: net.IP{192, 0, 2, 10}, Port: 33434}
@@ -317,6 +340,9 @@ func TestMTRAggregatorModernPublishedSnapshotSurvivesMutations(t *testing.T) {
 	assertPublishedUnchanged("ClearHop")
 	agg.Reset()
 	assertPublishedUnchanged("Reset")
+	if agg.snapshot != nil {
+		t.Fatalf("Reset retained %d internally cached rows", len(agg.snapshot))
+	}
 }
 
 func TestMTRAggregatorModernCloneIsolationByTTL(t *testing.T) {


### PR DESCRIPTION
### Summary

- 将 active `trace.MTRAggregator` 改为 TTL slice、稳定 rows 与 comparable identity 索引。
- 缓存不可变 bucket/全局快照；preview clone 只对被修改 TTL 执行 copy-on-write。
- 固定同 TTL multipath 首次观测顺序，并补齐快照、metadata、迁移与 clone 隔离合同。

### Problem

旧聚合器在每次 Snapshot 时遍历两层 map、重新排序和重建全部统计行；preview 每次先深复制完整聚合器，再更新一个 partial TTL。64 TTL × 4 paths 下，这两条热路径分别产生 458 与 1,381 allocs/op。

### Before/after call chain

- 之前：`Update -> group map -> accumulator map`；`Snapshot -> TTL sort -> row sort -> rebuild`；`preview -> full Clone -> Update(partial)`。
- 现在：`Update -> buckets[ttl-1] -> stable row/index`；`Snapshot -> versioned bucket cache -> isolated clone`；`preview -> shared immutable slots -> affected-TTL COW`。

生产调用链仍为 `mtr_loop_runtime`、`mtr_scheduler_runtime`、`mtr_runner` 与 `mtr_raw`。无调用者的 `server/mtr.go` legacy aggregator 未修改。

### Compatibility

- 保留 `MTRHopStat`、`MTRSnapshot`、`MTRAggregator` 及全部既有导出方法签名。
- TTL 仍升序；同 TTL multipath 按已批准合同固定为首次观测顺序，metadata patch 不改变行位。
- unknown 单路径归并、MigrateStats move/merge/cap、统计公式、JSON schema、CLI/TTY 输出与三 flavor 边界不变。
- Snapshot 继续返回调用方隔离副本，并新增 `Geo.Router`、MPLS、Response 的完整深隔离证明。

### Testing

- Go 1.27.1 default JSON 与 `GOEXPERIMENT=nojsonv2`：`go test -count=1 ./...`。
- `go build ./...`、`go vet ./...`、`go mod verify`、空的 `go mod tidy -diff`。
- default/nojsonv2 下 tiny、ntr 专项测试；三 flavor 原生与 Linux/Windows amd64 交叉构建。
- Web 前端 15 项 Node 测试。
- `golangci-lint v2.13.2 --new-from-rev main`：0 个新增问题。无范围限制运行仍报告 78 个既存基线问题，本 PR 未修改或掩盖它们。
- 独立只读合同审计无 actionable finding。

#### Race

- `go test -race -count=1 ./...` 通过。
- 新增聚合器合同测试重复 100 次及定向 race 均通过。

#### Benchstat

Apple M5、Go 1.27.1、`GOMAXPROCS=10`、`GOEXPERIMENT=nojsonv2`，parent/head 各 10 次、每次 1 秒：

| Benchmark | parent | head | 变化 |
| --- | ---: | ---: | ---: |
| Update 64x4 | 80.68 us | 44.19 us | -45.22% |
| Clone 64x4 | 36.838 us | 0.407 us | -98.90% |
| Snapshot 64x4 | 26.678 us | 5.990 us | -77.55% |
| preview Clone+Update 64x4 | 67.54 us | 11.33 us | -83.22% |

- Snapshot allocs/op：458 -> 257，-43.89%（门槛至少 -25%）。
- Snapshot ns/op：-77.55%（门槛至少 -15%）。
- preview B/op：229,600 -> 97,008，-57.75%（门槛至少 -50%）。
- 所有变化 `p=0.000, n=10`，无需扩展到 20 次。

#### Profile

- Snapshot：26,332 -> 5,584 ns/op；106,544/458 -> 49,152/257 B/op/allocs。
- preview：66,959 -> 10,462 ns/op；229,600/1,381 -> 97,008/283 B/op/allocs。
- parent Snapshot 的 map 重建/排序热点退出；head alloc space 集中到保证调用方隔离的 `cloneMTRStats`。
- parent preview 的完整 Clone 占 52.49% alloc space；head 直接 Clone 降至 3.52%，受影响 TTL 的 bucket copy 为 2.71%。

完整数据见 `docs/performance/go127-mtr-aggregator.md`；原始 benchmark/profile 由性能 CI artifact 保存。

#### Size

Darwin arm64，`-buildvcs=false -trimpath -ldflags '-s -w -buildid='`：

| Flavor | parent | head | 变化 |
| --- | ---: | ---: | ---: |
| nexttrace | 30,093,618 B | 30,110,146 B | +0.055% |
| nexttrace-tiny | 11,016,978 B | 11,016,962 B | -16 B |
| ntr | 11,016,978 B | 11,016,962 B | -16 B |

### Platform risk

- 改动为纯 Go 内存结构，不触碰 raw socket、协议报文或平台文件。
- Linux/Windows/Darwin 三 flavor 均已构建；三个 Darwin release-style 产物各恰有一个 `LC_BUILD_VERSION minos 13.0`。
- 主要风险是 COW ownership 或缓存失效遗漏；测试覆盖 Update、Reset、Clear、Patch、Migrate move/merge、published Snapshot 与双向 clone 隔离。

### Rollback

按逆序撤销本 PR 三个提交即可；没有配置、JSON、持久数据或导出 API 迁移。

### Commits

- `b2005e3 perf(mtr): 缓存聚合快照并按跳复制预览`
- `18c7f6a test(mtr): 锁定稳定顺序与快照隔离`
- `e9260d4 docs(perf): 记录 MTR 聚合优化证据`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能优化**
  * 优化 MTR 聚合、统计更新、快照生成及预览克隆效率。
  * 改进 IPv4、IPv6、备用地址和主机名的路径识别与统计合并。
  * 保持导出 API、统计结果、JSON 格式及 CLI/TTY 输出兼容。

* **可靠性**
  * 增强快照和克隆数据隔离，避免后续更新影响已发布结果。
  * 改进元数据更新、TTL 迁移、路径清理及重置行为。

* **文档**
  * 新增性能优化说明、基准数据、验证清单及回退方案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->