### PR TITLE
refactor(wshandle): 统一 WebSocket 连接生命周期

### DIFF
--- a/docs/performance/go127-wshandle-lifecycle.md
+++ b/docs/performance/go127-wshandle-lifecycle.md
@@ -1,0 +1,133 @@
+# Go 1.27 WebSocket 客户端生命周期证据
+
+## 范围与结论
+
+本轮只统一出站 `wshandle.WsConn` 及 NextTrace API v3 receiver 的生命周期：
+
+- 每个 managed connection 使用 `context.WithCancelCause` 根 context；唯一 supervisor
+  拥有连接 generation、替换、重试、心跳、状态通知和 `Done` 关闭。
+- reader/writer 只执行 I/O 并向 supervisor 上报事件；连接等待使用可轮换
+  `stateChanged`，删除 20/50 ms polling。
+- 保持 54 秒文本 ping。只有当前 generation 的字面量 `pong` 清零计数；连续两个完整
+  响应窗口没有 pong 时结束该 generation，并按既有 200 ms/1 s 节奏重连。
+- managed `SendMessage` 在提交时绑定 generation。旧 generation 的请求不会在新连接
+  重放；仍在等待业务响应的请求只通过既有 `API Server Error` JSON 路径失败一次。
+- NextTrace API v3 按 `MsgReceiveCh` identity 保持单 receiver owner。连接替换期间旧、新
+  stream 可分别收尾，同一 stream 不会出现两个消费者。
+
+导出的 `Conn`、`Done`、`MsgSendCh`、`MsgReceiveCh` 和 `ConnMux` 保留；旧结构体字面量和
+legacy channel 发送路径继续可用。JSON schema、协议消息、Geo 字段和三 flavor 依赖边界
+不变。首帧 64 KiB read limit 属于 PR-6B，不在本轮加入。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `6422ec5b212eeee49ddac1f7942eaa2278c61d82` |
+| benchmark/profile source head | `e72134136844451075dffdc034d88513831b9134` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每次 1 秒，10 次 |
+| profile | `GOMAXPROCS=10`，MTR Snapshot 30 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+
+证据提交只调整本文档和与新实现一致的代码注释，不改变被测 Go 行为、测试 fixture 或
+benchmark harness。PR 性能工作流会在 exact head 另存 Linux cross-reference artifact。
+
+## 调用链变化
+
+### 旧路径
+
+连接初始化后由相互独立的连接、发送、接收与 ping goroutine 共同修改 `WsConn`：
+
+`New -> createWsConn -> messageSendHandler / messageReceiveHandler / wsPingHandler`
+
+连接断开后，多个 goroutine 通过共享 channel、锁和 polling 观察状态并尝试收尾或重连。
+write job 没有显式 generation，旧连接失败与新连接建立之间存在请求重放或响应错配窗口；
+关闭依赖 recover 避免重复关 channel。
+
+### 新路径
+
+managed connection 建立根 context 后启动唯一 supervisor：
+
+`New -> supervisor -> dial generation -> reader/writer events -> supervisor`
+
+supervisor 串行处理 dial、read、write、request cancel、heartbeat、interrupt 和 root cancel。
+generation context 结束时先隔离旧 reader/writer，再安排既有固定节奏的重连。可取消 timer
+替代轮询；root cancel 负责最终关闭，并等待已登记 worker 与 request cancel callback 退出。
+
+`NextTraceAPIV3GeoIP` 先选择同一个 `WsConn`，等待其连通并确保该 stream 的唯一 receiver，
+再通过 `SendMessage(ctx, ip)` 提交。request 与当时 generation 原子绑定；同 IP 并发请求按
+最早 pending job 匹配响应，取消、写失败、读失败和 generation 结束均由 supervisor 结算。
+
+receive backlog 固定最多 1024 项。消费变慢时 supervisor 暂停读取 reader event，而不是
+丢弃业务消息；root/generation cancel 仍能解除 reader 和 writer。
+
+## Benchmark
+
+parent/head 使用完全相同的 Go 1.27.1 `nojsonv2` harness 各运行 10 次。首次 parent 文件
+误用了默认 JSON 后端，已废弃并重新测量；以下只使用校准后的同配置数据：
+
+| Benchmark | parent | source head | 变化 | B/op | allocs/op |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| WebSocket JSON marshal | 479.1 ns | 465.9 ns | -2.73% | 416 -> 416 | 2 -> 2 |
+| WebSocket JSON unmarshal | 2.418 us | 2.353 us | -2.69% | 656 -> 656 | 15 -> 15 |
+
+两项均由 benchstat 判为显著改善。PR-6A 没有修改 server JSON benchmark 或
+`encoding/json` 调用，结果只用于确认完整构建没有回退，不归因于生命周期重构。
+
+全套 harness 还覆盖 GeoFeed、Geo HTTP/cache、MTR、协议 decoder、MTU 和 nali。未修改包
+在顺序长跑中呈现双向约 1%–6% 的时间变化，所有稳定分配合同保持一致；这些变化与本 PR
+调用链无关，不作为改善或回退结论。本轮没有规定独立的性能提升阈值。
+
+## Profile
+
+仓库现有 profile harness 不包含 `wshandle` lifecycle benchmark，因此 30 秒 MTR Snapshot
+profile 只作为全局交叉回归，不能解释为 supervisor 热点分析。parent/head 的 heap
+alloc-space 均全部集中到 `trace.cloneMTRStats`；CPU top 均为 Darwin runtime 调度、GC 和
+系统等待函数，没有新增业务热点。
+
+| MTR Snapshot benchmark median | parent | source head |
+| --- | ---: | ---: |
+| ns/op | 6.126 us | 6.059 us |
+| B/op | 49,152 | 49,152 |
+| allocs/op | 257 | 257 |
+
+## 产物大小
+
+Darwin arm64 产物使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`；两侧均为
+Go 1.27.1、`nojsonv2`，Darwin 不执行 UPX。
+
+| Flavor | parent | source head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,523,650 B | 30,110,162 B | -413,488 B / -1.3546% |
+| nexttrace-tiny | 11,446,770 B | 11,050,018 B | -396,752 B / -3.4661% |
+| ntr | 11,446,770 B | 11,050,018 B | -396,752 B / -3.4661% |
+
+## 验证
+
+`synctest` 与普通测试覆盖：
+
+- 首次连接、200 ms/1 s retry、parent cancel、interrupt、读写失败和幂等 shutdown；
+- 54 秒 ping、两个完整缺失 pong 窗口、字面量/非字面量/stale-generation pong；
+- generation 替换唤醒、旧 write 不重放、API error 单次投递及响应/写结果竞态；
+- request context 取消、已排队取消不写 wire、cancel callback 全部 join；
+- 1024 项 receive backlog 的无丢失、顺序与慢消费者关闭；
+- 同 stream 单 receiver、连接 handoff、旧/新 stream 隔离及 v3 总 timeout 预算；
+- 同步/异步 token cache、FastIP 日志和 dev-mode panic 兼容行为。
+
+source head 已通过定向普通/race 测试、100 次常规压力、不同 `GOMAXPROCS` 的重复测试，
+以及 Go 1.27.1 `nojsonv2` 全仓测试。预热构建缓存后的全仓测试墙钟为 parent 24.67 秒、
+source head 16.74 秒，峰值 RSS 分别约 445 MB、447 MB；只记录完成耗时，不作性能改善
+结论。证据提交后的 exact-head 仍须通过默认 JSON/nojsonv2、全仓 race、build、vet、lint、
+三 flavor、前端测试、module 检查与跨平台矩阵后才允许合并。
+
+## 平台风险与回退
+
+主要风险是 generation 边界、响应先于 write result、慢消费者 backpressure 和关闭期间的
+cancel callback 交错。所有连接状态只由 supervisor 写入，wire I/O 仍各自单 owner；race
+与 synctest 覆盖上述交错。Darwin 最低版本保持 macOS 13.0，没有新增平台 API。
+
+如需回退，可撤销生命周期实现、合同测试和证据提交。没有配置、JSON、协议、持久数据或
+导出 API 迁移。原始 benchmark、profile 和二进制不入库，由 CI artifact 保存。

--- a/docs/performance/go127-wshandle-lifecycle.md
+++ b/docs/performance/go127-wshandle-lifecycle.md
@@ -10,8 +10,9 @@
   `stateChanged`，删除 20/50 ms polling。
 - 保持 54 秒文本 ping。只有当前 generation 的字面量 `pong` 清零计数；连续两个完整
   响应窗口没有 pong 时结束该 generation，并按既有 200 ms/1 s 节奏重连。
-- managed `SendMessage` 在提交时绑定 generation。旧 generation 的请求不会在新连接
-  重放；仍在等待业务响应的请求只通过既有 `API Server Error` JSON 路径失败一次。
+- managed `SendMessage` 在提交时绑定 generation；新增的 `RequestMessage` 还将响应绑定到
+  具体 request。旧 generation 的请求不会在新连接重放；仍在等待业务响应的请求只通过
+  既有 `API Server Error` JSON 路径失败一次。
 - NextTrace API v3 按 `MsgReceiveCh` identity 保持单 receiver owner。连接替换期间旧、新
   stream 可分别收尾，同一 stream 不会出现两个消费者。
 
@@ -57,12 +58,25 @@ supervisor 串行处理 dial、read、write、request cancel、heartbeat、inter
 generation context 结束时先隔离旧 reader/writer，再安排既有固定节奏的重连。可取消 timer
 替代轮询；root cancel 负责最终关闭，并等待已登记 worker 与 request cancel callback 退出。
 
-`NextTraceAPIV3GeoIP` 先选择同一个 `WsConn`，等待其连通并确保该 stream 的唯一 receiver，
-再通过 `SendMessage(ctx, ip)` 提交。request 与当时 generation 原子绑定；同 IP 并发请求按
-最早 pending job 匹配响应，取消、写失败、读失败和 generation 结束均由 supervisor 结算。
+`NextTraceAPIV3GeoIP` 先选择同一个 `WsConn`，等待其连通并确保该 stream 的唯一兼容
+receiver，再通过 `RequestMessage(ctx, ip)` 提交。request 与当时 generation 原子绑定，响应
+直接交给该 request，不再经过无 generation 的公开 channel/IP pool；同 IP 并发请求按最早
+pending job 匹配响应。取消会废弃当前 generation，写失败、读失败和 generation 结束均由
+supervisor 结算。旧结构体字面量仍回退到原公开 channel/IP pool 路径。
 
-receive backlog 固定最多 1024 项。消费变慢时 supervisor 暂停读取 reader event，而不是
-丢弃业务消息；root/generation cancel 仍能解除 reader 和 writer。
+legacy `MsgSendCh` 写成功后会保留同 generation/IP 的 FIFO marker：其响应仍进入公开
+channel，不会误配给之后的 bound request；若 generation 先结束，已成功写出的 marker 静默
+清理，不额外生成 API error。writer 在排队 write-result 前通过共享原子状态发布成功结果，
+因此断线与 write-result 的选择顺序不会制造伪失败。
+
+v3 wire 只返回 IP，没有 request ID。为避免已取消请求的迟到同 IP 响应命中后续请求，任一
+已开始 wire write 的 tracked request 取消时会轮换整个 generation；同 generation 其余
+pending request 通过既有 `API Server Error` 各失败一次。尚未开始写的取消仍静默跳过且不
+影响连接。该取舍优先保证不返回错误 Geo 数据。
+
+receive backlog 和 pending request/legacy marker 均固定最多 1024 项。消费变慢时 supervisor
+暂停读取 reader event，而不是丢弃业务消息；上限触发既有 generation 回收，root/generation
+cancel 仍能解除 reader 和 writer。
 
 ## Benchmark
 
@@ -112,7 +126,9 @@ Go 1.27.1、`nojsonv2`，Darwin 不执行 UPX。
 - 首次连接、200 ms/1 s retry、parent cancel、interrupt、读写失败和幂等 shutdown；
 - 54 秒 ping、两个完整缺失 pong 窗口、字面量/非字面量/stale-generation pong；
 - generation 替换唤醒、旧 write 不重放、API error 单次投递及响应/写结果竞态；
-- request context 取消、已排队取消不写 wire、cancel callback 全部 join；
+- 同 IP 旧 generation 响应与全局连接 handoff 不会完成新 request；
+- legacy channel 与 bound request 混用时，同 IP 响应仍按提交顺序隔离；
+- request context 取消并轮换 generation、已排队取消不写 wire、cancel callback 全部 join；
 - 1024 项 receive backlog 的无丢失、顺序与慢消费者关闭；
 - 同 stream 单 receiver、连接 handoff、旧/新 stream 隔离及 v3 总 timeout 预算；
 - 同步/异步 token cache、FastIP 日志和 dev-mode panic 兼容行为。
@@ -125,9 +141,11 @@ source head 16.74 秒，峰值 RSS 分别约 445 MB、447 MB；只记录完成�
 
 ## 平台风险与回退
 
-主要风险是 generation 边界、响应先于 write result、慢消费者 backpressure 和关闭期间的
-cancel callback 交错。所有连接状态只由 supervisor 写入，wire I/O 仍各自单 owner；race
-与 synctest 覆盖上述交错。Darwin 最低版本保持 macOS 13.0，没有新增平台 API。
+主要风险是 generation 边界、响应先于 write result、慢消费者 backpressure、关闭期间的
+cancel callback 交错，以及单个 bound request 取消会使同 generation 的其他 pending request
+失败一次。所有连接状态只由 supervisor 写入，wire I/O 仍各自单 owner；race 与 synctest
+覆盖上述交错。Darwin 最低版本保持 macOS 13.0，没有新增平台 API。
 
 如需回退，可撤销生命周期实现、合同测试和证据提交。没有配置、JSON、协议、持久数据或
-导出 API 迁移。原始 benchmark、profile 和二进制不入库，由 CI artifact 保存。
+既有导出 API 迁移；`RequestMessage` 与 unsupported sentinel 都是增量接口。原始 benchmark、
+profile 和二进制不入库，由 CI artifact 保存。

--- a/ipgeo/nexttrace_api_v3.go
+++ b/ipgeo/nexttrace_api_v3.go
@@ -32,48 +32,69 @@ var IPPools = IPPool{
 }
 
 var getNextTraceAPIV3WSConn = wshandle.GetWsConn
+var sendNextTraceAPIV3IPRequestFn = sendNextTraceAPIV3IPRequest
 
 func sendNextTraceAPIV3IPRequest(ctx context.Context, wsConn *wshandle.WsConn, ip string) bool {
 	if wsConn == nil {
 		return false
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if ctx.Err() != nil {
-		return false
-	}
-	select {
-	case wsConn.MsgSendCh <- ip:
-		return true
-	case <-ctx.Done():
-		return false
+	return wsConn.SendMessage(ctx, ip) == nil
+}
+
+type nextTraceAPIV3Receiver struct {
+	done chan struct{}
+}
+
+type nextTraceAPIV3ReceiverOwner struct {
+	mu        sync.Mutex
+	receivers map[<-chan string]*nextTraceAPIV3Receiver
+}
+
+func newNextTraceAPIV3ReceiverOwner() *nextTraceAPIV3ReceiverOwner {
+	return &nextTraceAPIV3ReceiverOwner{
+		receivers: make(map[<-chan string]*nextTraceAPIV3Receiver),
 	}
 }
 
-func receiveNextTraceAPIV3Responses() {
-	for {
-		// 获得连接实例
-		wsConn := getNextTraceAPIV3WSConn()
-		if wsConn == nil {
-			return
-		}
-		if !receiveNextTraceAPIV3Conn(wsConn) {
-			return
-		}
+func (o *nextTraceAPIV3ReceiverOwner) ensure(wsConn *wshandle.WsConn) *nextTraceAPIV3Receiver {
+	if wsConn == nil || wsConn.MsgReceiveCh == nil {
+		return nil
 	}
+	receiveCh := (<-chan string)(wsConn.MsgReceiveCh)
+
+	o.mu.Lock()
+	if receiver := o.receivers[receiveCh]; receiver != nil {
+		o.mu.Unlock()
+		return receiver
+	}
+	receiver := &nextTraceAPIV3Receiver{done: make(chan struct{})}
+	o.receivers[receiveCh] = receiver
+	o.mu.Unlock()
+
+	go o.consume(wsConn, receiveCh, receiver)
+	return receiver
 }
 
-func receiveNextTraceAPIV3Conn(wsConn *wshandle.WsConn) bool {
-	// 防止多协程抢夺一个ws连接，导致死锁，当一个协程获得ws的控制权后上锁
+func (o *nextTraceAPIV3ReceiverOwner) consume(
+	wsConn *wshandle.WsConn,
+	receiveCh <-chan string,
+	receiver *nextTraceAPIV3Receiver,
+) {
 	wsConn.ConnMux.Lock()
-	// 函数退出时解锁，给其他协程使用
-	defer wsConn.ConnMux.Unlock()
-	for data := range wsConn.MsgReceiveCh {
+	for data := range receiveCh {
 		dispatchNextTraceAPIV3Message(data)
 	}
-	return getNextTraceAPIV3WSConn() != wsConn
+	wsConn.ConnMux.Unlock()
+
+	o.mu.Lock()
+	if o.receivers[receiveCh] == receiver {
+		delete(o.receivers, receiveCh)
+	}
+	o.mu.Unlock()
+	close(receiver.done)
 }
+
+var nextTraceAPIV3Receivers = newNextTraceAPIV3ReceiverOwner()
 
 func dispatchNextTraceAPIV3Message(data string) {
 	// json解析 -> data
@@ -141,44 +162,6 @@ func deliverGeo(ch chan IPGeoData, geo IPGeoData) {
 	}
 }
 
-// 当前的实现中，每次调用 receiveNextTraceAPIV3Responses() 都会锁定 WebSocket 连接
-// 当前为单例模式，只启动一个 NextTrace API v3 接收协程
-
-var (
-	nextTraceAPIV3ReceiveMu      sync.Mutex
-	nextTraceAPIV3ReceiveRunning bool
-	nextTraceAPIV3ReceiveRestart bool
-)
-
-func startNextTraceAPIV3Receiver() {
-	nextTraceAPIV3ReceiveMu.Lock()
-	if nextTraceAPIV3ReceiveRunning {
-		nextTraceAPIV3ReceiveRestart = true
-		nextTraceAPIV3ReceiveMu.Unlock()
-		return
-	}
-	nextTraceAPIV3ReceiveRunning = true
-	nextTraceAPIV3ReceiveRestart = false
-	nextTraceAPIV3ReceiveMu.Unlock()
-
-	go runNextTraceAPIV3ReceiveLoop()
-}
-
-func runNextTraceAPIV3ReceiveLoop() {
-	for {
-		receiveNextTraceAPIV3Responses()
-
-		nextTraceAPIV3ReceiveMu.Lock()
-		if !nextTraceAPIV3ReceiveRestart {
-			nextTraceAPIV3ReceiveRunning = false
-			nextTraceAPIV3ReceiveMu.Unlock()
-			return
-		}
-		nextTraceAPIV3ReceiveRestart = false
-		nextTraceAPIV3ReceiveMu.Unlock()
-	}
-}
-
 // NextTraceAPIV3GeoIP queries the NextTrace API v3 WebSocket service.
 func NextTraceAPIV3GeoIP(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
 	// TODO: 根据lang的值请求中文/英文API
@@ -215,13 +198,15 @@ func NextTraceAPIV3GeoIP(ip string, timeout time.Duration, lang string, maptrace
 		return &IPGeoData{}, err
 	}
 
+	// Bind the response consumer to the same connection selected above. A
+	// concurrent global replacement must not move this request to another
+	// connection between readiness, send, and response dispatch.
+	nextTraceAPIV3Receivers.ensure(wsConn)
+
 	// 发送请求
-	if !sendNextTraceAPIV3IPRequest(waitCtx, wsConn, ip) {
+	if !sendNextTraceAPIV3IPRequestFn(waitCtx, wsConn, ip) {
 		return &IPGeoData{}, errors.New("TimeOut")
 	}
-
-	// 确保 NextTrace API v3 接收协程只启动一次
-	startNextTraceAPIV3Receiver()
 
 	// 等待数据返回或超时
 	select {

--- a/ipgeo/nexttrace_api_v3.go
+++ b/ipgeo/nexttrace_api_v3.go
@@ -13,13 +13,10 @@ import (
 	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
-/***
- * 原理介绍 By Leo
- * WebSocket 一共开启了一个发送和一个接收协程，在 New 了一个连接的实例对象后，不给予关闭，持续化连接
- * 当有新的IP请求时，一直在等待IP数据的发送协程接收到从 nexttrace_api_v3.go 的 sendNextTraceAPIV3IPRequest 函数发来的IP数据，向服务端发送数据
- * 由于实际使用时有大量并发，但是 ws 在同一时刻每次有且只能处理一次发送一条数据，所以必须给 ws 连接上互斥锁，保证每次只有一个协程访问
- * 运作模型可以理解为一个 Node 一直在等待数据，当获得一个新的任务后，转交给下一个协程，不再关注这个 Node 的下一步处理过程，并且回到空闲状态继续等待新的任务
-***/
+// NextTrace API v3 uses the process-wide WsConn supervisor for serialized
+// writes and generation-bound request delivery. A receiver is owned by each
+// MsgReceiveCh identity so replacing the global connection cannot create two
+// consumers for the same stream or move an old response onto a new stream.
 
 // IPPool IP 查询池 map - ip - ip channel
 type IPPool struct {

--- a/ipgeo/nexttrace_api_v3.go
+++ b/ipgeo/nexttrace_api_v3.go
@@ -68,20 +68,17 @@ func (o *nextTraceAPIV3ReceiverOwner) ensure(wsConn *wshandle.WsConn) *nextTrace
 	o.receivers[receiveCh] = receiver
 	o.mu.Unlock()
 
-	go o.consume(wsConn, receiveCh, receiver)
+	go o.consume(receiveCh, receiver)
 	return receiver
 }
 
 func (o *nextTraceAPIV3ReceiverOwner) consume(
-	wsConn *wshandle.WsConn,
 	receiveCh <-chan string,
 	receiver *nextTraceAPIV3Receiver,
 ) {
-	wsConn.ConnMux.Lock()
 	for data := range receiveCh {
 		dispatchNextTraceAPIV3Message(data)
 	}
-	wsConn.ConnMux.Unlock()
 
 	o.mu.Lock()
 	if o.receivers[receiveCh] == receiver {

--- a/ipgeo/nexttrace_api_v3.go
+++ b/ipgeo/nexttrace_api_v3.go
@@ -30,12 +30,17 @@ var IPPools = IPPool{
 
 var getNextTraceAPIV3WSConn = wshandle.GetWsConn
 var sendNextTraceAPIV3IPRequestFn = sendNextTraceAPIV3IPRequest
+var requestNextTraceAPIV3IPFn = requestNextTraceAPIV3IP
 
 func sendNextTraceAPIV3IPRequest(ctx context.Context, wsConn *wshandle.WsConn, ip string) bool {
 	if wsConn == nil {
 		return false
 	}
 	return wsConn.SendMessage(ctx, ip) == nil
+}
+
+func requestNextTraceAPIV3IP(ctx context.Context, wsConn *wshandle.WsConn, ip string) (string, error) {
+	return wsConn.RequestMessage(ctx, ip)
 }
 
 type nextTraceAPIV3Receiver struct {
@@ -91,6 +96,12 @@ func (o *nextTraceAPIV3ReceiverOwner) consume(
 var nextTraceAPIV3Receivers = newNextTraceAPIV3ReceiverOwner()
 
 func dispatchNextTraceAPIV3Message(data string) {
+	ip, geo := parseNextTraceAPIV3Message(data)
+	ch := nextTraceAPIV3ResponseChannel(ip)
+	deliverGeo(ch, geo)
+}
+
+func parseNextTraceAPIV3Message(data string) (string, IPGeoData) {
 	// json解析 -> data
 	res := gjson.Parse(data)
 	// 根据返回的IP信息，发送给对应等待回复的IP通道上
@@ -124,8 +135,10 @@ func dispatchNextTraceAPIV3Message(data string) {
 		Prefix:    res.Get("prefix").String(),
 		Router:    m,
 	}
+	return ip, geo
+}
 
-	// Safely load (or lazily create) the channel for this IP before sending
+func nextTraceAPIV3ResponseChannel(ip string) chan IPGeoData {
 	IPPools.poolMux.RLock()
 	ch, ok := IPPools.pool[ip]
 	IPPools.poolMux.RUnlock()
@@ -137,7 +150,7 @@ func dispatchNextTraceAPIV3Message(data string) {
 		ch = IPPools.pool[ip]
 		IPPools.poolMux.Unlock()
 	}
-	deliverGeo(ch, geo)
+	return ch
 }
 
 func deliverGeo(ch chan IPGeoData, geo IPGeoData) {
@@ -164,20 +177,6 @@ func NextTraceAPIV3GeoIP(ip string, timeout time.Duration, lang string, maptrace
 		timeout = 2 * time.Second
 	}
 
-	// 确保对应 IP 的通道已存在（读锁快速路径 + 写锁惰性创建）
-	IPPools.poolMux.RLock()
-	ch, ok := IPPools.pool[ip]
-	IPPools.poolMux.RUnlock()
-	if !ok || ch == nil {
-		IPPools.poolMux.Lock()
-		if IPPools.pool[ip] == nil {
-			IPPools.pool[ip] = make(chan IPGeoData, 1)
-		}
-		ch = IPPools.pool[ip]
-		IPPools.poolMux.Unlock()
-	}
-	drainStaleGeo(ch)
-
 	wsConn := getNextTraceAPIV3WSConn()
 	if wsConn == nil {
 		return &IPGeoData{}, errors.New("TimeOut")
@@ -192,12 +191,22 @@ func NextTraceAPIV3GeoIP(ip string, timeout time.Duration, lang string, maptrace
 		return &IPGeoData{}, err
 	}
 
-	// Bind the response consumer to the same connection selected above. A
-	// concurrent global replacement must not move this request to another
-	// connection between readiness, send, and response dispatch.
+	// Keep one consumer on the compatibility stream for unsolicited or legacy
+	// messages. Bound responses are delivered directly by the supervisor.
 	nextTraceAPIV3Receivers.ensure(wsConn)
+	response, err := requestNextTraceAPIV3IPFn(waitCtx, wsConn, ip)
+	if err == nil {
+		_, geo := parseNextTraceAPIV3Message(response)
+		return &geo, nil
+	}
+	if !errors.Is(err, wshandle.ErrRequestResponseUnsupported) {
+		return &IPGeoData{}, errors.New("TimeOut")
+	}
 
-	// 发送请求
+	// Compatibility WsConn values created as struct literals have no managed
+	// generation. Preserve their public-channel behavior for callers and tests.
+	ch := nextTraceAPIV3ResponseChannel(ip)
+	drainStaleGeo(ch)
 	if !sendNextTraceAPIV3IPRequestFn(waitCtx, wsConn, ip) {
 		return &IPGeoData{}, errors.New("TimeOut")
 	}

--- a/ipgeo/nexttrace_api_v3_test.go
+++ b/ipgeo/nexttrace_api_v3_test.go
@@ -95,6 +95,10 @@ func TestNextTraceAPIV3ReceiverOwnerKeepsOldAndNewChannelsDuringHandoff(t *testi
 
 	oldReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`
 	assertNextTraceAPIV3ASN(t, oldResult, "13335")
+	if !oldConn.ConnMux.TryLock() {
+		t.Fatal("receiver holds compatibility ConnMux while waiting for messages")
+	}
+	oldConn.ConnMux.Unlock()
 
 	close(oldReceiveCh)
 	waitForNextTraceAPIV3ReceiverDone(t, oldReceiver)

--- a/ipgeo/nexttrace_api_v3_test.go
+++ b/ipgeo/nexttrace_api_v3_test.go
@@ -189,6 +189,106 @@ func TestNextTraceAPIV3GeoIPBindsReceiverAndSendToSelectedConnection(t *testing.
 	}
 }
 
+func TestNextTraceAPIV3GeoIPIgnoresOldConnectionResponseAfterBoundSubmit(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	oldConn := &wshandle.WsConn{MsgReceiveCh: make(chan string, 1)}
+	newConn := &wshandle.WsConn{MsgReceiveCh: make(chan string, 1)}
+	newConn.SetConnected(true)
+	responseCh := make(chan IPGeoData, 1)
+	restoreGlobals := replaceNextTraceAPIV3Globals(
+		owner,
+		func() *wshandle.WsConn { return newConn },
+		map[string]chan IPGeoData{"1.1.1.1": responseCh},
+	)
+	oldReceiver := owner.ensure(oldConn)
+	if oldReceiver == nil {
+		t.Fatal("old connection receiver = nil")
+	}
+
+	oldRequestFn := requestNextTraceAPIV3IPFn
+	oldSendFn := sendNextTraceAPIV3IPRequestFn
+	var fallbackSendCalled atomic.Bool
+	submitted := make(chan struct{})
+	boundResponse := make(chan string, 1)
+	requestNextTraceAPIV3IPFn = func(ctx context.Context, conn *wshandle.WsConn, ip string) (string, error) {
+		if conn != newConn || ip != "1.1.1.1" {
+			t.Errorf("bound request = (%p, %q), want (%p, 1.1.1.1)", conn, ip, newConn)
+		}
+		close(submitted)
+		select {
+		case response := <-boundResponse:
+			return response, nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	sendNextTraceAPIV3IPRequestFn = func(context.Context, *wshandle.WsConn, string) bool {
+		fallbackSendCalled.Store(true)
+		return false
+	}
+	defer func() {
+		requestNextTraceAPIV3IPFn = oldRequestFn
+		sendNextTraceAPIV3IPRequestFn = oldSendFn
+		close(oldConn.MsgReceiveCh)
+		waitForNextTraceAPIV3ReceiverDone(t, oldReceiver)
+		newReceiver := nextTraceAPIV3ReceiverFor(owner, newConn.MsgReceiveCh)
+		close(newConn.MsgReceiveCh)
+		if newReceiver != nil {
+			waitForNextTraceAPIV3ReceiverDone(t, newReceiver)
+		}
+		restoreGlobals()
+	}()
+
+	type result struct {
+		geo *IPGeoData
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		geo, err := NextTraceAPIV3GeoIP("1.1.1.1", 2*time.Second, "en", false)
+		done <- result{geo: geo, err: err}
+	}()
+
+	select {
+	case <-submitted:
+	case <-time.After(time.Second):
+		t.Fatal("new connection request was not submitted")
+	}
+
+	oldConn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"OLD"}`
+	var oldGeo IPGeoData
+	select {
+	case oldGeo = <-responseCh:
+		if oldGeo.Asnumber != "OLD" {
+			t.Fatalf("old response ASN = %q, want OLD", oldGeo.Asnumber)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old connection response did not reach the compatibility pool")
+	}
+	responseCh <- oldGeo
+	select {
+	case got := <-done:
+		t.Fatalf("old connection response completed bound request: %+v", got)
+	default:
+	}
+
+	boundResponse <- `{"ip":"1.1.1.1","asnumber":"NEW"}`
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("NextTraceAPIV3GeoIP() error = %v", got.err)
+		}
+		if got.geo == nil || got.geo.Asnumber != "NEW" {
+			t.Fatalf("NextTraceAPIV3GeoIP() geo = %+v, want ASN NEW", got.geo)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bound response did not complete the new connection request")
+	}
+	if fallbackSendCalled.Load() {
+		t.Fatal("managed request fell back to the generationless send path")
+	}
+}
+
 func TestNextTraceAPIV3GeoIPRejectsSelectedConnectionClosedBeforeSubmit(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		owner := newNextTraceAPIV3ReceiverOwner()

--- a/ipgeo/nexttrace_api_v3_test.go
+++ b/ipgeo/nexttrace_api_v3_test.go
@@ -2,343 +2,466 @@ package ipgeo
 
 import (
 	"context"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
-func TestNextTraceAPIV3GeoIPWaitsForConnectionBeforeSending(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	oldPools := IPPools.pool
-	oldRunning, oldRestart := nextTraceAPIV3ReceiveState()
-	var conn *wshandle.WsConn
-	nextTraceAPIV3ReceiveStarted := make(chan struct{})
-	var getConnCalls int32
-	var closeStarted sync.Once
-	defer func() {
-		if conn != nil && conn.MsgReceiveCh != nil {
-			close(conn.MsgReceiveCh)
+func TestNextTraceAPIV3ReceiverOwnerConcurrentEnsureUsesOneConsumer(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	receiveCh := make(chan string)
+	conn := &wshandle.WsConn{MsgReceiveCh: receiveCh}
+
+	const callers = 64
+	receivers := make([]*nextTraceAPIV3Receiver, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range receivers {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			receivers[index] = owner.ensure(conn)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	first := receivers[0]
+	if first == nil {
+		t.Fatal("ensure() receiver = nil")
+	}
+	for i, receiver := range receivers[1:] {
+		if receiver != first {
+			t.Fatalf("ensure() receiver[%d] = %p, want %p", i+1, receiver, first)
 		}
-		waitForNextTraceAPIV3ReceiveStart(t, nextTraceAPIV3ReceiveStarted)
-		waitForNextTraceAPIV3ReceiveStop(t)
-		getNextTraceAPIV3WSConn = oldGet
-		IPPools.pool = oldPools
-		setNextTraceAPIV3ReceiveState(oldRunning, oldRestart)
-	}()
+	}
+	if got := nextTraceAPIV3ReceiverCount(owner); got != 1 {
+		t.Fatalf("receiver count = %d, want 1", got)
+	}
 
-	IPPools.pool = make(map[string]chan IPGeoData)
-	setNextTraceAPIV3ReceiveState(false, false)
+	close(receiveCh)
+	waitForNextTraceAPIV3ReceiverDone(t, first)
+	if got := nextTraceAPIV3ReceiverCount(owner); got != 0 {
+		t.Fatalf("receiver count after close = %d, want 0", got)
+	}
+}
 
-	conn = &wshandle.WsConn{
+func TestNextTraceAPIV3ReceiverOwnerDeduplicatesSharedChannelWrappers(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	receiveCh := make(chan string)
+	firstConn := &wshandle.WsConn{MsgReceiveCh: receiveCh}
+	secondConn := &wshandle.WsConn{MsgReceiveCh: receiveCh}
+
+	first := owner.ensure(firstConn)
+	second := owner.ensure(secondConn)
+	if first == nil || second != first {
+		t.Fatalf("shared channel receivers = (%p, %p), want one receiver", first, second)
+	}
+	if got := nextTraceAPIV3ReceiverCount(owner); got != 1 {
+		t.Fatalf("receiver count = %d, want 1", got)
+	}
+
+	close(receiveCh)
+	waitForNextTraceAPIV3ReceiverDone(t, first)
+}
+
+func TestNextTraceAPIV3ReceiverOwnerKeepsOldAndNewChannelsDuringHandoff(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	oldReceiveCh := make(chan string, 1)
+	newReceiveCh := make(chan string, 1)
+	oldConn := &wshandle.WsConn{MsgReceiveCh: oldReceiveCh}
+	newConn := &wshandle.WsConn{MsgReceiveCh: newReceiveCh}
+	oldReceiver := owner.ensure(oldConn)
+	newReceiver := owner.ensure(newConn)
+	if oldReceiver == nil || newReceiver == nil || oldReceiver == newReceiver {
+		t.Fatalf("handoff receivers = (%p, %p), want distinct receivers", oldReceiver, newReceiver)
+	}
+	if got := nextTraceAPIV3ReceiverCount(owner); got != 2 {
+		t.Fatalf("receiver count during handoff = %d, want 2", got)
+	}
+
+	oldResult := make(chan IPGeoData, 1)
+	newResult := make(chan IPGeoData, 1)
+	restorePool := replaceNextTraceAPIV3Pool(map[string]chan IPGeoData{
+		"1.1.1.1": oldResult,
+		"2.2.2.2": newResult,
+	})
+	defer restorePool()
+
+	oldReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`
+	assertNextTraceAPIV3ASN(t, oldResult, "13335")
+
+	close(oldReceiveCh)
+	waitForNextTraceAPIV3ReceiverDone(t, oldReceiver)
+	if got := nextTraceAPIV3ReceiverCount(owner); got != 1 {
+		t.Fatalf("receiver count after old close = %d, want 1", got)
+	}
+
+	newReceiveCh <- `{"ip":"2.2.2.2","asnumber":"64512"}`
+	assertNextTraceAPIV3ASN(t, newResult, "64512")
+	close(newReceiveCh)
+	waitForNextTraceAPIV3ReceiverDone(t, newReceiver)
+}
+
+func TestNextTraceAPIV3GeoIPBindsReceiverAndSendToSelectedConnection(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	oldConn := &wshandle.WsConn{
 		MsgSendCh:    make(chan string, 1),
 		MsgReceiveCh: make(chan string, 1),
-		Interrupt:    make(chan os.Signal, 1),
-	}
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn {
-		if atomic.AddInt32(&getConnCalls, 1) >= 3 {
-			closeStarted.Do(func() { close(nextTraceAPIV3ReceiveStarted) })
-		}
-		return conn
-	}
-
-	sent := make(chan string, 1)
-	go func() {
-		msg := <-conn.MsgSendCh
-		sent <- msg
-		conn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`
-	}()
-
-	var (
-		gotGeo *IPGeoData
-		gotErr error
-	)
-	done := make(chan struct{})
-	go func() {
-		gotGeo, gotErr = NextTraceAPIV3GeoIP("1.1.1.1", 300*time.Millisecond, "en", false)
-		close(done)
-	}()
-
-	select {
-	case <-sent:
-		t.Fatal("NextTraceAPIV3GeoIP sent request before websocket became connected")
-	case <-time.After(60 * time.Millisecond):
-	}
-
-	conn.SetConnected(true)
-
-	select {
-	case msg := <-sent:
-		if msg != "1.1.1.1" {
-			t.Fatalf("sent request = %q, want 1.1.1.1", msg)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("NextTraceAPIV3GeoIP did not send request after websocket became connected")
-	}
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("NextTraceAPIV3GeoIP did not complete")
-	}
-
-	if gotErr != nil {
-		t.Fatalf("NextTraceAPIV3GeoIP error = %v, want nil", gotErr)
-	}
-	if gotGeo == nil || gotGeo.Asnumber != "13335" {
-		t.Fatalf("NextTraceAPIV3GeoIP geo = %+v, want ASN 13335", gotGeo)
-	}
-}
-
-func TestNextTraceAPIV3GeoIPUsesSingleTimeoutBudget(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	oldPools := IPPools.pool
-	oldRunning, oldRestart := nextTraceAPIV3ReceiveState()
-	var conn *wshandle.WsConn
-	nextTraceAPIV3ReceiveStarted := make(chan struct{})
-	var getConnCalls int32
-	var closeStarted sync.Once
-	defer func() {
-		if conn != nil && conn.MsgReceiveCh != nil {
-			close(conn.MsgReceiveCh)
-		}
-		waitForNextTraceAPIV3ReceiveStart(t, nextTraceAPIV3ReceiveStarted)
-		waitForNextTraceAPIV3ReceiveStop(t)
-		getNextTraceAPIV3WSConn = oldGet
-		IPPools.pool = oldPools
-		setNextTraceAPIV3ReceiveState(oldRunning, oldRestart)
-	}()
-
-	IPPools.pool = make(map[string]chan IPGeoData)
-	setNextTraceAPIV3ReceiveState(false, false)
-
-	conn = &wshandle.WsConn{
-		MsgSendCh:    make(chan string, 1),
-		MsgReceiveCh: make(chan string),
-		Interrupt:    make(chan os.Signal, 1),
-	}
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn {
-		if atomic.AddInt32(&getConnCalls, 1) >= 3 {
-			closeStarted.Do(func() { close(nextTraceAPIV3ReceiveStarted) })
-		}
-		return conn
-	}
-
-	start := time.Now()
-	done := make(chan error, 1)
-	go func() {
-		_, err := NextTraceAPIV3GeoIP("1.1.1.1", 2*time.Second, "en", false)
-		done <- err
-	}()
-
-	time.Sleep(1500 * time.Millisecond)
-	conn.SetConnected(true)
-
-	select {
-	case err := <-done:
-		if err == nil || err.Error() != "TimeOut" {
-			t.Fatalf("NextTraceAPIV3GeoIP error = %v, want TimeOut", err)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("NextTraceAPIV3GeoIP exceeded expected shared timeout budget")
-	}
-
-	if elapsed := time.Since(start); elapsed > 2800*time.Millisecond {
-		t.Fatalf("NextTraceAPIV3GeoIP elapsed = %s, want <= 2.8s", elapsed)
-	}
-}
-
-func TestNextTraceAPIV3ReceiveReturnsWhenWebsocketMissing(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	defer func() { getNextTraceAPIV3WSConn = oldGet }()
-
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn { return nil }
-
-	done := make(chan struct{})
-	go func() {
-		receiveNextTraceAPIV3Responses()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses should return when websocket is nil")
-	}
-}
-
-func TestNextTraceAPIV3ReceiveContinuesAfterWebsocketReplacement(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	oldPools := IPPools.pool
-	defer func() {
-		getNextTraceAPIV3WSConn = oldGet
-		IPPools.pool = oldPools
-	}()
-
-	oldConn := &wshandle.WsConn{
-		MsgReceiveCh: make(chan string),
-		Interrupt:    make(chan os.Signal, 1),
 	}
 	newConn := &wshandle.WsConn{
-		MsgReceiveCh: make(chan string),
-		Interrupt:    make(chan os.Signal, 1),
+		MsgSendCh:    make(chan string, 1),
+		MsgReceiveCh: make(chan string, 1),
 	}
-	current := oldConn
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn {
-		return current
-	}
+	oldConn.SetConnected(true)
+	newConn.SetConnected(true)
 
-	oldResult := make(chan IPGeoData, 1)
-	newResult := make(chan IPGeoData, 1)
-	IPPools.pool = map[string]chan IPGeoData{
-		"1.1.1.1": oldResult,
-		"2.2.2.2": newResult,
-	}
+	var getCalls atomic.Int32
+	restoreGlobals := replaceNextTraceAPIV3Globals(owner, func() *wshandle.WsConn {
+		if getCalls.Add(1) == 1 {
+			return oldConn
+		}
+		return newConn
+	}, make(map[string]chan IPGeoData))
+	defer func() {
+		oldReceiver := nextTraceAPIV3ReceiverFor(owner, oldConn.MsgReceiveCh)
+		close(oldConn.MsgReceiveCh)
+		if oldReceiver != nil {
+			waitForNextTraceAPIV3ReceiverDone(t, oldReceiver)
+		}
+		close(newConn.MsgReceiveCh)
+		restoreGlobals()
+	}()
 
-	done := make(chan struct{})
+	type result struct {
+		geo *IPGeoData
+		err error
+	}
+	done := make(chan result, 1)
 	go func() {
-		receiveNextTraceAPIV3Responses()
-		close(done)
+		geo, err := NextTraceAPIV3GeoIP("1.1.1.1", 2*time.Second, "en", false)
+		done <- result{geo: geo, err: err}
 	}()
 
 	select {
-	case oldConn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`:
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not consume from the original websocket")
-	}
-	select {
-	case geo := <-oldResult:
-		if geo.Asnumber != "13335" {
-			t.Fatalf("old websocket geo ASN = %q, want 13335", geo.Asnumber)
+	case ip := <-oldConn.MsgSendCh:
+		if ip != "1.1.1.1" {
+			t.Fatalf("old connection request = %q, want 1.1.1.1", ip)
+		}
+		if nextTraceAPIV3ReceiverFor(owner, oldConn.MsgReceiveCh) == nil {
+			t.Fatal("request was sent before its selected receive channel was ensured")
 		}
 	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not dispatch original websocket data")
-	}
-
-	current = newConn
-	close(oldConn.MsgReceiveCh)
-
-	select {
-	case newConn.MsgReceiveCh <- `{"ip":"2.2.2.2","asnumber":"64512"}`:
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not switch to replacement websocket")
+		t.Fatal("selected old connection did not receive request")
 	}
 	select {
-	case geo := <-newResult:
-		if geo.Asnumber != "64512" {
-			t.Fatalf("new websocket geo ASN = %q, want 64512", geo.Asnumber)
+	case ip := <-newConn.MsgSendCh:
+		t.Fatalf("replacement connection unexpectedly received request %q", ip)
+	default:
+	}
+
+	oldConn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("NextTraceAPIV3GeoIP() error = %v", got.err)
+		}
+		if got.geo == nil || got.geo.Asnumber != "13335" {
+			t.Fatalf("NextTraceAPIV3GeoIP() geo = %+v, want ASN 13335", got.geo)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not dispatch replacement websocket data")
+		t.Fatal("NextTraceAPIV3GeoIP() did not receive response from selected connection")
 	}
-
-	close(newConn.MsgReceiveCh)
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not exit after replacement websocket closed")
+	if got := getCalls.Load(); got != 1 {
+		t.Fatalf("GetWsConn calls = %d, want 1", got)
+	}
+	if nextTraceAPIV3ReceiverFor(owner, newConn.MsgReceiveCh) != nil {
+		t.Fatal("replacement connection unexpectedly gained a receiver")
 	}
 }
 
-func TestStartNextTraceAPIV3ReceiverRestartsAfterQueuedStart(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	oldPools := IPPools.pool
-	oldRunning, oldRestart := nextTraceAPIV3ReceiveState()
-	var closeOld, closeNew sync.Once
-	var oldConn, newConn *wshandle.WsConn
+func TestNextTraceAPIV3GeoIPRejectsSelectedConnectionClosedBeforeSubmit(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		owner := newNextTraceAPIV3ReceiverOwner()
+		oldConn := &wshandle.WsConn{
+			MsgSendCh:    make(chan string, 1),
+			MsgReceiveCh: make(chan string, 1),
+		}
+		newConn := &wshandle.WsConn{
+			MsgSendCh:    make(chan string, 1),
+			MsgReceiveCh: make(chan string, 1),
+		}
+		oldConn.SetConnected(true)
+		newConn.SetConnected(true)
+
+		var current atomic.Pointer[wshandle.WsConn]
+		current.Store(oldConn)
+		restoreGlobals := replaceNextTraceAPIV3Globals(
+			owner,
+			func() *wshandle.WsConn { return current.Load() },
+			make(map[string]chan IPGeoData),
+		)
+		oldSendFn := sendNextTraceAPIV3IPRequestFn
+		reachedSubmit := make(chan struct{})
+		releaseSubmit := make(chan struct{})
+		sendNextTraceAPIV3IPRequestFn = func(ctx context.Context, conn *wshandle.WsConn, ip string) bool {
+			close(reachedSubmit)
+			<-releaseSubmit
+			return sendNextTraceAPIV3IPRequest(ctx, conn, ip)
+		}
+		defer func() {
+			sendNextTraceAPIV3IPRequestFn = oldSendFn
+			newConn.Close()
+			restoreGlobals()
+		}()
+
+		type result struct {
+			geo *IPGeoData
+			err error
+		}
+		startedAt := time.Now()
+		done := make(chan result, 1)
+		go func() {
+			geo, err := NextTraceAPIV3GeoIP("1.1.1.1", time.Millisecond, "en", false)
+			done <- result{geo: geo, err: err}
+		}()
+
+		<-reachedSubmit
+		receiver := nextTraceAPIV3ReceiverFor(owner, oldConn.MsgReceiveCh)
+		if receiver == nil {
+			t.Fatal("selected connection receiver was not ensured before submit")
+		}
+		current.Store(newConn)
+		oldConn.Close()
+		close(releaseSubmit)
+		synctest.Wait()
+
+		got := <-done
+		if got.err == nil || got.err.Error() != "TimeOut" {
+			t.Fatalf("NextTraceAPIV3GeoIP() error = %v, want TimeOut", got.err)
+		}
+		if got.geo == nil || got.geo.Asnumber != "" || got.geo.IP != "" {
+			t.Fatalf("NextTraceAPIV3GeoIP() geo = %+v, want empty result", got.geo)
+		}
+		if elapsed := time.Since(startedAt); elapsed != 0 {
+			t.Fatalf("closed selected connection consumed timeout budget: %s", elapsed)
+		}
+		select {
+		case msg := <-oldConn.MsgSendCh:
+			t.Fatalf("closed old connection accepted request %q", msg)
+		default:
+		}
+		select {
+		case msg := <-newConn.MsgSendCh:
+			t.Fatalf("replacement connection unexpectedly accepted request %q", msg)
+		default:
+		}
+		<-receiver.done
+	})
+}
+
+func TestNextTraceAPIV3GeoIPWaitsForConnectionBeforeSending(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		owner := newNextTraceAPIV3ReceiverOwner()
+		conn := &wshandle.WsConn{
+			MsgSendCh:    make(chan string, 1),
+			MsgReceiveCh: make(chan string, 1),
+		}
+		restoreGlobals := replaceNextTraceAPIV3Globals(
+			owner,
+			func() *wshandle.WsConn { return conn },
+			make(map[string]chan IPGeoData),
+		)
+		defer func() {
+			receiver := nextTraceAPIV3ReceiverFor(owner, conn.MsgReceiveCh)
+			close(conn.MsgReceiveCh)
+			if receiver != nil {
+				<-receiver.done
+			}
+			restoreGlobals()
+		}()
+
+		type result struct {
+			geo *IPGeoData
+			err error
+		}
+		done := make(chan result, 1)
+		go func() {
+			geo, err := NextTraceAPIV3GeoIP("1.1.1.1", time.Millisecond, "en", false)
+			done <- result{geo: geo, err: err}
+		}()
+		synctest.Wait()
+
+		select {
+		case ip := <-conn.MsgSendCh:
+			t.Fatalf("request %q sent before connection became ready", ip)
+		default:
+		}
+		time.Sleep(time.Second)
+		synctest.Wait()
+		select {
+		case ip := <-conn.MsgSendCh:
+			t.Fatalf("request %q sent before connection became ready", ip)
+		default:
+		}
+
+		conn.SetConnected(true)
+		synctest.Wait()
+		select {
+		case ip := <-conn.MsgSendCh:
+			if ip != "1.1.1.1" {
+				t.Fatalf("request = %q, want 1.1.1.1", ip)
+			}
+		default:
+			t.Fatal("request not sent after connection became ready")
+		}
+		conn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`
+		synctest.Wait()
+		got := <-done
+		if got.err != nil {
+			t.Fatalf("NextTraceAPIV3GeoIP() error = %v", got.err)
+		}
+		if got.geo == nil || got.geo.Asnumber != "13335" {
+			t.Fatalf("NextTraceAPIV3GeoIP() geo = %+v, want ASN 13335", got.geo)
+		}
+	})
+}
+
+func TestNextTraceAPIV3GeoIPUsesSingleMinimumTimeoutBudget(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		owner := newNextTraceAPIV3ReceiverOwner()
+		conn := &wshandle.WsConn{
+			MsgSendCh:    make(chan string, 1),
+			MsgReceiveCh: make(chan string),
+		}
+		restoreGlobals := replaceNextTraceAPIV3Globals(
+			owner,
+			func() *wshandle.WsConn { return conn },
+			make(map[string]chan IPGeoData),
+		)
+		defer func() {
+			receiver := nextTraceAPIV3ReceiverFor(owner, conn.MsgReceiveCh)
+			close(conn.MsgReceiveCh)
+			if receiver != nil {
+				<-receiver.done
+			}
+			restoreGlobals()
+		}()
+
+		started := time.Now()
+		done := make(chan error, 1)
+		go func() {
+			_, err := NextTraceAPIV3GeoIP("1.1.1.1", time.Millisecond, "en", false)
+			done <- err
+		}()
+		synctest.Wait()
+
+		time.Sleep(1500 * time.Millisecond)
+		conn.SetConnected(true)
+		synctest.Wait()
+		select {
+		case ip := <-conn.MsgSendCh:
+			if ip != "1.1.1.1" {
+				t.Fatalf("request = %q, want 1.1.1.1", ip)
+			}
+		default:
+			t.Fatal("request not sent after connection became ready")
+		}
+
+		time.Sleep(500 * time.Millisecond)
+		synctest.Wait()
+		if err := <-done; err == nil || err.Error() != "TimeOut" {
+			t.Fatalf("NextTraceAPIV3GeoIP() error = %v, want TimeOut", err)
+		}
+		if elapsed := time.Since(started); elapsed != 2*time.Second {
+			t.Fatalf("NextTraceAPIV3GeoIP() elapsed = %s, want 2s", elapsed)
+		}
+	})
+}
+
+func TestNextTraceAPIV3GeoIPReturnsTimeOutWhenWebsocketMissing(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	restoreGlobals := replaceNextTraceAPIV3Globals(
+		owner,
+		func() *wshandle.WsConn { return nil },
+		make(map[string]chan IPGeoData),
+	)
+	defer restoreGlobals()
+
+	_, err := NextTraceAPIV3GeoIP("1.1.1.1", time.Millisecond, "en", false)
+	if err == nil || err.Error() != "TimeOut" {
+		t.Fatalf("NextTraceAPIV3GeoIP() error = %v, want TimeOut", err)
+	}
+	if got := nextTraceAPIV3ReceiverCount(owner); got != 0 {
+		t.Fatalf("receiver count = %d, want 0", got)
+	}
+}
+
+func TestNextTraceAPIV3APIErrorDeliveredOnce(t *testing.T) {
+	owner := newNextTraceAPIV3ReceiverOwner()
+	conn := &wshandle.WsConn{
+		MsgSendCh:    make(chan string, 1),
+		MsgReceiveCh: make(chan string, 1),
+	}
+	conn.SetConnected(true)
+	restoreGlobals := replaceNextTraceAPIV3Globals(
+		owner,
+		func() *wshandle.WsConn { return conn },
+		make(map[string]chan IPGeoData),
+	)
 	defer func() {
-		if oldConn != nil {
-			closeOld.Do(func() { close(oldConn.MsgReceiveCh) })
+		receiver := nextTraceAPIV3ReceiverFor(owner, conn.MsgReceiveCh)
+		close(conn.MsgReceiveCh)
+		if receiver != nil {
+			waitForNextTraceAPIV3ReceiverDone(t, receiver)
 		}
-		if newConn != nil {
-			closeNew.Do(func() { close(newConn.MsgReceiveCh) })
-		}
-		waitForNextTraceAPIV3ReceiveStop(t)
-		getNextTraceAPIV3WSConn = oldGet
-		IPPools.pool = oldPools
-		setNextTraceAPIV3ReceiveState(oldRunning, oldRestart)
+		restoreGlobals()
 	}()
 
-	oldConn = &wshandle.WsConn{
-		MsgReceiveCh: make(chan string),
-		Interrupt:    make(chan os.Signal, 1),
-	}
-	newConn = &wshandle.WsConn{
-		MsgReceiveCh: make(chan string),
-		Interrupt:    make(chan os.Signal, 1),
-	}
-	afterOldClose := atomic.Bool{}
-	afterOldCloseCalls := atomic.Int32{}
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn {
-		if afterOldClose.Load() {
-			if afterOldCloseCalls.Add(1) == 1 {
-				return oldConn
-			}
-			return newConn
-		}
-		return oldConn
-	}
-
-	oldResult := make(chan IPGeoData, 1)
-	newResult := make(chan IPGeoData, 1)
-	IPPools.pool = map[string]chan IPGeoData{
-		"1.1.1.1": oldResult,
-		"2.2.2.2": newResult,
-	}
-	setNextTraceAPIV3ReceiveState(false, false)
-
-	startNextTraceAPIV3Receiver()
-	select {
-	case oldConn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`:
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not consume from the original websocket")
-	}
-	select {
-	case geo := <-oldResult:
-		if geo.Asnumber != "13335" {
-			t.Fatalf("old websocket geo ASN = %q, want 13335", geo.Asnumber)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not dispatch original websocket data")
-	}
-
-	startNextTraceAPIV3Receiver()
-	afterOldClose.Store(true)
-	closeOld.Do(func() { close(oldConn.MsgReceiveCh) })
+	done := make(chan struct {
+		geo *IPGeoData
+		err error
+	}, 1)
+	go func() {
+		geo, err := NextTraceAPIV3GeoIP("1.1.1.1", 2*time.Second, "en", false)
+		done <- struct {
+			geo *IPGeoData
+			err error
+		}{geo: geo, err: err}
+	}()
 
 	select {
-	case newConn.MsgReceiveCh <- `{"ip":"2.2.2.2","asnumber":"64512"}`:
+	case <-conn.MsgSendCh:
 	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not restart for a queued start")
+		t.Fatal("request was not sent")
 	}
-	select {
-	case geo := <-newResult:
-		if geo.Asnumber != "64512" {
-			t.Fatalf("new websocket geo ASN = %q, want 64512", geo.Asnumber)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("receiveNextTraceAPIV3Responses did not dispatch restarted websocket data")
+	conn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"API Server Error"}`
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("NextTraceAPIV3GeoIP() error = %v", got.err)
+	}
+	if got.geo == nil || got.geo.Asnumber != "API Server Error" {
+		t.Fatalf("NextTraceAPIV3GeoIP() geo = %+v, want API Server Error", got.geo)
 	}
 
-	closeNew.Do(func() { close(newConn.MsgReceiveCh) })
+	IPPools.poolMux.RLock()
+	responseCh := IPPools.pool["1.1.1.1"]
+	IPPools.poolMux.RUnlock()
+	select {
+	case duplicate := <-responseCh:
+		t.Fatalf("duplicate API error delivery = %+v", duplicate)
+	default:
+	}
 }
 
 func TestSendNextTraceAPIV3IPRequestHonorsContextWhenQueueIsFull(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	defer func() { getNextTraceAPIV3WSConn = oldGet }()
-
-	conn := &wshandle.WsConn{
-		MsgSendCh: make(chan string, 1),
-		Interrupt: make(chan os.Signal, 1),
-	}
+	conn := &wshandle.WsConn{MsgSendCh: make(chan string, 1)}
 	conn.MsgSendCh <- "blocked"
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn {
-		return conn
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	if sendNextTraceAPIV3IPRequest(ctx, conn, "1.1.1.1") {
@@ -347,15 +470,7 @@ func TestSendNextTraceAPIV3IPRequestHonorsContextWhenQueueIsFull(t *testing.T) {
 }
 
 func TestSendNextTraceAPIV3IPRequestUsesProvidedConnection(t *testing.T) {
-	oldGet := getNextTraceAPIV3WSConn
-	defer func() { getNextTraceAPIV3WSConn = oldGet }()
-
-	conn := &wshandle.WsConn{
-		MsgSendCh: make(chan string, 1),
-		Interrupt: make(chan os.Signal, 1),
-	}
-	getNextTraceAPIV3WSConn = func() *wshandle.WsConn { return nil }
-
+	conn := &wshandle.WsConn{MsgSendCh: make(chan string, 1)}
 	if !sendNextTraceAPIV3IPRequest(context.Background(), conn, "1.1.1.1") {
 		t.Fatal("sendNextTraceAPIV3IPRequest() = false, want true")
 	}
@@ -370,12 +485,10 @@ func TestSendNextTraceAPIV3IPRequestUsesProvidedConnection(t *testing.T) {
 }
 
 func TestDispatchNextTraceAPIV3MessageReplacesStaleBufferedResponse(t *testing.T) {
-	oldPools := IPPools.pool
-	defer func() { IPPools.pool = oldPools }()
-
 	ch := make(chan IPGeoData, 1)
 	ch <- IPGeoData{Asnumber: "STALE"}
-	IPPools.pool = map[string]chan IPGeoData{"1.1.1.1": ch}
+	restorePool := replaceNextTraceAPIV3Pool(map[string]chan IPGeoData{"1.1.1.1": ch})
+	defer restorePool()
 
 	dispatchNextTraceAPIV3Message(`{"ip":"1.1.1.1","asnumber":"13335"}`)
 
@@ -389,42 +502,64 @@ func TestDispatchNextTraceAPIV3MessageReplacesStaleBufferedResponse(t *testing.T
 	}
 }
 
-func waitForNextTraceAPIV3ReceiveStart(t *testing.T, started <-chan struct{}) {
+func replaceNextTraceAPIV3Globals(
+	owner *nextTraceAPIV3ReceiverOwner,
+	getConn func() *wshandle.WsConn,
+	pool map[string]chan IPGeoData,
+) func() {
+	oldOwner := nextTraceAPIV3Receivers
+	oldGetConn := getNextTraceAPIV3WSConn
+	nextTraceAPIV3Receivers = owner
+	getNextTraceAPIV3WSConn = getConn
+	restorePool := replaceNextTraceAPIV3Pool(pool)
+	return func() {
+		restorePool()
+		getNextTraceAPIV3WSConn = oldGetConn
+		nextTraceAPIV3Receivers = oldOwner
+	}
+}
+
+func replaceNextTraceAPIV3Pool(pool map[string]chan IPGeoData) func() {
+	IPPools.poolMux.Lock()
+	oldPool := IPPools.pool
+	IPPools.pool = pool
+	IPPools.poolMux.Unlock()
+	return func() {
+		IPPools.poolMux.Lock()
+		IPPools.pool = oldPool
+		IPPools.poolMux.Unlock()
+	}
+}
+
+func nextTraceAPIV3ReceiverFor(owner *nextTraceAPIV3ReceiverOwner, ch <-chan string) *nextTraceAPIV3Receiver {
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	return owner.receivers[ch]
+}
+
+func nextTraceAPIV3ReceiverCount(owner *nextTraceAPIV3ReceiverOwner) int {
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	return len(owner.receivers)
+}
+
+func waitForNextTraceAPIV3ReceiverDone(t *testing.T, receiver *nextTraceAPIV3Receiver) {
 	t.Helper()
 	select {
-	case <-started:
+	case <-receiver.done:
 	case <-time.After(time.Second):
-		t.Fatal("waitForNextTraceAPIV3ReceiveStart: receiveNextTraceAPIV3Responses did not start")
+		t.Fatal("NextTrace API v3 receiver did not stop")
 	}
 }
 
-func waitForNextTraceAPIV3ReceiveStop(t *testing.T) {
+func assertNextTraceAPIV3ASN(t *testing.T, ch <-chan IPGeoData, want string) {
 	t.Helper()
-	deadline := time.After(time.Second)
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		running, _ := nextTraceAPIV3ReceiveState()
-		if !running {
-			return
+	select {
+	case geo := <-ch:
+		if geo.Asnumber != want {
+			t.Fatalf("geo ASN = %q, want %q", geo.Asnumber, want)
 		}
-		select {
-		case <-deadline:
-			t.Fatal("waitForNextTraceAPIV3ReceiveStop: receiveNextTraceAPIV3Responses did not stop")
-		case <-ticker.C:
-		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for ASN %q", want)
 	}
-}
-
-func nextTraceAPIV3ReceiveState() (bool, bool) {
-	nextTraceAPIV3ReceiveMu.Lock()
-	defer nextTraceAPIV3ReceiveMu.Unlock()
-	return nextTraceAPIV3ReceiveRunning, nextTraceAPIV3ReceiveRestart
-}
-
-func setNextTraceAPIV3ReceiveState(running, restart bool) {
-	nextTraceAPIV3ReceiveMu.Lock()
-	defer nextTraceAPIV3ReceiveMu.Unlock()
-	nextTraceAPIV3ReceiveRunning = running
-	nextTraceAPIV3ReceiveRestart = restart
 }

--- a/wshandle/client.go
+++ b/wshandle/client.go
@@ -2,12 +2,9 @@ package wshandle
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"log"
 	"net"
-	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -27,52 +24,122 @@ func formatHostPort(addr, port string) string {
 }
 
 type wsWriteJob struct {
-	msgType int
-	data    []byte
+	id         uint64
+	generation uint64
+	genDone    <-chan struct{}
+	wire       wsWire
+	kind       wsWriteKind
+	msgType    int
+	data       []byte
+	requestIP  string
+	requestCtx context.Context
+	stopCancel func() bool
+	awaitReply bool
+	pongSerial uint64
 }
 
 const (
 	wsClientWriteQueueSize = 1024
 	wsClientWriteTimeout   = 5 * time.Second
 	wsClientDialTimeout    = 5 * time.Second
+	wsClientPingInterval   = 54 * time.Second
+	wsClientReconnectDelay = 200 * time.Millisecond
+	wsClientDialRetryDelay = time.Second
 )
 
 type WsConn struct {
-	Connecting    bool
-	Connected     bool            // 连接状态
-	MsgSendCh     chan string     // 消息发送通道
-	MsgReceiveCh  chan string     // 消息接收通道
-	Done          chan struct{}   // 发送结束通道
-	Exit          chan bool       // 程序退出信号
-	Interrupt     chan os.Signal  // 终端中止信号
-	Conn          *websocket.Conn // 主连接
-	ConnMux       sync.Mutex      // 连接互斥锁
-	stateMu       sync.RWMutex
-	lifecycleMu   sync.Mutex
-	loopWG        sync.WaitGroup
-	closeOnce     sync.Once
-	baseWatchOnce sync.Once
-	writeCh       chan wsWriteJob // serialized write queue
-	writeStop     chan struct{}   // signals writeLoop to exit
-	closeCh       chan struct{}   // signals background loops to exit
-	closed        bool
-	baseCtx       context.Context
-	directIP      bool
-	apiHost       string
-	apiPort       string
-	apiFastIP     string
+	Connecting       bool
+	Connected        bool            // 连接状态
+	MsgSendCh        chan string     // 消息发送通道
+	MsgReceiveCh     chan string     // 消息接收通道
+	Done             chan struct{}   // 发送结束通道
+	Exit             chan bool       // 程序退出信号
+	Interrupt        chan os.Signal  // 终端中止信号
+	Conn             *websocket.Conn // 主连接
+	ConnMux          sync.Mutex      // 连接互斥锁
+	stateMu          sync.RWMutex
+	closeOnce        sync.Once
+	closeSignal      sync.Once
+	receiveOnce      sync.Once
+	closeCh          chan struct{} // signals background loops to exit
+	baseCtx          context.Context
+	rootCtx          context.Context
+	cancelRoot       context.CancelCauseFunc
+	managed          bool
+	phase            wsPhase
+	stateChanged     chan struct{}
+	doneClosed       bool
+	supervisorOnce   sync.Once
+	supervisorReady  chan struct{}
+	supervisorDone   chan struct{}
+	firstAttemptDone chan struct{}
+	firstAttemptOnce sync.Once
+	firstAttemptErr  error
+	submitCh         chan wsSubmission
+	requestCancels   chan wsRequestCancel
+	dialResults      chan wsDialResult
+	readEvents       chan wsReadEvent
+	managedWriteCh   chan wsWriteJob
+	writeResults     chan wsWriteResult
+	workerWG         sync.WaitGroup
+	directIP         bool
+	apiHost          string
+	apiPort          string
+	apiFastIP        string
+	syncFirstAttempt bool
 }
 
-func (c *WsConn) getConn() *websocket.Conn {
-	c.stateMu.RLock()
-	defer c.stateMu.RUnlock()
-	return c.Conn
+func (c *WsConn) ensureCompatSignalsLocked() {
+	if c.stateChanged == nil {
+		c.stateChanged = make(chan struct{})
+	}
+	if c.closeCh == nil {
+		c.closeCh = make(chan struct{})
+	}
+	if c.rootCtx == nil {
+		c.rootCtx, c.cancelRoot = context.WithCancelCause(context.Background())
+	}
 }
 
-func (c *WsConn) setConn(conn *websocket.Conn) {
+func (c *WsConn) notifyStateLocked() {
+	if c.stateChanged == nil {
+		c.stateChanged = make(chan struct{})
+		return
+	}
+	close(c.stateChanged)
+	c.stateChanged = make(chan struct{})
+}
+
+func (c *WsConn) stateSnapshot() (connected bool, phase wsPhase, changed <-chan struct{}, rootDone <-chan struct{}) {
 	c.stateMu.Lock()
-	c.Conn = conn
+	c.ensureCompatSignalsLocked()
+	connected = c.Connected
+	phase = c.phase
+	changed = c.stateChanged
+	rootDone = c.rootCtx.Done()
 	c.stateMu.Unlock()
+	return
+}
+
+func (c *WsConn) closeSignalChan() {
+	if c == nil {
+		return
+	}
+	c.closeSignal.Do(func() {
+		c.stateMu.Lock()
+		c.ensureCompatSignalsLocked()
+		ch := c.closeCh
+		c.stateMu.Unlock()
+		close(ch)
+	})
+}
+
+func (c *WsConn) closeReceiveChannel() {
+	c.receiveOnce.Do(func() {
+		if c.MsgReceiveCh != nil {
+			close(c.MsgReceiveCh)
+		}
+	})
 }
 
 func (c *WsConn) getDoneChan() chan struct{} {
@@ -81,74 +148,29 @@ func (c *WsConn) getDoneChan() chan struct{} {
 	return c.Done
 }
 
-func (c *WsConn) setDoneChan(done chan struct{}) {
-	c.stateMu.Lock()
-	c.Done = done
-	c.stateMu.Unlock()
-}
-
-// initWriteLoop creates the write channel and starts the single writer goroutine.
-// Must be called once when the WsConn is created.
-func (c *WsConn) initWriteLoop() {
-	c.writeCh = make(chan wsWriteJob, wsClientWriteQueueSize)
-	c.writeStop = make(chan struct{})
-	c.startLoop(c.writeLoop)
-}
-
-// writeLoop is the sole goroutine allowed to call conn.WriteMessage.
-func (c *WsConn) writeLoop() {
-	for {
+func (c *WsConn) closeDoneLocked() {
+	if c.Done != nil && !c.doneClosed {
 		select {
-		case <-c.writeStop:
-			return
-		case job, ok := <-c.writeCh:
-			if !ok {
-				return
-			}
-			conn := c.getConn()
-			if conn == nil {
-				c.setConnected(false)
-				continue
-			}
-			_ = conn.SetWriteDeadline(time.Now().Add(wsClientWriteTimeout))
-			if err := conn.WriteMessage(job.msgType, job.data); err != nil {
-				log.Printf("wshandle writeLoop: %v", err)
-				c.setConnected(false)
-			}
+		case <-c.Done:
+		default:
+			close(c.Done)
 		}
-	}
-}
-
-// enqueueWrite sends a write job to the writeLoop. Returns an error if the
-// queue is full or writeLoop has stopped.
-func (c *WsConn) enqueueWrite(job wsWriteJob) error {
-	c.lifecycleMu.Lock()
-	defer c.lifecycleMu.Unlock()
-	if c.closed {
-		return errWriteLoopStopped
-	}
-	select {
-	case c.writeCh <- job:
-		return nil
-	case <-c.writeStop:
-		return errWriteLoopStopped
-	default:
-		return errWriteQueueFull
+		c.doneClosed = true
+		c.notifyStateLocked()
 	}
 }
 
 var (
-	errWriteQueueFull   = errors.New("wshandle: write queue full")
-	errWriteLoopStopped = errors.New("wshandle: write loop stopped")
-	errConnClosed       = errors.New("wshandle: connection closed")
+	errWriteQueueFull = errors.New("wshandle: write queue full")
+	errConnClosed     = errors.New("wshandle: connection closed")
 )
 
 var wsconn *WsConn
 var wsconnMu sync.RWMutex
 var wsconnNewMu sync.Mutex
 var envToken = util.EnvToken
+var cacheTokenMu sync.Mutex
 var cacheToken string
-var cacheTokenFailedTimes int
 var createWsConnFn = createWsConn
 var wsGetFastIPFn = util.GetFastIPWithContext
 var wsGetTokenFn = pow.GetTokenWithContext
@@ -158,19 +180,6 @@ type wsEndpoint struct {
 	port   string
 	fastIP string
 	direct bool
-}
-
-func newWsConn(conn *websocket.Conn, interrupt chan os.Signal) *WsConn {
-	c := &WsConn{
-		Conn:         conn,
-		MsgSendCh:    make(chan string, 10),
-		MsgReceiveCh: make(chan string, 10),
-		Interrupt:    interrupt,
-		closeCh:      make(chan struct{}),
-		baseCtx:      context.Background(),
-	}
-	c.initWriteLoop()
-	return c
 }
 
 func normalizeContext(ctx context.Context) context.Context {
@@ -187,68 +196,8 @@ func contextErr(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func contextDone(ctx context.Context) <-chan struct{} {
-	if ctx == nil {
-		return nil
-	}
-	return ctx.Done()
-}
-
 func isContextStop(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-func suppressCanceledContextLog(ctx context.Context, err error) bool {
-	return isContextStop(err) || contextErr(ctx) != nil
-}
-
-func deriveOperationContext(parent context.Context, stopCh <-chan struct{}, timeout time.Duration) (context.Context, context.CancelFunc) {
-	base := normalizeContext(parent)
-	linkedCtx, linkedCancel := context.WithCancel(base)
-	if stopCh != nil {
-		go func() {
-			select {
-			case <-stopCh:
-				linkedCancel()
-			case <-linkedCtx.Done():
-			}
-		}()
-	}
-	if timeout <= 0 {
-		return linkedCtx, linkedCancel
-	}
-	ctx, cancel := context.WithTimeout(linkedCtx, timeout)
-	return ctx, func() {
-		cancel()
-		linkedCancel()
-	}
-}
-
-func (c *WsConn) startLoop(fn func()) {
-	c.loopWG.Add(1)
-	go func() {
-		defer c.loopWG.Done()
-		fn()
-	}()
-}
-
-func (c *WsConn) startBaseContextWatcher() {
-	if c == nil {
-		return
-	}
-	c.baseWatchOnce.Do(func() {
-		done := c.baseContextDone()
-		if done == nil {
-			return
-		}
-		go func() {
-			select {
-			case <-done:
-				c.Close()
-			case <-c.closeCh:
-			}
-		}()
-	})
 }
 
 func (c *WsConn) isClosed() bool {
@@ -263,13 +212,6 @@ func (c *WsConn) isClosed() bool {
 	}
 }
 
-func (c *WsConn) baseContextDone() <-chan struct{} {
-	if c == nil {
-		return nil
-	}
-	return contextDone(c.baseCtx)
-}
-
 func (c *WsConn) baseContextErr() error {
 	if c == nil {
 		return nil
@@ -277,45 +219,8 @@ func (c *WsConn) baseContextErr() error {
 	return contextErr(c.baseCtx)
 }
 
-func (c *WsConn) stopIfBaseContextCanceled() bool {
-	if err := c.baseContextErr(); err != nil {
-		c.setConnectionState(false, false)
-		return true
-	}
-	return false
-}
-
 func (c *WsConn) suppressCanceledContextLog(err error) bool {
 	return isContextStop(err) || c.baseContextErr() != nil
-}
-
-func closeSignalChan(ch chan struct{}) {
-	if ch == nil {
-		return
-	}
-	defer func() {
-		_ = recover()
-	}()
-	close(ch)
-}
-
-func (c *WsConn) closeConn() {
-	conn := c.getConn()
-	if conn == nil {
-		return
-	}
-	_ = conn.Close()
-	c.setConn(nil)
-}
-
-func (c *WsConn) replaceConn(conn *websocket.Conn) {
-	c.stateMu.Lock()
-	prev := c.Conn
-	c.Conn = conn
-	c.stateMu.Unlock()
-	if prev != nil && prev != conn {
-		_ = prev.Close()
-	}
 }
 
 func (c *WsConn) Close() {
@@ -323,37 +228,55 @@ func (c *WsConn) Close() {
 		return
 	}
 	c.closeOnce.Do(func() {
-		c.lifecycleMu.Lock()
-		c.closed = true
-		c.lifecycleMu.Unlock()
-
-		c.setConnectionState(false, false)
-		if c.closeCh != nil {
-			close(c.closeCh)
+		if c.managed {
+			if c.cancelRoot != nil {
+				c.cancelRoot(errConnClosed)
+			}
+			if c.Interrupt != nil {
+				signal.Stop(c.Interrupt)
+			}
+			if c.supervisorDone != nil {
+				<-c.supervisorDone
+			}
+			return
 		}
-		closeSignalChan(c.writeStop)
-		closeSignalChan(c.getDoneChan())
+
+		c.closeSignalChan()
+		if c.cancelRoot != nil {
+			c.cancelRoot(errConnClosed)
+		}
 		if c.Interrupt != nil {
 			signal.Stop(c.Interrupt)
 		}
-		c.closeConn()
-		c.loopWG.Wait()
-		if c.MsgReceiveCh != nil {
-			close(c.MsgReceiveCh)
-		}
-	})
-}
 
-func (c *WsConn) setConnectionState(connected, connecting bool) {
-	c.stateMu.Lock()
-	c.Connected = connected
-	c.Connecting = connecting
-	c.stateMu.Unlock()
+		c.stateMu.Lock()
+		conn := c.Conn
+		c.Conn = nil
+		c.Connected = false
+		c.Connecting = false
+		c.phase = wsPhaseClosed
+		c.closeDoneLocked()
+		c.notifyStateLocked()
+		c.stateMu.Unlock()
+		if conn != nil {
+			_ = conn.Close()
+		}
+		c.closeReceiveChannel()
+	})
 }
 
 func (c *WsConn) setConnected(v bool) {
 	c.stateMu.Lock()
+	changed := c.Connected != v
 	c.Connected = v
+	if v {
+		c.phase = wsPhaseConnected
+	} else if c.phase == wsPhaseConnected {
+		c.phase = wsPhaseIdle
+	}
+	if changed {
+		c.notifyStateLocked()
+	}
 	c.stateMu.Unlock()
 }
 
@@ -363,12 +286,6 @@ func (c *WsConn) SetConnected(v bool) {
 		return
 	}
 	c.setConnected(v)
-}
-
-func (c *WsConn) setConnecting(v bool) {
-	c.stateMu.Lock()
-	c.Connecting = v
-	c.stateMu.Unlock()
 }
 
 func (c *WsConn) IsConnected() bool {
@@ -390,121 +307,22 @@ func (c *WsConn) WaitUntilConnected(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if c.IsConnected() {
-		return nil
-	}
-
-	ticker := time.NewTicker(20 * time.Millisecond)
-	defer ticker.Stop()
-
 	for {
-		if c.IsConnected() {
+		connected, phase, changed, rootDone := c.stateSnapshot()
+		if connected {
 			return nil
+		}
+		if phase == wsPhaseClosed {
+			return errConnClosed
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-rootDone:
+			return errConnClosed
 		case <-c.closeCh:
 			return errConnClosed
-		case <-ticker.C:
-		}
-	}
-}
-
-func (c *WsConn) startReconnecting() bool {
-	if c.isClosed() {
-		return false
-	}
-	if c.stopIfBaseContextCanceled() {
-		return false
-	}
-	c.stateMu.Lock()
-	defer c.stateMu.Unlock()
-	if c.Connected || c.Connecting {
-		return false
-	}
-	c.Connecting = true
-	return true
-}
-
-func (c *WsConn) keepAlive() {
-	pingTicker := time.NewTicker(54 * time.Second)
-	defer pingTicker.Stop()
-	reconnectTicker := time.NewTicker(200 * time.Millisecond)
-	defer reconnectTicker.Stop()
-
-	for {
-		select {
-		case <-c.closeCh:
-			return
-		case <-c.baseContextDone():
-			c.setConnectionState(false, false)
-			return
-		case <-pingTicker.C:
-			if !c.IsConnected() {
-				continue
-			}
-			if err := c.enqueueWrite(wsWriteJob{
-				msgType: websocket.TextMessage,
-				data:    []byte("ping"),
-			}); err != nil {
-				log.Println(err)
-				c.setConnected(false)
-			}
-		case <-reconnectTicker.C:
-			if c.startReconnecting() {
-				c.recreateWsConn()
-			}
-		}
-	}
-}
-
-func (c *WsConn) reconnectNow() {
-	if c.startReconnecting() {
-		c.startLoop(c.recreateWsConn)
-	}
-}
-
-func (c *WsConn) messageReceiveHandler() {
-	done := c.getDoneChan()
-	defer closeSignalChan(done)
-	for {
-		select {
-		case <-c.closeCh:
-			return
-		case <-c.baseContextDone():
-			return
-		default:
-		}
-		if c.IsConnected() {
-			conn := c.getConn()
-			if conn == nil {
-				c.setConnected(false)
-				continue
-			}
-			_, msg, err := conn.ReadMessage()
-			if err != nil {
-				// 读取信息出错，连接已经意外断开
-				// log.Println(err)
-				c.setConnected(false)
-				return
-			}
-			if string(msg) != "pong" {
-				select {
-				case c.MsgReceiveCh <- string(msg):
-				case <-c.closeCh:
-					return
-				}
-			}
-		} else {
-			// 降低断线时期的 CPU 占用
-			select {
-			case <-c.closeCh:
-				return
-			case <-c.baseContextDone():
-				return
-			case <-time.After(200 * time.Millisecond):
-			}
+		case <-changed:
 		}
 	}
 }
@@ -520,176 +338,6 @@ func (c *WsConn) trySendReceiveMessage(msg string) {
 	default:
 		log.Println("wshandle: dropping queued receive message")
 	}
-}
-
-func (c *WsConn) waitForNextDoneChan(doneCh chan struct{}) chan struct{} {
-	for {
-		newDone := c.getDoneChan()
-		if newDone != nil && newDone != doneCh {
-			return newDone
-		}
-		select {
-		case <-c.closeCh:
-			return nil
-		case <-c.baseContextDone():
-			return nil
-		case <-time.After(50 * time.Millisecond):
-		}
-	}
-}
-
-func (c *WsConn) sendQueuedMessage(msg string) {
-	if !c.IsConnected() {
-		c.trySendReceiveMessage(apiServerErrorMessage(msg))
-		return
-	}
-
-	if err := c.enqueueWrite(wsWriteJob{
-		msgType: websocket.TextMessage,
-		data:    []byte(msg),
-	}); err != nil {
-		log.Println("write:", err)
-		c.setConnected(false)
-		c.trySendReceiveMessage(apiServerErrorMessage(msg))
-	}
-}
-
-func (c *WsConn) handleInterrupt(doneCh chan struct{}) {
-	_ = c.enqueueWrite(wsWriteJob{
-		msgType: websocket.CloseMessage,
-		data:    websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
-	})
-
-	select {
-	case <-doneCh:
-	case <-time.After(1 * time.Second):
-	}
-}
-
-func (c *WsConn) messageSendHandler() {
-	doneCh := c.getDoneChan()
-	for {
-		if current := c.getDoneChan(); current != nil && current != doneCh {
-			doneCh = current
-		}
-
-		select {
-		case <-c.closeCh:
-			return
-		case <-c.baseContextDone():
-			return
-		case <-doneCh:
-			doneCh = c.waitForNextDoneChan(doneCh)
-			if doneCh == nil {
-				return
-			}
-		case msg := <-c.MsgSendCh:
-			c.sendQueuedMessage(msg)
-		case <-c.Interrupt:
-			c.handleInterrupt(doneCh)
-			return
-		}
-	}
-}
-
-func (c *WsConn) recreateWsConn() {
-	if c.isClosed() {
-		return
-	}
-	if c.stopIfBaseContextCanceled() {
-		return
-	}
-	c.setConnected(false)
-	// 尝试重新连线
-	if !c.directIP && c.apiHost != "" && net.ParseIP(c.apiHost) == nil {
-		// 刷新一次最优 IP，防止旧 IP 已失效
-		fastIPCtx, cancelFastIP := deriveOperationContext(c.baseCtx, c.closeCh, 0)
-		refreshedFastIP, err := wsGetFastIPFn(fastIPCtx, c.apiHost, c.apiPort, true)
-		cancelFastIP()
-		if err != nil {
-			if !c.suppressCanceledContextLog(err) {
-				log.Printf("fast ip refresh failed: %v", err)
-			}
-			c.setConnectionState(false, false)
-			return
-		}
-		c.apiFastIP = refreshedFastIP
-	}
-	u := url.URL{Scheme: "wss", Host: formatHostPort(c.apiFastIP, c.apiPort), Path: "/v3/ipGeoWs"}
-	// log.Printf("connecting to %s", u.String())
-	jwtToken, ua := envToken, []string{"Privileged Client"}
-	err := error(nil)
-	if envToken == "" {
-		// 无环境变量 token
-		if cacheToken == "" {
-			// 无cacheToken, 重新获取 token
-			tokenCtx, cancelToken := deriveOperationContext(c.baseCtx, c.closeCh, 0)
-			if util.GetPowProvider() == "" {
-				jwtToken, err = wsGetTokenFn(tokenCtx, c.apiFastIP, c.apiHost, c.apiPort)
-			} else {
-				jwtToken, err = wsGetTokenFn(tokenCtx, util.GetPowProvider(), util.GetPowProvider(), c.apiPort)
-			}
-			cancelToken()
-			if err != nil {
-				if util.EnvDevMode {
-					panic(err)
-				}
-				if !c.suppressCanceledContextLog(err) {
-					log.Printf("pow token fetch failed: %v", err)
-				}
-				cacheToken = ""
-				cacheTokenFailedTimes++
-				c.setConnectionState(false, false)
-				return
-			}
-		} else {
-			// 使用 cacheToken
-			jwtToken = cacheToken
-		}
-		ua = []string{util.UserAgent}
-	}
-	cacheToken = jwtToken
-	requestHeader := http.Header{
-		"Host":          []string{c.apiHost},
-		"User-Agent":    ua,
-		"Authorization": []string{"Bearer " + jwtToken},
-	}
-	dialer := *websocket.DefaultDialer // 按值拷贝，变成独立实例
-	// 现在 dialer 是一个新的 Dialer（值），内部字段与 DefaultDialer 相同
-	dialer.TLSClientConfig = &tls.Config{
-		ServerName: c.apiHost,
-	}
-	proxyUrl := util.GetProxy()
-	if proxyUrl != nil {
-		dialer.Proxy = http.ProxyURL(proxyUrl)
-	}
-	ctx, cancel := deriveOperationContext(c.baseCtx, c.closeCh, wsClientDialTimeout)
-	ws, _, err := dialer.DialContext(ctx, u.String(), requestHeader)
-	cancel()
-	if c.isClosed() {
-		if ws != nil {
-			_ = ws.Close()
-		}
-		return
-	}
-	if err != nil {
-		if !c.suppressCanceledContextLog(err) {
-			log.Println("dial:", err)
-		}
-		// <-time.After(time.Second * 1)
-		c.setConnectionState(false, false)
-		cacheTokenFailedTimes += 1
-		if !c.suppressCanceledContextLog(err) {
-			time.Sleep(1 * time.Second)
-		}
-		//fmt.Println("重连失败", cacheTokenFailedTimes, "次")
-		return
-	}
-	c.replaceConn(ws)
-	c.setConnectionState(true, false)
-
-	c.setDoneChan(make(chan struct{}))
-	c.startLoop(c.messageReceiveHandler)
 }
 
 func initWsConnBase(ctx context.Context) (context.Context, chan os.Signal, wsEndpoint) {
@@ -711,118 +359,20 @@ func initWsConnBase(ctx context.Context) (context.Context, chan os.Signal, wsEnd
 	return ctx, interrupt, endpoint
 }
 
-func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal, endpoint wsEndpoint) *WsConn {
-	ws := newWsConn(nil, interrupt)
-	ws.baseCtx = ctx
-	ws.directIP = endpoint.direct
-	ws.apiHost = endpoint.host
-	ws.apiPort = endpoint.port
-	ws.apiFastIP = endpoint.fastIP
-	ws.setDoneChan(make(chan struct{}))
-	ws.setConnectionState(false, false)
-	ws.startBaseContextWatcher()
-	if contextErr(ctx) != nil {
-		return ws
-	}
-	ws.startLoop(ws.keepAlive)
-	ws.startLoop(ws.messageSendHandler)
-	return ws
-}
-
 func createWsConn(ctx context.Context) *WsConn {
-	proxyUrl := util.GetProxy()
 	ctx, interrupt, endpoint := initWsConnBase(ctx)
-	if !endpoint.direct {
-		// 默认配置完成，开始寻找最优 IP
-		refreshedFastIP, err := wsGetFastIPFn(ctx, endpoint.host, endpoint.port, true)
-		if err != nil {
-			if util.EnvDevMode {
-				panic(err)
-			}
-			if !suppressCanceledContextLog(ctx, err) {
-				log.Printf("fast ip probe failed: %v", err)
-			}
-			return newReconnectableWsConn(ctx, interrupt, endpoint)
-		}
-		endpoint.fastIP = refreshedFastIP
+	ws := newManagedWsConnWithPolicy(ctx, interrupt, endpoint, true)
+	<-ws.firstAttemptDone
+	if err := ws.firstAttemptFailure(); err != nil {
+		ws.Close()
+		panic(err)
 	}
-	jwtToken, ua := envToken, []string{"Privileged Client"}
-	err := error(nil)
-	if envToken == "" {
-		if util.GetPowProvider() == "" {
-			jwtToken, err = wsGetTokenFn(ctx, endpoint.fastIP, endpoint.host, endpoint.port)
-		} else {
-			jwtToken, err = wsGetTokenFn(ctx, util.GetPowProvider(), util.GetPowProvider(), endpoint.port)
-		}
-		if err != nil {
-			if util.EnvDevMode {
-				panic(err)
-			}
-			if !suppressCanceledContextLog(ctx, err) {
-				log.Printf("pow token fetch failed: %v", err)
-			}
-			return newReconnectableWsConn(ctx, interrupt, endpoint)
-		}
-		ua = []string{util.UserAgent}
-	}
-	cacheToken = jwtToken
-	cacheTokenFailedTimes = 0
-	requestHeader := http.Header{
-		"Host":          []string{endpoint.host},
-		"User-Agent":    ua,
-		"Authorization": []string{"Bearer " + jwtToken},
-	}
-	dialer := *websocket.DefaultDialer // 按值拷贝，变成独立实例
-	// 现在 dialer 是一个新的 Dialer（值），内部字段与 DefaultDialer 相同
-	dialer.TLSClientConfig = &tls.Config{
-		ServerName: endpoint.host,
-	}
-	if proxyUrl != nil {
-		dialer.Proxy = http.ProxyURL(proxyUrl)
-	}
-	u := url.URL{Scheme: "wss", Host: formatHostPort(endpoint.fastIP, endpoint.port), Path: "/v3/ipGeoWs"}
-	// log.Printf("connecting to %s", u.String())
-
-	dialCtx, cancel := deriveOperationContext(ctx, nil, wsClientDialTimeout)
-	c, _, err := dialer.DialContext(dialCtx, u.String(), requestHeader)
-	cancel()
-
-	ws := newWsConn(c, interrupt)
-	ws.baseCtx = ctx
-	ws.directIP = endpoint.direct
-	ws.apiHost = endpoint.host
-	ws.apiPort = endpoint.port
-	ws.apiFastIP = endpoint.fastIP
-	ws.setConnectionState(err == nil, false)
-	ws.startBaseContextWatcher()
-
-	if err != nil {
-		if !suppressCanceledContextLog(ctx, err) {
-			log.Println("dial:", err)
-		}
-		// <-time.After(time.Second * 1)
-		cacheTokenFailedTimes++
-		ws.setDoneChan(make(chan struct{}))
-		if contextErr(ctx) == nil {
-			ws.startLoop(ws.keepAlive)
-			ws.startLoop(ws.messageSendHandler)
-		}
-		return ws
-	}
-	// defer c.Close()
-	// 将连接写入WsConn，方便随时可取
-	ws.setDoneChan(make(chan struct{}))
-	ws.startLoop(ws.keepAlive)
-	ws.startLoop(ws.messageReceiveHandler)
-	ws.startLoop(ws.messageSendHandler)
 	return ws
 }
 
 func createWsConnAsync(ctx context.Context) *WsConn {
 	ctx, interrupt, endpoint := initWsConnBase(ctx)
-	ws := newReconnectableWsConn(ctx, interrupt, endpoint)
-	ws.reconnectNow()
-	return ws
+	return newManagedWsConn(ctx, interrupt, endpoint)
 }
 
 func replaceGlobalWsConn(newConn *WsConn, ctx context.Context) *WsConn {

--- a/wshandle/client.go
+++ b/wshandle/client.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -35,7 +36,14 @@ type wsWriteJob struct {
 	requestCtx context.Context
 	stopCancel func() bool
 	awaitReply bool
+	progress   *wsWriteProgress
+	reply      chan<- string
 	pongSerial uint64
+}
+
+type wsWriteProgress struct {
+	began     atomic.Bool
+	succeeded atomic.Bool
 }
 
 const (
@@ -159,6 +167,10 @@ func (c *WsConn) closeDoneLocked() {
 		c.notifyStateLocked()
 	}
 }
+
+// ErrRequestResponseUnsupported reports that a compatibility WsConn has no
+// supervisor capable of binding a response to its request generation.
+var ErrRequestResponseUnsupported = errors.New("wshandle: request-bound responses require a managed connection")
 
 var (
 	errWriteQueueFull = errors.New("wshandle: write queue full")

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -4,16 +4,17 @@ package wshandle
 // t.Parallel without isolating that state first.
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"net"
+	"log"
 	"os"
-	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/nxtrace/NTrace-core/util"
 )
 
@@ -40,18 +41,23 @@ func TestFormatHostPort(t *testing.T) {
 	}
 }
 
-func newStartedTestWsConn() *WsConn {
-	return newStartedTestWsConnWithContext(context.Background())
+func newLiteralTestWsConn(ctx context.Context) *WsConn {
+	return &WsConn{
+		MsgSendCh:    make(chan string, 10),
+		MsgReceiveCh: make(chan string, 10),
+		Done:         make(chan struct{}),
+		Interrupt:    make(chan os.Signal, 1),
+		baseCtx:      normalizeContext(ctx),
+	}
 }
 
-func newStartedTestWsConnWithContext(ctx context.Context) *WsConn {
-	c := newWsConn(nil, make(chan os.Signal, 1))
-	c.baseCtx = ctx
-	c.setDoneChan(make(chan struct{}))
-	c.setConnectionState(false, false)
-	c.startLoop(c.keepAlive)
-	c.startLoop(c.messageSendHandler)
-	return c
+func waitForConnected(t *testing.T, conn *WsConn) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := conn.WaitUntilConnected(ctx); err != nil {
+		t.Fatalf("WaitUntilConnected() error = %v", err)
+	}
 }
 
 func saveAndRestoreGlobalWsConn(t *testing.T) {
@@ -72,8 +78,14 @@ func saveAndRestoreGlobalWsConn(t *testing.T) {
 	})
 }
 
-func TestWsConnCloseStopsBackgroundLoops(t *testing.T) {
-	conn := newStartedTestWsConn()
+func TestWsConnCloseIsIdempotent(t *testing.T) {
+	dialer := newSupervisorTestDialer()
+	wire := newSupervisorTestWire()
+	dialer.results <- supervisorTestDialResult{wire: wire}
+	defer installSupervisorTestDialer(dialer)()
+
+	conn := newSupervisorTestConn(context.Background())
+	waitForConnected(t, conn)
 	doneCh := conn.getDoneChan()
 
 	conn.Close()
@@ -82,542 +94,605 @@ func TestWsConnCloseStopsBackgroundLoops(t *testing.T) {
 	if !conn.isClosed() {
 		t.Fatal("connection should be marked closed")
 	}
-	if err := conn.enqueueWrite(wsWriteJob{msgType: websocket.TextMessage, data: []byte("ping")}); !errors.Is(err, errWriteLoopStopped) {
-		t.Fatalf("enqueueWrite error=%v, want %v", err, errWriteLoopStopped)
+	if !wire.isClosed() {
+		t.Fatal("Close should close the active websocket generation")
 	}
 	select {
 	case <-doneCh:
 	default:
-		t.Fatal("done channel should be closed by Close")
+		t.Fatal("Done should be closed before Close returns")
 	}
 	select {
 	case _, ok := <-conn.MsgReceiveCh:
 		if ok {
-			t.Fatal("receive channel should be closed by Close")
+			t.Fatal("MsgReceiveCh should be closed")
 		}
 	default:
-		t.Fatal("receive channel should be closed after Close returns")
+		t.Fatal("MsgReceiveCh should be closed before Close returns")
+	}
+}
+
+func TestZeroValueWsConnCanBeClosed(t *testing.T) {
+	var conn WsConn
+	conn.Close()
+	conn.Close()
+	if !conn.isClosed() {
+		t.Fatal("zero-value connection should be closed")
+	}
+	if err := conn.WaitUntilConnected(context.Background()); !errors.Is(err, errConnClosed) {
+		t.Fatalf("WaitUntilConnected() error = %v, want %v", err, errConnClosed)
 	}
 }
 
 func TestNewClosesPreviousGlobalWsConn(t *testing.T) {
 	oldCreateFn := createWsConnFn
-	defer func() {
-		createWsConnFn = oldCreateFn
-	}()
+	defer func() { createWsConnFn = oldCreateFn }()
 	saveAndRestoreGlobalWsConn(t)
 
-	oldConn := newStartedTestWsConn()
+	oldConn := newLiteralTestWsConn(context.Background())
 	wsconnMu.Lock()
 	wsconn = oldConn
 	wsconnMu.Unlock()
 
-	createWsConnFn = func(context.Context) *WsConn {
-		return newStartedTestWsConn()
-	}
+	newConn := newLiteralTestWsConn(context.Background())
+	createWsConnFn = func(context.Context) *WsConn { return newConn }
 
-	newConn := New()
-	defer newConn.Close()
-
-	if newConn == oldConn {
-		t.Fatal("New should replace the previous global connection")
-	}
-	if GetWsConn() != newConn {
-		t.Fatal("GetWsConn should return the replacement connection")
+	got := New()
+	defer got.Close()
+	if got != newConn || GetWsConn() != newConn {
+		t.Fatal("New should publish and return the replacement connection")
 	}
 	if !oldConn.isClosed() {
-		t.Fatal("previous global connection should be closed before replacement")
-	}
-	if err := oldConn.enqueueWrite(wsWriteJob{msgType: websocket.TextMessage, data: []byte("ping")}); !errors.Is(err, errWriteLoopStopped) {
-		t.Fatalf("old enqueueWrite error=%v, want %v", err, errWriteLoopStopped)
+		t.Fatal("previous global connection should be closed")
 	}
 }
 
 func TestReplaceGlobalWsConnKeepsOldConnForCanceledContext(t *testing.T) {
 	saveAndRestoreGlobalWsConn(t)
-
-	oldConn := newStartedTestWsConn()
+	oldConn := newLiteralTestWsConn(context.Background())
 	wsconnMu.Lock()
 	wsconn = oldConn
 	wsconnMu.Unlock()
 
-	newConn := newStartedTestWsConn()
+	newConn := newLiteralTestWsConn(context.Background())
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
 	got := replaceGlobalWsConn(newConn, ctx)
-	if got != oldConn {
-		t.Fatal("replaceGlobalWsConn should return existing connection for canceled context")
-	}
-	if GetWsConn() != oldConn {
-		t.Fatal("canceled replacement should not overwrite global connection")
+	if got != oldConn || GetWsConn() != oldConn {
+		t.Fatal("canceled replacement should keep the existing connection")
 	}
 	if oldConn.isClosed() {
 		t.Fatal("existing connection should remain open")
 	}
 	if !newConn.isClosed() {
-		t.Fatal("canceled replacement connection should be closed")
+		t.Fatal("rejected replacement should be closed")
 	}
 }
 
 func TestReplaceGlobalWsConnDoesNotRewriteBaseContext(t *testing.T) {
 	saveAndRestoreGlobalWsConn(t)
-
 	originalCtx, originalCancel := context.WithCancel(context.Background())
 	defer originalCancel()
 	replacementCtx, replacementCancel := context.WithCancel(context.Background())
 	defer replacementCancel()
 
-	newConn := newStartedTestWsConnWithContext(originalCtx)
-
+	newConn := newLiteralTestWsConn(originalCtx)
 	got := replaceGlobalWsConn(newConn, replacementCtx)
 	defer got.Close()
-
 	if got != newConn {
 		t.Fatal("replaceGlobalWsConn should install the supplied connection")
 	}
 	if newConn.baseCtx != originalCtx {
-		t.Fatal("replaceGlobalWsConn should not rewrite baseCtx after construction")
+		t.Fatal("replaceGlobalWsConn should not rewrite baseCtx")
 	}
+}
+
+type blockingCloseWire struct {
+	closeStarted chan struct{}
+	releaseClose chan struct{}
+	readDone     chan struct{}
+	closeOnce    sync.Once
+}
+
+func newBlockingCloseWire() *blockingCloseWire {
+	return &blockingCloseWire{
+		closeStarted: make(chan struct{}),
+		releaseClose: make(chan struct{}),
+		readDone:     make(chan struct{}),
+	}
+}
+
+func (w *blockingCloseWire) ReadMessage() (int, []byte, error) {
+	<-w.readDone
+	return 0, nil, errSupervisorTestWireClosed
+}
+
+func (*blockingCloseWire) SetWriteDeadline(time.Time) error { return nil }
+
+func (*blockingCloseWire) WriteMessage(int, []byte) error { return nil }
+
+func (w *blockingCloseWire) Close() error {
+	w.closeOnce.Do(func() {
+		close(w.closeStarted)
+		<-w.releaseClose
+		close(w.readDone)
+	})
+	return nil
 }
 
 func TestGetWsConnDoesNotBlockWhileNewClosesPreviousConn(t *testing.T) {
 	oldCreateFn := createWsConnFn
-	defer func() {
-		createWsConnFn = oldCreateFn
-	}()
+	defer func() { createWsConnFn = oldCreateFn }()
 	saveAndRestoreGlobalWsConn(t)
 
-	release := make(chan struct{})
-	oldConn := newWsConn(nil, make(chan os.Signal, 1))
-	oldConn.setDoneChan(make(chan struct{}))
-	oldConn.startLoop(func() {
-		<-release
-	})
-
+	dialer := newSupervisorTestDialer()
+	oldWire := newBlockingCloseWire()
+	dialer.results <- supervisorTestDialResult{wire: oldWire}
+	defer installSupervisorTestDialer(dialer)()
+	oldConn := newSupervisorTestConn(context.Background())
+	waitForConnected(t, oldConn)
 	wsconnMu.Lock()
 	wsconn = oldConn
 	wsconnMu.Unlock()
 
-	newConn := newStartedTestWsConn()
-	defer newConn.Close()
-	createWsConnFn = func(context.Context) *WsConn {
-		return newConn
-	}
-
+	newConn := newLiteralTestWsConn(context.Background())
+	createWsConnFn = func(context.Context) *WsConn { return newConn }
 	newResult := make(chan *WsConn, 1)
-	go func() {
-		newResult <- New()
-	}()
+	go func() { newResult <- New() }()
 
 	select {
-	case <-oldConn.closeCh:
+	case <-oldWire.closeStarted:
 	case <-time.After(time.Second):
 		t.Fatal("New did not start closing the previous connection")
 	}
-
-	getResult := make(chan *WsConn, 1)
-	go func() {
-		getResult <- GetWsConn()
-	}()
-
-	select {
-	case got := <-getResult:
-		if got != newConn {
-			t.Fatalf("GetWsConn returned %p, want %p", got, newConn)
-		}
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("GetWsConn blocked while New was waiting for old Close")
+	if got := GetWsConn(); got != newConn {
+		t.Fatalf("GetWsConn() = %p, want %p while old Close is blocked", got, newConn)
 	}
-
-	close(release)
-
+	close(oldWire.releaseClose)
 	select {
 	case got := <-newResult:
 		if got != newConn {
-			t.Fatalf("New returned %p, want %p", got, newConn)
+			t.Fatalf("New() = %p, want %p", got, newConn)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("New did not finish after releasing old Close")
-	}
-}
-
-func TestSendQueuedMessageDoesNotBlockWhenDisconnectedAndReceiveQueueIsUnavailable(t *testing.T) {
-	conn := newWsConn(nil, make(chan os.Signal, 1))
-	defer conn.Close()
-	conn.MsgReceiveCh = make(chan string)
-
-	done := make(chan struct{})
-	go func() {
-		conn.sendQueuedMessage("1.1.1.1")
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("sendQueuedMessage blocked while disconnected")
-	}
-}
-
-func TestSendQueuedMessageDoesNotBlockWhenEnqueueWriteFails(t *testing.T) {
-	conn := newWsConn(nil, make(chan os.Signal, 1))
-	defer conn.Close()
-	conn.MsgReceiveCh = make(chan string)
-	conn.setConnectionState(true, false)
-
-	conn.lifecycleMu.Lock()
-	conn.closed = true
-	conn.lifecycleMu.Unlock()
-
-	done := make(chan struct{})
-	go func() {
-		conn.sendQueuedMessage("1.1.1.1")
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("sendQueuedMessage blocked after enqueueWrite failure")
-	}
-}
-
-func TestMessageReceiveHandlerCloseRaceDoesNotPanic(t *testing.T) {
-	for i := 0; i < 50; i++ {
-		conn := newWsConn(nil, make(chan os.Signal, 1))
-		conn.setDoneChan(make(chan struct{}))
-		conn.setConnectionState(false, false)
-
-		started := make(chan struct{})
-		conn.startLoop(func() {
-			close(started)
-			conn.messageReceiveHandler()
-		})
-
-		<-started
-
-		done := make(chan struct{})
-		go func() {
-			conn.Close()
-			close(done)
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(time.Second):
-			t.Fatal("Close hung while messageReceiveHandler was exiting")
-		}
+		t.Fatal("New did not finish after old Close was released")
 	}
 }
 
 func TestCreateWsConnHonorsCanceledContextDuringFastIP(t *testing.T) {
 	oldFastIPFn := wsGetFastIPFn
-	defer func() { wsGetFastIPFn = oldFastIPFn }()
+	oldHostPort := util.EnvHostPort
+	defer func() {
+		wsGetFastIPFn = oldFastIPFn
+		util.EnvHostPort = oldHostPort
+	}()
+	util.EnvHostPort = "example.com:443"
 
 	started := make(chan struct{})
-	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
+	wsGetFastIPFn = func(ctx context.Context, domain, port string, enableOutput bool) (string, error) {
 		close(started)
 		<-ctx.Done()
 		return "", ctx.Err()
 	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan *WsConn, 1)
-	go func() {
-		done <- createWsConn(ctx)
-	}()
-
+	go func() { done <- createWsConn(ctx) }()
 	<-started
 	cancel()
 
 	select {
 	case conn := <-done:
-		if conn == nil {
-			t.Fatal("createWsConn returned nil")
+		if conn == nil || conn.IsConnected() {
+			t.Fatalf("createWsConn() = %#v after cancellation", conn)
 		}
-		defer conn.Close()
-		if conn.IsConnected() {
-			t.Fatal("connection should not be connected after canceled startup")
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("createWsConn did not return promptly after cancel")
+		conn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("createWsConn did not return after context cancellation")
 	}
 }
 
 func TestCreateWsConnAsyncReturnsBeforeFastIP(t *testing.T) {
 	oldFastIPFn := wsGetFastIPFn
-	defer func() { wsGetFastIPFn = oldFastIPFn }()
+	oldHostPort := util.EnvHostPort
+	defer func() {
+		wsGetFastIPFn = oldFastIPFn
+		util.EnvHostPort = oldHostPort
+	}()
+	util.EnvHostPort = "example.com:443"
 
 	fastIPStarted := make(chan struct{}, 1)
 	fastIPDone := make(chan struct{}, 1)
 	releaseFastIP := make(chan struct{})
-	defer close(releaseFastIP)
-	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
-		select {
-		case fastIPStarted <- struct{}{}:
-		default:
-		}
-		defer func() {
-			select {
-			case fastIPDone <- struct{}{}:
-			default:
-			}
-		}()
+	wsGetFastIPFn = func(ctx context.Context, domain, port string, enableOutput bool) (string, error) {
+		fastIPStarted <- struct{}{}
+		defer func() { fastIPDone <- struct{}{} }()
 		select {
 		case <-releaseFastIP:
-			return "127.0.0.1", nil
+			return "192.0.2.1", nil
 		case <-ctx.Done():
 			return "", ctx.Err()
 		}
 	}
 
 	returned := make(chan *WsConn, 1)
-	go func() {
-		returned <- createWsConnAsync(context.Background())
-	}()
-
+	go func() { returned <- createWsConnAsync(context.Background()) }()
 	select {
 	case <-fastIPStarted:
 	case <-time.After(time.Second):
 		t.Fatal("FastIP probe did not start")
 	}
-
 	select {
 	case conn := <-returned:
-		if conn == nil {
-			t.Fatal("createWsConnAsync returned nil")
-		}
-		defer conn.Close()
+		conn.Close()
 	case <-fastIPDone:
-		t.Fatal("createWsConnAsync waited for FastIP to complete")
+		t.Fatal("createWsConnAsync waited for FastIP")
 	case <-time.After(time.Second):
-		t.Fatal("createWsConnAsync did not return while FastIP was blocked")
+		t.Fatal("createWsConnAsync did not return")
 	}
+	close(releaseFastIP)
 }
 
-func TestWaitUntilConnectedReturnsOnConnect(t *testing.T) {
-	conn := newStartedTestWsConn()
+func TestWaitUntilConnectedSupportsStructLiteral(t *testing.T) {
+	conn := newLiteralTestWsConn(context.Background())
 	defer conn.Close()
-
 	done := make(chan error, 1)
-	go func() {
-		done <- conn.WaitUntilConnected(context.Background())
-	}()
-
-	conn.setConnectionState(true, false)
-
+	go func() { done <- conn.WaitUntilConnected(context.Background()) }()
+	conn.SetConnected(true)
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Fatalf("WaitUntilConnected returned error: %v", err)
+			t.Fatalf("WaitUntilConnected() error = %v", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("WaitUntilConnected did not observe connected state")
+		t.Fatal("SetConnected did not wake WaitUntilConnected")
 	}
 }
 
 func TestWaitUntilConnectedHonorsContext(t *testing.T) {
-	conn := newStartedTestWsConn()
+	conn := newLiteralTestWsConn(context.Background())
 	defer conn.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-
-	err := conn.WaitUntilConnected(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("WaitUntilConnected error = %v, want %v", err, context.DeadlineExceeded)
-	}
-}
-
-func TestSuppressCanceledContextLogTreatsDeadlineAsStop(t *testing.T) {
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
-	defer cancel()
-
-	if !suppressCanceledContextLog(ctx, errors.New("dial failed")) {
-		t.Fatal("suppressCanceledContextLog should suppress logs when parent context hit deadline")
-	}
-	if !suppressCanceledContextLog(context.Background(), context.DeadlineExceeded) {
-		t.Fatal("suppressCanceledContextLog should suppress direct deadline errors")
+	if err := conn.WaitUntilConnected(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitUntilConnected() error = %v, want %v", err, context.DeadlineExceeded)
 	}
 }
 
 func TestWsConnSuppressCanceledContextLogTreatsDeadlineAsStop(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
-
-	conn := newWsConn(nil, make(chan os.Signal, 1))
-	conn.baseCtx = ctx
+	conn := newLiteralTestWsConn(ctx)
 	defer conn.Close()
-
 	if !conn.suppressCanceledContextLog(errors.New("dial failed")) {
-		t.Fatal("WsConn suppressCanceledContextLog should suppress logs when base context hit deadline")
+		t.Fatal("canceled base context should suppress connection errors")
 	}
 	if !conn.suppressCanceledContextLog(context.DeadlineExceeded) {
-		t.Fatal("WsConn suppressCanceledContextLog should suppress direct deadline errors")
+		t.Fatal("deadline errors should be suppressed")
 	}
 }
 
-func TestRecreateWsConnCloseCancelsFastIP(t *testing.T) {
+func TestCreateWsConnAsyncPreservesDirectIPEndpointAndHeaders(t *testing.T) {
 	oldFastIPFn := wsGetFastIPFn
+	oldHostPort := util.EnvHostPort
 	defer func() {
 		wsGetFastIPFn = oldFastIPFn
+		util.EnvHostPort = oldHostPort
 	}()
+	util.EnvHostPort = "192.0.2.10:8443"
 
-	started := make(chan struct{})
-	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
-		close(started)
-		<-ctx.Done()
-		return "", ctx.Err()
+	var fastIPCalls atomic.Int32
+	wsGetFastIPFn = func(context.Context, string, string, bool) (string, error) {
+		fastIPCalls.Add(1)
+		return "", errors.New("unexpected FastIP lookup")
 	}
+	dialer := newSupervisorTestDialer()
+	wire := newSupervisorTestWire()
+	dialer.results <- supervisorTestDialResult{wire: wire}
+	defer installSupervisorTestDialer(dialer)()
 
-	conn := newStartedTestWsConn()
-	conn.apiHost = "example.com"
-	conn.apiPort = "443"
+	conn := createWsConnAsync(context.Background())
 	defer conn.Close()
+	waitForConnected(t, conn)
+	if !conn.directIP || conn.apiFastIP != "192.0.2.10" {
+		t.Fatalf("direct endpoint = (%v, %q), want (true, 192.0.2.10)", conn.directIP, conn.apiFastIP)
+	}
+	if got := fastIPCalls.Load(); got != 0 {
+		t.Fatalf("FastIP calls = %d, want 0 for direct endpoint", got)
+	}
 
-	done := make(chan struct{})
-	go func() {
-		conn.recreateWsConn()
-		close(done)
-	}()
-
-	<-started
-	conn.Close()
-
+	var req wsDialRequest
 	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("recreateWsConn did not stop promptly after Close")
+	case req = <-dialer.calls:
+	case <-time.After(time.Second):
+		t.Fatal("missing websocket dial request")
+	}
+	if req.URL != "wss://192.0.2.10:8443/v3/ipGeoWs" {
+		t.Fatalf("dial URL = %q", req.URL)
+	}
+	if req.ServerName != "api.nxtrace.org" || req.Header.Get("Host") != "api.nxtrace.org" {
+		t.Fatalf("SNI/Host = (%q, %q)", req.ServerName, req.Header.Get("Host"))
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer supervisor-test-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := req.Header.Get("User-Agent"); got != "Privileged Client" {
+		t.Fatalf("User-Agent = %q", got)
 	}
 }
 
-func TestRecreateWsConnCanceledBaseContextSkipsReconnect(t *testing.T) {
-	oldFastIPFn := wsGetFastIPFn
-	defer func() {
-		wsGetFastIPFn = oldFastIPFn
-	}()
-
-	var fastIPCalls int32
-	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
-		atomic.AddInt32(&fastIPCalls, 1)
-		return "127.0.0.1", nil
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	conn := newWsConn(nil, make(chan os.Signal, 1))
-	conn.baseCtx = ctx
-	conn.apiHost = "example.com"
-	conn.apiPort = "443"
-	conn.setConnectionState(false, true)
-	defer conn.Close()
-
-	conn.recreateWsConn()
-
-	if got := atomic.LoadInt32(&fastIPCalls); got != 0 {
-		t.Fatalf("FastIP refresh calls = %d, want 0 after base context cancel", got)
-	}
-	if conn.IsConnecting() {
-		t.Fatal("connection should not remain connecting after base context cancel")
-	}
-}
-
-func TestKeepAliveStopsOnCanceledBaseContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	conn := newWsConn(nil, make(chan os.Signal, 1))
-	conn.baseCtx = ctx
-	defer conn.Close()
-
-	done := make(chan struct{})
-	go func() {
-		conn.keepAlive()
-		close(done)
-	}()
-
-	cancel()
-
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("keepAlive did not stop after base context cancel")
-	}
-}
-
-func TestBaseContextWatcherClosesConnection(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	conn := newWsConn(nil, make(chan os.Signal, 1))
-	conn.baseCtx = ctx
-	conn.setDoneChan(make(chan struct{}))
-	conn.startBaseContextWatcher()
-
-	cancel()
-
-	select {
-	case <-conn.closeCh:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("base context watcher did not close connection")
-	}
-}
-
-func TestCreateWsConnAsyncPreservesDirectIPOnReconnect(t *testing.T) {
-	saveAndRestoreGlobalWsConn(t)
-
-	oldFastIPFn := wsGetFastIPFn
-	oldEnvHostPort := util.EnvHostPort
+func TestCreateWsConnSyncRefreshesCachedToken(t *testing.T) {
+	oldDialFn := wsDialFn
+	oldTokenFn := wsGetTokenFn
 	oldEnvToken := envToken
-	t.Cleanup(func() {
-		wsGetFastIPFn = oldFastIPFn
-		util.EnvHostPort = oldEnvHostPort
+	oldHostPort := util.EnvHostPort
+	oldCacheToken := loadCachedToken()
+	defer func() {
+		wsDialFn = oldDialFn
+		wsGetTokenFn = oldTokenFn
 		envToken = oldEnvToken
-	})
+		util.EnvHostPort = oldHostPort
+		storeCachedToken(oldCacheToken)
+	}()
 
-	var fastIPCalls int32
-	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
-		atomic.AddInt32(&fastIPCalls, 1)
-		return "", errors.New("unexpected FastIP refresh")
+	util.EnvHostPort = "192.0.2.10:443"
+	envToken = ""
+	storeCachedToken("stale-token")
+	var tokenCalls atomic.Int32
+	wsGetTokenFn = func(context.Context, string, string, string) (string, error) {
+		tokenCalls.Add(1)
+		return "fresh-token", nil
 	}
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("net.Listen() error = %v", err)
+	dialer := newSupervisorTestDialer()
+	wire := newSupervisorTestWire()
+	dialer.results <- supervisorTestDialResult{wire: wire}
+	wsDialFn = dialer.dial
+
+	conn := createWsConn(context.Background())
+	defer conn.Close()
+	if !conn.IsConnected() || conn.IsConnecting() {
+		t.Fatal("synchronous create returned before successful state was published")
 	}
-	directPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-	_ = listener.Close()
-	util.EnvHostPort = "127.0.0.1:" + directPort
-	envToken = "token"
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	conn := createWsConnAsync(ctx)
-
-	if !conn.directIP {
-		t.Fatal("async websocket should preserve direct-IP state")
+	if got := tokenCalls.Load(); got != 1 {
+		t.Fatalf("token calls = %d, want 1", got)
 	}
-	if conn.apiFastIP != "127.0.0.1" {
-		t.Fatalf("apiFastIP = %q, want direct IP preserved", conn.apiFastIP)
-	}
-	cancel()
-	conn.Close()
-
-	// Keep the reconnect context live and use a closed local port so
-	// recreateWsConn reaches the direct-IP dial path without external network.
-	reconnectCtx, reconnectCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer reconnectCancel()
-	if err := reconnectCtx.Err(); err != nil {
-		t.Fatalf("reconnect context should be live before recreateWsConn: %v", err)
-	}
-	reconnectConn := newWsConn(nil, make(chan os.Signal, 1))
-	reconnectConn.baseCtx = reconnectCtx
-	reconnectConn.directIP = true
-	reconnectConn.apiHost = "api.nxtrace.org"
-	reconnectConn.apiPort = directPort
-	reconnectConn.apiFastIP = "127.0.0.1"
-	defer reconnectConn.Close()
-
-	reconnectConn.recreateWsConn()
-
-	if got := atomic.LoadInt32(&fastIPCalls); got != 0 {
-		t.Fatalf("FastIP refresh calls = %d, want 0 for direct-IP reconnect", got)
+	select {
+	case req := <-dialer.calls:
+		if got := req.Header.Get("Authorization"); got != "Bearer fresh-token" {
+			t.Fatalf("Authorization = %q, want fresh token", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("missing websocket dial request")
 	}
 }
+
+func TestCreateWsConnAsyncReusesCachedToken(t *testing.T) {
+	oldDialFn := wsDialFn
+	oldTokenFn := wsGetTokenFn
+	oldEnvToken := envToken
+	oldHostPort := util.EnvHostPort
+	oldCacheToken := loadCachedToken()
+	defer func() {
+		wsDialFn = oldDialFn
+		wsGetTokenFn = oldTokenFn
+		envToken = oldEnvToken
+		util.EnvHostPort = oldHostPort
+		storeCachedToken(oldCacheToken)
+	}()
+
+	util.EnvHostPort = "192.0.2.10:443"
+	envToken = ""
+	storeCachedToken("cached-token")
+	var tokenCalls atomic.Int32
+	wsGetTokenFn = func(context.Context, string, string, string) (string, error) {
+		tokenCalls.Add(1)
+		return "unexpected-token", nil
+	}
+	dialer := newSupervisorTestDialer()
+	wire := newSupervisorTestWire()
+	dialer.results <- supervisorTestDialResult{wire: wire}
+	wsDialFn = dialer.dial
+
+	conn := createWsConnAsync(context.Background())
+	defer conn.Close()
+	waitForConnected(t, conn)
+	if got := tokenCalls.Load(); got != 0 {
+		t.Fatalf("token calls = %d, want 0", got)
+	}
+	select {
+	case req := <-dialer.calls:
+		if got := req.Header.Get("Authorization"); got != "Bearer cached-token" {
+			t.Fatalf("Authorization = %q, want cached token", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("missing websocket dial request")
+	}
+}
+
+func TestFreshCredentialFailurePreservesCachedToken(t *testing.T) {
+	oldTokenFn := wsGetTokenFn
+	oldEnvToken := envToken
+	oldCacheToken := loadCachedToken()
+	defer func() {
+		wsGetTokenFn = oldTokenFn
+		envToken = oldEnvToken
+		storeCachedToken(oldCacheToken)
+	}()
+
+	envToken = ""
+	storeCachedToken("retry-token")
+	wsGetTokenFn = func(context.Context, string, string, string) (string, error) {
+		return "", errors.New("fresh token failed")
+	}
+	if _, _, err := websocketCredentials(context.Background(), "192.0.2.1", "api.nxtrace.org", "443", false); err == nil {
+		t.Fatal("fresh credential lookup unexpectedly succeeded")
+	}
+	if got := loadCachedToken(); got != "retry-token" {
+		t.Fatalf("cached token = %q, want preserved retry token", got)
+	}
+}
+
+func TestCreateWsConnSyncReturnsAfterFailedStatePublished(t *testing.T) {
+	oldHostPort := util.EnvHostPort
+	defer func() { util.EnvHostPort = oldHostPort }()
+	util.EnvHostPort = "192.0.2.10:443"
+
+	dialer := newSupervisorTestDialer()
+	dialer.results <- supervisorTestDialResult{err: errors.New("dial failed")}
+	defer installSupervisorTestDialer(dialer)()
+
+	conn := createWsConn(context.Background())
+	defer conn.Close()
+	connected, phase, _, _ := conn.stateSnapshot()
+	if connected || conn.IsConnecting() || phase != wsPhaseRetryWait {
+		t.Fatalf("sync failure state = (connected=%v, connecting=%v, phase=%v), want retry wait", connected, conn.IsConnecting(), phase)
+	}
+}
+
+func TestDialFailurePanicPolicy(t *testing.T) {
+	syncConn := &WsConn{syncFirstAttempt: true}
+	asyncConn := &WsConn{}
+	tests := []struct {
+		name   string
+		conn   *WsConn
+		result wsDialResult
+		want   bool
+	}{
+		{name: "sync initial FastIP", conn: syncConn, result: wsDialResult{attemptID: 1, stage: wsDialStageFastIP}, want: true},
+		{name: "async initial FastIP", conn: asyncConn, result: wsDialResult{attemptID: 1, stage: wsDialStageFastIP}},
+		{name: "sync retry FastIP", conn: syncConn, result: wsDialResult{attemptID: 2, stage: wsDialStageFastIP}},
+		{name: "sync initial token", conn: syncConn, result: wsDialResult{attemptID: 1, stage: wsDialStageToken}, want: true},
+		{name: "async initial token", conn: asyncConn, result: wsDialResult{attemptID: 1, stage: wsDialStageToken}, want: true},
+		{name: "retry token", conn: syncConn, result: wsDialResult{attemptID: 2, stage: wsDialStageToken}, want: true},
+		{name: "connect", conn: syncConn, result: wsDialResult{attemptID: 1, stage: wsDialStageConnect}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.conn.shouldPanicDialFailure(tt.result); got != tt.want {
+				t.Fatalf("shouldPanicDialFailure() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateWsConnSyncDevModeFailurePanicsInCaller(t *testing.T) {
+	oldFastIPFn := wsGetFastIPFn
+	oldTokenFn := wsGetTokenFn
+	oldEnvToken := envToken
+	oldHostPort := util.EnvHostPort
+	oldDevMode := util.EnvDevMode
+	oldCacheToken := loadCachedToken()
+	defer func() {
+		wsGetFastIPFn = oldFastIPFn
+		wsGetTokenFn = oldTokenFn
+		envToken = oldEnvToken
+		util.EnvHostPort = oldHostPort
+		util.EnvDevMode = oldDevMode
+		storeCachedToken(oldCacheToken)
+	}()
+
+	util.EnvDevMode = true
+	envToken = ""
+	wantErr := errors.New("initial development failure")
+	tests := []struct {
+		name  string
+		setup func()
+	}{
+		{
+			name: "FastIP",
+			setup: func() {
+				util.EnvHostPort = "example.com:443"
+				wsGetFastIPFn = func(context.Context, string, string, bool) (string, error) {
+					return "", wantErr
+				}
+			},
+		},
+		{
+			name: "token",
+			setup: func() {
+				util.EnvHostPort = "192.0.2.10:443"
+				wsGetTokenFn = func(context.Context, string, string, string) (string, error) {
+					return "", wantErr
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			if got := recoverCreateWsConnPanic(); got != wantErr {
+				t.Fatalf("createWsConn() panic = %v, want %v", got, wantErr)
+			}
+		})
+	}
+}
+
+func recoverCreateWsConnPanic() (recovered any) {
+	defer func() {
+		recovered = recover()
+	}()
+	_ = createWsConn(context.Background())
+	return nil
+}
+
+func TestFastIPFailureLogPreservesInitialProbeWording(t *testing.T) {
+	oldOutput := log.Writer()
+	oldFlags := log.Flags()
+	defer func() {
+		log.SetOutput(oldOutput)
+		log.SetFlags(oldFlags)
+	}()
+	log.SetFlags(0)
+
+	var output bytes.Buffer
+	log.SetOutput(&output)
+	errProbe := errors.New("lookup failed")
+	(&WsConn{syncFirstAttempt: true}).logDialFailure(wsDialResult{
+		attemptID: 1,
+		stage:     wsDialStageFastIP,
+		err:       errProbe,
+	})
+	if got := strings.TrimSpace(output.String()); got != "fast ip probe failed: lookup failed" {
+		t.Fatalf("sync FastIP log = %q", got)
+	}
+
+	output.Reset()
+	(&WsConn{}).logDialFailure(wsDialResult{
+		attemptID: 1,
+		stage:     wsDialStageFastIP,
+		err:       errProbe,
+	})
+	if got := strings.TrimSpace(output.String()); got != "fast ip refresh failed: lookup failed" {
+		t.Fatalf("async FastIP log = %q", got)
+	}
+}
+
+func TestLiteralWsConnSendMessageFallback(t *testing.T) {
+	conn := newLiteralTestWsConn(context.Background())
+	if err := conn.SendMessage(context.Background(), "192.0.2.20"); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+	select {
+	case got := <-conn.MsgSendCh:
+		if got != "192.0.2.20" {
+			t.Fatalf("fallback message = %q", got)
+		}
+	default:
+		t.Fatal("literal fallback did not enqueue message")
+	}
+	conn.Close()
+	if err := conn.SendMessage(context.Background(), "192.0.2.21"); !errors.Is(err, errConnClosed) {
+		t.Fatalf("SendMessage() after Close error = %v, want %v", err, errConnClosed)
+	}
+}
+
+func TestZeroValueWsConnSendMessageHonorsContext(t *testing.T) {
+	var conn WsConn
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := conn.SendMessage(ctx, "192.0.2.22"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SendMessage() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+	conn.Close()
+}
+
+var _ wsWire = (*blockingCloseWire)(nil)

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -685,6 +685,28 @@ func TestLiteralWsConnSendMessageFallback(t *testing.T) {
 	}
 }
 
+func TestLiteralWsConnRequestMessageIsUnsupportedWithoutSideEffects(t *testing.T) {
+	conn := &WsConn{
+		MsgSendCh:    make(chan string, 1),
+		MsgReceiveCh: make(chan string, 1),
+	}
+
+	response, err := conn.RequestMessage(context.Background(), "192.0.2.23")
+	if !errors.Is(err, ErrRequestResponseUnsupported) || response != "" {
+		t.Fatalf("RequestMessage() = (%q, %v), want empty unsupported result", response, err)
+	}
+	select {
+	case sent := <-conn.MsgSendCh:
+		t.Fatalf("unsupported RequestMessage() sent %q", sent)
+	default:
+	}
+	select {
+	case received := <-conn.MsgReceiveCh:
+		t.Fatalf("unsupported RequestMessage() received %q", received)
+	default:
+	}
+}
+
 func TestZeroValueWsConnSendMessageHonorsContext(t *testing.T) {
 	var conn WsConn
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)

--- a/wshandle/supervisor.go
+++ b/wshandle/supervisor.go
@@ -1,0 +1,982 @@
+package wshandle
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+const wsClientReceiveBacklog = 1024
+
+type wsPhase uint8
+
+const (
+	wsPhaseIdle wsPhase = iota
+	wsPhaseConnecting
+	wsPhaseRetryWait
+	wsPhaseConnected
+	wsPhaseClosing
+	wsPhaseClosed
+)
+
+type wsWire interface {
+	ReadMessage() (int, []byte, error)
+	SetWriteDeadline(time.Time) error
+	WriteMessage(int, []byte) error
+	Close() error
+}
+
+type wsWriteKind uint8
+
+const (
+	wsWriteRequest wsWriteKind = iota
+	wsWritePing
+	wsWriteClose
+)
+
+type wsDialStage uint8
+
+const (
+	wsDialStageFastIP wsDialStage = iota
+	wsDialStageToken
+	wsDialStageConnect
+)
+
+type wsDialRequest struct {
+	URL        string
+	Header     http.Header
+	ServerName string
+	Proxy      *url.URL
+}
+
+type wsDialResult struct {
+	attemptID  uint64
+	wire       wsWire
+	publicConn *websocket.Conn
+	fastIP     string
+	stage      wsDialStage
+	err        error
+}
+
+type wsReadEvent struct {
+	generation uint64
+	data       []byte
+	err        error
+}
+
+type wsWriteResult struct {
+	job wsWriteJob
+	err error
+}
+
+type wsSubmission struct {
+	ctx context.Context
+	msg string
+	ack chan error
+}
+
+type wsRequestCancel struct {
+	generation uint64
+	jobID      uint64
+}
+
+type wsGeneration struct {
+	id         uint64
+	ctx        context.Context
+	cancel     context.CancelCauseFunc
+	wire       wsWire
+	publicConn *websocket.Conn
+}
+
+type wsSupervisorState struct {
+	attemptID     uint64
+	attemptActive bool
+	attemptCancel context.CancelCauseFunc
+	nextGenID     uint64
+	nextJobID     uint64
+	generation    *wsGeneration
+	pending       map[uint64]wsWriteJob
+
+	retryTimer     *time.Timer
+	retryC         <-chan time.Time
+	heartbeatTimer *time.Timer
+	heartbeatC     <-chan time.Time
+	graceTimer     *time.Timer
+	graceC         <-chan time.Time
+
+	pingPending     bool
+	pingOutstanding bool
+	pongSerial      uint64
+	missedPongs     uint8
+	interrupting    bool
+}
+
+var wsDialFn = defaultWSDial
+
+var (
+	errStaleWriteGeneration = errors.New("wshandle: stale write generation")
+	errMissingWriteConn     = errors.New("wshandle: missing write connection")
+	errRequestCanceled      = errors.New("wshandle: request canceled before write")
+	errWebSocketRead        = errors.New("wshandle: websocket read failed")
+	errWebSocketWrite       = errors.New("wshandle: websocket write failed")
+	errPongTimeout          = errors.New("wshandle: pong timeout")
+	errInterrupted          = errors.New("wshandle: interrupted")
+)
+
+func defaultWSDial(ctx context.Context, req wsDialRequest) (wsWire, *websocket.Conn, error) {
+	dialer := *websocket.DefaultDialer
+	dialer.TLSClientConfig = &tls.Config{ServerName: req.ServerName}
+	if req.Proxy != nil {
+		dialer.Proxy = http.ProxyURL(req.Proxy)
+	}
+	conn, _, err := dialer.DialContext(ctx, req.URL, req.Header)
+	if conn == nil {
+		return nil, nil, err
+	}
+	return conn, conn, err
+}
+
+func newManagedWsConn(ctx context.Context, interrupt chan os.Signal, endpoint wsEndpoint) *WsConn {
+	return newManagedWsConnWithPolicy(ctx, interrupt, endpoint, false)
+}
+
+func newManagedWsConnWithPolicy(
+	ctx context.Context,
+	interrupt chan os.Signal,
+	endpoint wsEndpoint,
+	syncFirstAttempt bool,
+) *WsConn {
+	baseCtx := normalizeContext(ctx)
+	rootCtx, cancelRoot := context.WithCancelCause(baseCtx)
+	c := &WsConn{
+		MsgSendCh:        make(chan string, 10),
+		MsgReceiveCh:     make(chan string, 10),
+		Done:             make(chan struct{}),
+		Interrupt:        interrupt,
+		closeCh:          make(chan struct{}),
+		baseCtx:          baseCtx,
+		rootCtx:          rootCtx,
+		cancelRoot:       cancelRoot,
+		managed:          true,
+		phase:            wsPhaseIdle,
+		stateChanged:     make(chan struct{}),
+		supervisorReady:  make(chan struct{}),
+		supervisorDone:   make(chan struct{}),
+		firstAttemptDone: make(chan struct{}),
+		submitCh:         make(chan wsSubmission),
+		requestCancels:   make(chan wsRequestCancel, wsClientWriteQueueSize),
+		dialResults:      make(chan wsDialResult),
+		readEvents:       make(chan wsReadEvent, wsClientReceiveBacklog),
+		managedWriteCh:   make(chan wsWriteJob, wsClientWriteQueueSize),
+		writeResults:     make(chan wsWriteResult, wsClientWriteQueueSize),
+		directIP:         endpoint.direct,
+		apiHost:          endpoint.host,
+		apiPort:          endpoint.port,
+		apiFastIP:        endpoint.fastIP,
+		syncFirstAttempt: syncFirstAttempt,
+	}
+	c.startManagedSupervisor()
+	return c
+}
+
+func (c *WsConn) startManagedSupervisor() {
+	c.supervisorOnce.Do(func() {
+		c.workerWG.Add(1)
+		go c.managedWriteLoop()
+		go c.supervise()
+	})
+	<-c.supervisorReady
+}
+
+func (c *WsConn) completeFirstAttempt() {
+	c.firstAttemptOnce.Do(func() {
+		close(c.firstAttemptDone)
+	})
+}
+
+func (c *WsConn) supervise() {
+	state := wsSupervisorState{pending: make(map[uint64]wsWriteJob)}
+	var receiveQueue []string
+	defer c.finishSupervision(&state)
+
+	if c.rootCtx.Err() == nil {
+		c.beginDialAttempt(&state)
+	}
+	close(c.supervisorReady)
+
+	sendCh := c.MsgSendCh
+	interruptCh := c.Interrupt
+	for {
+		var receiveOut chan string
+		var receiveMsg string
+		var readEvents <-chan wsReadEvent
+		if len(receiveQueue) > 0 && c.MsgReceiveCh != nil {
+			receiveOut = c.MsgReceiveCh
+			receiveMsg = receiveQueue[0]
+		}
+		if len(receiveQueue) < wsClientReceiveBacklog {
+			readEvents = c.readEvents
+		}
+		select {
+		case <-c.rootCtx.Done():
+			return
+		case receiveOut <- receiveMsg:
+			receiveQueue[0] = ""
+			receiveQueue = receiveQueue[1:]
+		case result := <-c.dialResults:
+			c.handleDialResult(&state, result)
+		case event := <-readEvents:
+			c.handleReadEvent(&state, event, &receiveQueue)
+		case result := <-c.writeResults:
+			c.handleWriteResult(&state, result)
+		case submission := <-c.submitCh:
+			c.handleSubmission(&state, submission)
+		case canceled := <-c.requestCancels:
+			c.handleRequestCancel(&state, canceled)
+		case <-state.retryC:
+			stopSupervisorTimer(&state.retryTimer, &state.retryC)
+			c.beginDialAttempt(&state)
+		case <-state.heartbeatC:
+			stopSupervisorTimer(&state.heartbeatTimer, &state.heartbeatC)
+			c.handleHeartbeat(&state)
+		case <-state.graceC:
+			stopSupervisorTimer(&state.graceTimer, &state.graceC)
+			c.cancelRoot(errInterrupted)
+		case msg, ok := <-sendCh:
+			if !ok {
+				sendCh = nil
+				continue
+			}
+			c.handlePublicWrite(&state, msg)
+		case <-interruptCh:
+			interruptCh = nil
+			c.handleInterruptEvent(&state)
+		}
+	}
+}
+
+func (c *WsConn) beginDialAttempt(state *wsSupervisorState) {
+	if state.attemptActive || state.generation != nil || c.rootCtx.Err() != nil {
+		return
+	}
+	state.attemptID++
+	state.attemptActive = true
+	attemptCtx, cancel := context.WithCancelCause(c.rootCtx)
+	state.attemptCancel = cancel
+	c.publishManagedPhase(wsPhaseConnecting)
+
+	attemptID := state.attemptID
+	c.workerWG.Add(1)
+	go func() {
+		defer c.workerWG.Done()
+		result := c.performDialAttempt(attemptCtx, attemptID)
+		if c.rootCtx.Err() != nil {
+			closeDialResult(result)
+			return
+		}
+		select {
+		case c.dialResults <- result:
+		case <-c.rootCtx.Done():
+			closeDialResult(result)
+		}
+	}()
+}
+
+func (c *WsConn) performDialAttempt(ctx context.Context, attemptID uint64) wsDialResult {
+	direct, host, port, fastIP := c.endpointSnapshot()
+	result := wsDialResult{attemptID: attemptID, fastIP: fastIP}
+	if !direct && host != "" && net.ParseIP(host) == nil {
+		refreshed, err := wsGetFastIPFn(ctx, host, port, true)
+		if err != nil {
+			result.stage = wsDialStageFastIP
+			result.err = err
+			return result
+		}
+		fastIP = refreshed
+		result.fastIP = refreshed
+	}
+
+	allowCachedToken := !c.syncFirstAttempt || attemptID > 1
+	token, ua, err := websocketCredentials(ctx, fastIP, host, port, allowCachedToken)
+	if err != nil {
+		result.stage = wsDialStageToken
+		result.err = err
+		return result
+	}
+
+	dialURL := url.URL{Scheme: "wss", Host: formatHostPort(fastIP, port), Path: "/v3/ipGeoWs"}
+	request := wsDialRequest{
+		URL:        dialURL.String(),
+		ServerName: host,
+		Proxy:      util.GetProxy(),
+		Header: http.Header{
+			"Host":          []string{host},
+			"User-Agent":    ua,
+			"Authorization": []string{"Bearer " + token},
+		},
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, wsClientDialTimeout)
+	wire, publicConn, err := wsDialFn(dialCtx, request)
+	cancel()
+	result.stage = wsDialStageConnect
+	result.wire = wire
+	result.publicConn = publicConn
+	result.err = err
+	if ctx.Err() != nil {
+		closeDialResult(result)
+		result.wire = nil
+		result.publicConn = nil
+		result.err = ctx.Err()
+	}
+	return result
+}
+
+func websocketCredentials(
+	ctx context.Context,
+	fastIP, host, port string,
+	allowCachedToken bool,
+) (string, []string, error) {
+	if envToken != "" {
+		return envToken, []string{"Privileged Client"}, nil
+	}
+	if allowCachedToken {
+		if token := loadCachedToken(); token != "" {
+			return token, []string{util.UserAgent}, nil
+		}
+	}
+	tokenHost := fastIP
+	tokenDomain := host
+	if provider := util.GetPowProvider(); provider != "" {
+		tokenHost = provider
+		tokenDomain = provider
+	}
+	token, err := wsGetTokenFn(ctx, tokenHost, tokenDomain, port)
+	if err != nil {
+		return "", nil, err
+	}
+	storeCachedToken(token)
+	return token, []string{util.UserAgent}, nil
+}
+
+func loadCachedToken() string {
+	cacheTokenMu.Lock()
+	defer cacheTokenMu.Unlock()
+	return cacheToken
+}
+
+func storeCachedToken(token string) {
+	cacheTokenMu.Lock()
+	cacheToken = token
+	cacheTokenMu.Unlock()
+}
+
+func (c *WsConn) endpointSnapshot() (direct bool, host, port, fastIP string) {
+	c.stateMu.RLock()
+	direct = c.directIP
+	host = c.apiHost
+	port = c.apiPort
+	fastIP = c.apiFastIP
+	c.stateMu.RUnlock()
+	return
+}
+
+func (c *WsConn) handleDialResult(state *wsSupervisorState, result wsDialResult) {
+	if result.attemptID != state.attemptID || !state.attemptActive || c.rootCtx.Err() != nil {
+		closeDialResult(result)
+		return
+	}
+	state.attemptActive = false
+	if state.attemptCancel != nil {
+		state.attemptCancel(nil)
+		state.attemptCancel = nil
+	}
+	if result.err != nil {
+		closeDialResult(result)
+		if util.EnvDevMode && c.shouldPanicDialFailure(result) && !isContextStop(result.err) {
+			if c.syncFirstAttempt && result.attemptID == 1 {
+				c.recordFirstAttemptFailure(result.err)
+				c.cancelRoot(result.err)
+				c.completeFirstAttempt()
+				return
+			}
+			panic(result.err)
+		}
+		c.logDialFailure(result)
+		delay := wsClientReconnectDelay
+		if result.stage == wsDialStageConnect && result.attemptID > 1 {
+			delay = wsClientDialRetryDelay
+		}
+		c.publishManagedPhase(wsPhaseRetryWait)
+		resetSupervisorTimer(&state.retryTimer, &state.retryC, delay)
+		c.completeFirstAttempt()
+		return
+	}
+
+	c.stateMu.Lock()
+	c.apiFastIP = result.fastIP
+	c.stateMu.Unlock()
+	c.installGeneration(state, result)
+	c.completeFirstAttempt()
+}
+
+func (c *WsConn) shouldPanicDialFailure(result wsDialResult) bool {
+	switch result.stage {
+	case wsDialStageFastIP:
+		return c.syncFirstAttempt && result.attemptID == 1
+	case wsDialStageToken:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *WsConn) recordFirstAttemptFailure(err error) {
+	c.stateMu.Lock()
+	c.firstAttemptErr = err
+	c.phase = wsPhaseClosing
+	c.Connected = false
+	c.Connecting = false
+	c.notifyStateLocked()
+	c.stateMu.Unlock()
+}
+
+func (c *WsConn) firstAttemptFailure() error {
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
+	return c.firstAttemptErr
+}
+
+func (c *WsConn) logDialFailure(result wsDialResult) {
+	if c.suppressCanceledContextLog(result.err) {
+		return
+	}
+	switch result.stage {
+	case wsDialStageFastIP:
+		if c.syncFirstAttempt && result.attemptID == 1 {
+			log.Printf("fast ip probe failed: %v", result.err)
+		} else {
+			log.Printf("fast ip refresh failed: %v", result.err)
+		}
+	case wsDialStageToken:
+		log.Printf("pow token fetch failed: %v", result.err)
+	case wsDialStageConnect:
+		log.Printf("dial: %v", result.err)
+	}
+}
+
+func (c *WsConn) installGeneration(state *wsSupervisorState, result wsDialResult) {
+	state.nextGenID++
+	genCtx, cancel := context.WithCancelCause(c.rootCtx)
+	generation := &wsGeneration{
+		id:         state.nextGenID,
+		ctx:        genCtx,
+		cancel:     cancel,
+		wire:       result.wire,
+		publicConn: result.publicConn,
+	}
+	state.generation = generation
+	state.missedPongs = 0
+	state.pongSerial = 0
+	state.pingPending = false
+	state.pingOutstanding = false
+	state.interrupting = false
+	stopSupervisorTimer(&state.retryTimer, &state.retryC)
+	c.publishManagedConnected(result.publicConn)
+	c.startManagedReader(generation)
+	resetSupervisorTimer(&state.heartbeatTimer, &state.heartbeatC, wsClientPingInterval)
+}
+
+func (c *WsConn) startManagedReader(generation *wsGeneration) {
+	c.workerWG.Add(1)
+	go func() {
+		defer c.workerWG.Done()
+		for {
+			_, data, err := generation.wire.ReadMessage()
+			event := wsReadEvent{generation: generation.id, data: data, err: err}
+			select {
+			case c.readEvents <- event:
+			case <-generation.ctx.Done():
+				return
+			case <-c.rootCtx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+}
+
+func (c *WsConn) managedWriteLoop() {
+	defer c.workerWG.Done()
+	for {
+		if c.rootCtx.Err() != nil {
+			return
+		}
+		select {
+		case <-c.rootCtx.Done():
+			return
+		case job := <-c.managedWriteCh:
+			result := wsWriteResult{job: job}
+			if job.awaitReply && contextErr(job.requestCtx) != nil {
+				result.err = errRequestCanceled
+			} else {
+				select {
+				case <-job.genDone:
+					result.err = errStaleWriteGeneration
+				default:
+					if job.wire == nil {
+						result.err = errMissingWriteConn
+					} else {
+						_ = job.wire.SetWriteDeadline(time.Now().Add(wsClientWriteTimeout))
+						if job.awaitReply && contextErr(job.requestCtx) != nil {
+							result.err = errRequestCanceled
+						} else {
+							result.err = job.wire.WriteMessage(job.msgType, job.data)
+						}
+					}
+				}
+			}
+			select {
+			case c.writeResults <- result:
+			case <-c.rootCtx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (c *WsConn) handleReadEvent(state *wsSupervisorState, event wsReadEvent, receiveQueue *[]string) {
+	if state.generation == nil || event.generation != state.generation.id {
+		return
+	}
+	if event.err != nil {
+		if state.interrupting {
+			c.cancelRoot(errInterrupted)
+			return
+		}
+		c.endGeneration(state, errors.Join(errWebSocketRead, event.err), true)
+		return
+	}
+	if string(event.data) == "pong" {
+		state.pongSerial++
+		state.missedPongs = 0
+		state.pingOutstanding = false
+		return
+	}
+	c.completePendingResponse(state, event.generation, event.data)
+	*receiveQueue = append(*receiveQueue, string(event.data))
+}
+
+func (c *WsConn) completePendingResponse(state *wsSupervisorState, generation uint64, data []byte) {
+	var response struct {
+		IP string `json:"ip"`
+	}
+	if err := json.Unmarshal(data, &response); err != nil || response.IP == "" {
+		return
+	}
+
+	var oldestID uint64
+	for id, job := range state.pending {
+		if job.generation != generation || job.requestIP != response.IP {
+			continue
+		}
+		if oldestID == 0 || id < oldestID {
+			oldestID = id
+		}
+	}
+	if oldestID != 0 {
+		c.finishPendingRequest(state, oldestID)
+	}
+}
+
+func (c *WsConn) handlePublicWrite(state *wsSupervisorState, msg string) {
+	if err := c.registerRequest(state, msg, nil, false); err != nil {
+		c.trySendReceiveMessage(apiServerErrorMessage(msg))
+		if errors.Is(err, errWriteQueueFull) {
+			c.endGeneration(state, err, true)
+		}
+	}
+}
+
+func (c *WsConn) handleSubmission(state *wsSupervisorState, submission wsSubmission) {
+	if err := contextErr(submission.ctx); err != nil {
+		submission.ack <- err
+		return
+	}
+	err := c.registerRequest(state, submission.msg, submission.ctx, true)
+	if errors.Is(err, errWriteQueueFull) {
+		c.endGeneration(state, err, true)
+	}
+	submission.ack <- err
+}
+
+func (c *WsConn) registerRequest(
+	state *wsSupervisorState,
+	msg string,
+	requestCtx context.Context,
+	awaitReply bool,
+) error {
+	if awaitReply {
+		if err := contextErr(requestCtx); err != nil {
+			return err
+		}
+	}
+	if c.rootCtx.Err() != nil || state.generation == nil || state.interrupting {
+		return errConnClosed
+	}
+	state.nextJobID++
+	job := wsWriteJob{
+		id:         state.nextJobID,
+		generation: state.generation.id,
+		genDone:    state.generation.ctx.Done(),
+		wire:       state.generation.wire,
+		kind:       wsWriteRequest,
+		msgType:    websocket.TextMessage,
+		data:       []byte(msg),
+		requestIP:  msg,
+		requestCtx: requestCtx,
+		awaitReply: awaitReply,
+	}
+	if !c.enqueueManagedWrite(job) {
+		return errWriteQueueFull
+	}
+	if awaitReply {
+		c.watchRequestContext(&job)
+	}
+	state.pending[job.id] = job
+	return nil
+}
+
+func (c *WsConn) watchRequestContext(job *wsWriteJob) {
+	c.workerWG.Add(1)
+	canceled := wsRequestCancel{generation: job.generation, jobID: job.id}
+	job.stopCancel = context.AfterFunc(job.requestCtx, func() {
+		defer c.workerWG.Done()
+		select {
+		case c.requestCancels <- canceled:
+		case <-c.rootCtx.Done():
+		}
+	})
+}
+
+func (c *WsConn) handleRequestCancel(state *wsSupervisorState, canceled wsRequestCancel) {
+	job, ok := state.pending[canceled.jobID]
+	if !ok || job.generation != canceled.generation {
+		return
+	}
+	c.finishPendingRequest(state, canceled.jobID)
+}
+
+func (c *WsConn) finishPendingRequest(state *wsSupervisorState, jobID uint64) (wsWriteJob, bool) {
+	job, ok := state.pending[jobID]
+	if !ok {
+		return wsWriteJob{}, false
+	}
+	delete(state.pending, jobID)
+	if job.stopCancel != nil && job.stopCancel() {
+		c.workerWG.Done()
+	}
+	return job, true
+}
+
+// SendMessage submits msg to the current websocket generation.
+func (c *WsConn) SendMessage(ctx context.Context, msg string) error {
+	if c == nil {
+		return errConnClosed
+	}
+	ctx = normalizeContext(ctx)
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+	if !c.managed {
+		_, phase, _, rootDone := c.stateSnapshot()
+		if phase == wsPhaseClosed {
+			return errConnClosed
+		}
+		select {
+		case c.MsgSendCh <- msg:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-rootDone:
+			return errConnClosed
+		}
+	}
+
+	submission := wsSubmission{
+		ctx: ctx,
+		msg: msg,
+		ack: make(chan error, 1),
+	}
+	select {
+	case c.submitCh <- submission:
+		return <-submission.ack
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.rootCtx.Done():
+		return errConnClosed
+	}
+}
+
+func (c *WsConn) enqueueManagedWrite(job wsWriteJob) bool {
+	select {
+	case c.managedWriteCh <- job:
+		return true
+	case <-c.rootCtx.Done():
+		return false
+	default:
+		return false
+	}
+}
+
+func (c *WsConn) handleWriteResult(state *wsSupervisorState, result wsWriteResult) {
+	job := result.job
+	if job.kind == wsWriteRequest {
+		pendingJob, pending := state.pending[job.id]
+		if errors.Is(result.err, errRequestCanceled) {
+			if pending {
+				c.finishPendingRequest(state, job.id)
+			}
+			return
+		}
+		if result.err == nil {
+			if pending && !pendingJob.awaitReply {
+				c.finishPendingRequest(state, job.id)
+			}
+			return
+		}
+		if pending {
+			c.finishPendingRequest(state, job.id)
+			if contextErr(pendingJob.requestCtx) == nil {
+				c.trySendReceiveMessage(apiServerErrorMessage(pendingJob.requestIP))
+			}
+		}
+		if state.generation != nil && job.generation == state.generation.id {
+			c.endGeneration(state, errors.Join(errWebSocketWrite, result.err), true)
+		}
+		return
+	}
+	if state.generation == nil || job.generation != state.generation.id {
+		return
+	}
+	if result.err != nil {
+		if state.interrupting {
+			c.cancelRoot(errInterrupted)
+			return
+		}
+		c.endGeneration(state, errors.Join(errWebSocketWrite, result.err), true)
+		return
+	}
+	switch job.kind {
+	case wsWritePing:
+		state.pingPending = false
+		state.pingOutstanding = job.pongSerial == state.pongSerial
+		resetSupervisorTimer(&state.heartbeatTimer, &state.heartbeatC, wsClientPingInterval)
+	case wsWriteClose:
+		// Wait for the peer/read loop or the interrupt grace timer.
+	}
+}
+
+func (c *WsConn) handleHeartbeat(state *wsSupervisorState) {
+	if state.generation == nil || state.interrupting {
+		return
+	}
+	if state.pingOutstanding {
+		state.missedPongs++
+		state.pingOutstanding = false
+		if state.missedPongs >= 2 {
+			c.endGeneration(state, errPongTimeout, true)
+			return
+		}
+	}
+	state.nextJobID++
+	job := wsWriteJob{
+		id:         state.nextJobID,
+		generation: state.generation.id,
+		genDone:    state.generation.ctx.Done(),
+		wire:       state.generation.wire,
+		kind:       wsWritePing,
+		msgType:    websocket.TextMessage,
+		data:       []byte("ping"),
+		pongSerial: state.pongSerial,
+	}
+	state.pingPending = true
+	if !c.enqueueManagedWrite(job) {
+		state.pingPending = false
+		c.endGeneration(state, errWriteQueueFull, true)
+	}
+}
+
+func (c *WsConn) handleInterruptEvent(state *wsSupervisorState) {
+	if state.interrupting {
+		return
+	}
+	if state.generation == nil {
+		c.cancelRoot(errInterrupted)
+		return
+	}
+	state.interrupting = true
+	state.nextJobID++
+	job := wsWriteJob{
+		id:         state.nextJobID,
+		generation: state.generation.id,
+		genDone:    state.generation.ctx.Done(),
+		wire:       state.generation.wire,
+		kind:       wsWriteClose,
+		msgType:    websocket.CloseMessage,
+		data:       websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+	}
+	if !c.enqueueManagedWrite(job) {
+		c.cancelRoot(errInterrupted)
+		return
+	}
+	resetSupervisorTimer(&state.graceTimer, &state.graceC, time.Second)
+}
+
+func (c *WsConn) endGeneration(state *wsSupervisorState, cause error, retry bool) {
+	generation := state.generation
+	if generation == nil {
+		return
+	}
+	state.generation = nil
+	generation.cancel(cause)
+	stopSupervisorTimer(&state.heartbeatTimer, &state.heartbeatC)
+	stopSupervisorTimer(&state.graceTimer, &state.graceC)
+	state.pingPending = false
+	state.pingOutstanding = false
+	state.interrupting = false
+	c.publishManagedDisconnected(retry)
+	_ = generation.wire.Close()
+	c.failPendingGeneration(state, generation.id)
+	if retry && c.rootCtx.Err() == nil {
+		resetSupervisorTimer(&state.retryTimer, &state.retryC, wsClientReconnectDelay)
+	}
+}
+
+func (c *WsConn) failPendingGeneration(state *wsSupervisorState, generation uint64) {
+	for id, job := range state.pending {
+		if job.generation != generation {
+			continue
+		}
+		c.finishPendingRequest(state, id)
+		if contextErr(job.requestCtx) == nil {
+			c.trySendReceiveMessage(apiServerErrorMessage(job.requestIP))
+		}
+	}
+}
+
+func (c *WsConn) publishManagedPhase(phase wsPhase) {
+	c.stateMu.Lock()
+	c.phase = phase
+	c.Connected = phase == wsPhaseConnected
+	c.Connecting = phase == wsPhaseConnecting
+	c.notifyStateLocked()
+	c.stateMu.Unlock()
+}
+
+func (c *WsConn) publishManagedConnected(conn *websocket.Conn) {
+	c.stateMu.Lock()
+	if c.Done == nil || c.doneClosed {
+		c.Done = make(chan struct{})
+		c.doneClosed = false
+	}
+	c.Conn = conn
+	c.phase = wsPhaseConnected
+	c.Connected = true
+	c.Connecting = false
+	c.notifyStateLocked()
+	c.stateMu.Unlock()
+}
+
+func (c *WsConn) publishManagedDisconnected(retry bool) {
+	c.stateMu.Lock()
+	c.Conn = nil
+	c.Connected = false
+	c.Connecting = false
+	if retry {
+		c.phase = wsPhaseRetryWait
+	} else {
+		c.phase = wsPhaseClosing
+	}
+	c.closeDoneLocked()
+	c.notifyStateLocked()
+	c.stateMu.Unlock()
+}
+
+func (c *WsConn) finishSupervision(state *wsSupervisorState) {
+	if state.attemptCancel != nil {
+		state.attemptCancel(errConnClosed)
+	}
+	stopSupervisorTimer(&state.retryTimer, &state.retryC)
+	stopSupervisorTimer(&state.heartbeatTimer, &state.heartbeatC)
+	stopSupervisorTimer(&state.graceTimer, &state.graceC)
+	if state.generation != nil {
+		c.endGeneration(state, context.Cause(c.rootCtx), false)
+	}
+	c.completeFirstAttempt()
+	c.closeSignalChan()
+	c.workerWG.Wait()
+	if c.Interrupt != nil {
+		signal.Stop(c.Interrupt)
+	}
+	c.stateMu.Lock()
+	c.Conn = nil
+	c.Connected = false
+	c.Connecting = false
+	c.phase = wsPhaseClosed
+	c.closeDoneLocked()
+	c.notifyStateLocked()
+	c.stateMu.Unlock()
+	c.closeReceiveChannel()
+	close(c.supervisorDone)
+}
+
+func closeDialResult(result wsDialResult) {
+	publicWire, _ := result.wire.(*websocket.Conn)
+	if result.wire != nil {
+		_ = result.wire.Close()
+	}
+	if result.publicConn != nil && result.publicConn != publicWire {
+		_ = result.publicConn.Close()
+	}
+}
+
+func resetSupervisorTimer(timer **time.Timer, timerC *<-chan time.Time, delay time.Duration) {
+	if *timer == nil {
+		*timer = time.NewTimer(delay)
+	} else {
+		if !(*timer).Stop() {
+			select {
+			case <-(*timer).C:
+			default:
+			}
+		}
+		(*timer).Reset(delay)
+	}
+	*timerC = (*timer).C
+}
+
+func stopSupervisorTimer(timer **time.Timer, timerC *<-chan time.Time) {
+	if *timer != nil {
+		if !(*timer).Stop() {
+			select {
+			case <-(*timer).C:
+			default:
+			}
+		}
+	}
+	*timerC = nil
+}

--- a/wshandle/supervisor.go
+++ b/wshandle/supervisor.go
@@ -82,9 +82,10 @@ type wsWriteResult struct {
 }
 
 type wsSubmission struct {
-	ctx context.Context
-	msg string
-	ack chan error
+	ctx   context.Context
+	msg   string
+	ack   chan error
+	reply chan<- string
 }
 
 type wsRequestCancel struct {
@@ -541,10 +542,16 @@ func (c *WsConn) managedWriteLoop() {
 						result.err = errMissingWriteConn
 					} else {
 						_ = job.wire.SetWriteDeadline(time.Now().Add(wsClientWriteTimeout))
+						if job.progress != nil {
+							job.progress.began.Store(true)
+						}
 						if job.awaitReply && contextErr(job.requestCtx) != nil {
 							result.err = errRequestCanceled
 						} else {
 							result.err = job.wire.WriteMessage(job.msgType, job.data)
+							if result.err == nil && job.progress != nil {
+								job.progress.succeeded.Store(true)
+							}
 						}
 					}
 				}
@@ -576,16 +583,17 @@ func (c *WsConn) handleReadEvent(state *wsSupervisorState, event wsReadEvent, re
 		state.pingOutstanding = false
 		return
 	}
-	c.completePendingResponse(state, event.generation, event.data)
-	*receiveQueue = append(*receiveQueue, string(event.data))
+	if !c.completePendingResponse(state, event.generation, event.data) {
+		*receiveQueue = append(*receiveQueue, string(event.data))
+	}
 }
 
-func (c *WsConn) completePendingResponse(state *wsSupervisorState, generation uint64, data []byte) {
+func (c *WsConn) completePendingResponse(state *wsSupervisorState, generation uint64, data []byte) bool {
 	var response struct {
 		IP string `json:"ip"`
 	}
 	if err := json.Unmarshal(data, &response); err != nil || response.IP == "" {
-		return
+		return false
 	}
 
 	var oldestID uint64
@@ -598,12 +606,14 @@ func (c *WsConn) completePendingResponse(state *wsSupervisorState, generation ui
 		}
 	}
 	if oldestID != 0 {
-		c.finishPendingRequest(state, oldestID)
+		job, _ := c.finishPendingRequest(state, oldestID)
+		return deliverBoundResponse(job, string(data))
 	}
+	return false
 }
 
 func (c *WsConn) handlePublicWrite(state *wsSupervisorState, msg string) {
-	if err := c.registerRequest(state, msg, nil, false); err != nil {
+	if err := c.registerRequest(state, msg, nil, false, nil); err != nil {
 		c.trySendReceiveMessage(apiServerErrorMessage(msg))
 		if errors.Is(err, errWriteQueueFull) {
 			c.endGeneration(state, err, true)
@@ -616,7 +626,7 @@ func (c *WsConn) handleSubmission(state *wsSupervisorState, submission wsSubmiss
 		submission.ack <- err
 		return
 	}
-	err := c.registerRequest(state, submission.msg, submission.ctx, true)
+	err := c.registerRequest(state, submission.msg, submission.ctx, true, submission.reply)
 	if errors.Is(err, errWriteQueueFull) {
 		c.endGeneration(state, err, true)
 	}
@@ -628,6 +638,7 @@ func (c *WsConn) registerRequest(
 	msg string,
 	requestCtx context.Context,
 	awaitReply bool,
+	reply chan<- string,
 ) error {
 	if awaitReply {
 		if err := contextErr(requestCtx); err != nil {
@@ -636,6 +647,9 @@ func (c *WsConn) registerRequest(
 	}
 	if c.rootCtx.Err() != nil || state.generation == nil || state.interrupting {
 		return errConnClosed
+	}
+	if len(state.pending) >= wsClientWriteQueueSize {
+		return errWriteQueueFull
 	}
 	state.nextJobID++
 	job := wsWriteJob{
@@ -649,6 +663,8 @@ func (c *WsConn) registerRequest(
 		requestIP:  msg,
 		requestCtx: requestCtx,
 		awaitReply: awaitReply,
+		progress:   &wsWriteProgress{},
+		reply:      reply,
 	}
 	if !c.enqueueManagedWrite(job) {
 		return errWriteQueueFull
@@ -658,6 +674,17 @@ func (c *WsConn) registerRequest(
 	}
 	state.pending[job.id] = job
 	return nil
+}
+
+func deliverBoundResponse(job wsWriteJob, response string) bool {
+	if job.reply == nil {
+		return false
+	}
+	select {
+	case job.reply <- response:
+	default:
+	}
+	return true
 }
 
 func (c *WsConn) watchRequestContext(job *wsWriteJob) {
@@ -677,7 +704,11 @@ func (c *WsConn) handleRequestCancel(state *wsSupervisorState, canceled wsReques
 	if !ok || job.generation != canceled.generation {
 		return
 	}
-	c.finishPendingRequest(state, canceled.jobID)
+	job, _ = c.finishPendingRequest(state, canceled.jobID)
+	if job.awaitReply && job.progress != nil && job.progress.began.Load() &&
+		state.generation != nil && state.generation.id == canceled.generation {
+		c.endGeneration(state, errRequestCanceled, true)
+	}
 }
 
 func (c *WsConn) finishPendingRequest(state *wsSupervisorState, jobID uint64) (wsWriteJob, bool) {
@@ -731,6 +762,56 @@ func (c *WsConn) SendMessage(ctx context.Context, msg string) error {
 	}
 }
 
+// RequestMessage submits msg to the current managed websocket generation and
+// returns only the response matched to that request. Compatibility WsConn
+// values created as struct literals continue to use SendMessage and the public
+// receive channel instead.
+func (c *WsConn) RequestMessage(ctx context.Context, msg string) (string, error) {
+	if c == nil {
+		return "", errConnClosed
+	}
+	ctx = normalizeContext(ctx)
+	if err := contextErr(ctx); err != nil {
+		return "", err
+	}
+	if !c.managed {
+		return "", ErrRequestResponseUnsupported
+	}
+
+	reply := make(chan string, 1)
+	submission := wsSubmission{
+		ctx:   ctx,
+		msg:   msg,
+		ack:   make(chan error, 1),
+		reply: reply,
+	}
+	select {
+	case c.submitCh <- submission:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-c.rootCtx.Done():
+		return "", errConnClosed
+	}
+
+	select {
+	case err := <-submission.ack:
+		if err != nil {
+			return "", err
+		}
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-c.rootCtx.Done():
+		return "", errConnClosed
+	}
+
+	select {
+	case response := <-reply:
+		return response, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
 func (c *WsConn) enqueueManagedWrite(job wsWriteJob) bool {
 	select {
 	case c.managedWriteCh <- job:
@@ -753,15 +834,15 @@ func (c *WsConn) handleWriteResult(state *wsSupervisorState, result wsWriteResul
 			return
 		}
 		if result.err == nil {
-			if pending && !pendingJob.awaitReply {
-				c.finishPendingRequest(state, job.id)
-			}
 			return
 		}
 		if pending {
-			c.finishPendingRequest(state, job.id)
+			pendingJob, _ = c.finishPendingRequest(state, job.id)
 			if contextErr(pendingJob.requestCtx) == nil {
-				c.trySendReceiveMessage(apiServerErrorMessage(pendingJob.requestIP))
+				failure := apiServerErrorMessage(pendingJob.requestIP)
+				if !deliverBoundResponse(pendingJob, failure) {
+					c.trySendReceiveMessage(failure)
+				}
 			}
 		}
 		if state.generation != nil && job.generation == state.generation.id {
@@ -872,8 +953,14 @@ func (c *WsConn) failPendingGeneration(state *wsSupervisorState, generation uint
 			continue
 		}
 		c.finishPendingRequest(state, id)
+		if !job.awaitReply && job.progress != nil && job.progress.succeeded.Load() {
+			continue
+		}
 		if contextErr(job.requestCtx) == nil {
-			c.trySendReceiveMessage(apiServerErrorMessage(job.requestIP))
+			failure := apiServerErrorMessage(job.requestIP)
+			if !deliverBoundResponse(job, failure) {
+				c.trySendReceiveMessage(failure)
+			}
 		}
 	}
 }

--- a/wshandle/supervisor_synctest_test.go
+++ b/wshandle/supervisor_synctest_test.go
@@ -661,6 +661,269 @@ func TestManagedSendMessageDoesNotReplayAcceptedOldGenerationWrite(t *testing.T)
 	})
 }
 
+func TestManagedRequestMessageIgnoresQueuedPreviousGenerationResponse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		firstWire := newSupervisorTestWire()
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		for i := 0; i < cap(conn.MsgReceiveCh); i++ {
+			conn.MsgReceiveCh <- fmt.Sprintf("queued-%d", i)
+		}
+
+		const request = "203.0.113.40"
+		const oldResponse = `{"ip":"203.0.113.40","asnumber":"OLD"}`
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, request)
+		firstWire.reads <- supervisorTestRead{data: oldResponse}
+		synctest.Wait()
+
+		firstWire.reads <- supervisorTestRead{err: errors.New("replace generation")}
+		synctest.Wait()
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+
+		type requestResult struct {
+			response string
+			err      error
+		}
+		done := make(chan requestResult, 1)
+		go func() {
+			response, err := conn.RequestMessage(context.Background(), request)
+			done <- requestResult{response: response, err: err}
+		}()
+		synctest.Wait()
+		requireSupervisorWrite(t, secondWire, websocket.TextMessage, request)
+
+		<-conn.MsgReceiveCh
+		synctest.Wait()
+		sawOldResponse := false
+		for i := 0; i < cap(conn.MsgReceiveCh); i++ {
+			if got := <-conn.MsgReceiveCh; got == oldResponse {
+				sawOldResponse = true
+			}
+		}
+		if !sawOldResponse {
+			t.Fatal("previous-generation response was not released from the public queue")
+		}
+		select {
+		case got := <-done:
+			t.Fatalf("previous-generation response completed current request: %+v", got)
+		default:
+		}
+
+		const currentResponse = `{"ip":"203.0.113.40","asnumber":"CURRENT"}`
+		secondWire.reads <- supervisorTestRead{data: currentResponse}
+		synctest.Wait()
+		got := <-done
+		if got.err != nil || got.response != currentResponse {
+			t.Fatalf("RequestMessage() = (%q, %v), want (%q, nil)", got.response, got.err, currentResponse)
+		}
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedRequestMessageDoesNotConsumeLegacySameIPResponse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.44"
+		conn.MsgSendCh <- request
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+
+		type requestResult struct {
+			response string
+			err      error
+		}
+		done := make(chan requestResult, 1)
+		go func() {
+			response, err := conn.RequestMessage(context.Background(), request)
+			done <- requestResult{response: response, err: err}
+		}()
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+
+		const legacyResponse = `{"ip":"203.0.113.44","asnumber":"LEGACY"}`
+		wire.reads <- supervisorTestRead{data: legacyResponse}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, legacyResponse)
+		select {
+		case got := <-done:
+			t.Fatalf("legacy response completed bound request: %+v", got)
+		default:
+		}
+
+		const boundResponse = `{"ip":"203.0.113.44","asnumber":"BOUND"}`
+		wire.reads <- supervisorTestRead{data: boundResponse}
+		synctest.Wait()
+		got := <-done
+		if got.err != nil || got.response != boundResponse {
+			t.Fatalf("RequestMessage() = (%q, %v), want (%q, nil)", got.response, got.err, boundResponse)
+		}
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedRequestMessageGenerationFailureReturnsBoundAPIError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.41"
+		done := make(chan struct {
+			response string
+			err      error
+		}, 1)
+		go func() {
+			response, err := conn.RequestMessage(context.Background(), request)
+			done <- struct {
+				response string
+				err      error
+			}{response: response, err: err}
+		}()
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+
+		wire.reads <- supervisorTestRead{err: errors.New("request generation failed")}
+		synctest.Wait()
+		got := <-done
+		want := apiServerErrorMessage(request)
+		if got.err != nil || got.response != want {
+			t.Fatalf("RequestMessage() = (%q, %v), want (%q, nil)", got.response, got.err, want)
+		}
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedRequestMessageCancellationRotatesGeneration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		firstWire := newSupervisorTestWire()
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.42"
+		requestCtx, cancelRequest := context.WithCancel(context.Background())
+		firstDone := make(chan error, 1)
+		go func() {
+			_, err := conn.RequestMessage(requestCtx, request)
+			firstDone <- err
+		}()
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, request)
+
+		const peerRequest = "203.0.113.43"
+		peerDone := make(chan struct {
+			response string
+			err      error
+		}, 1)
+		go func() {
+			response, err := conn.RequestMessage(context.Background(), peerRequest)
+			peerDone <- struct {
+				response string
+				err      error
+			}{response: response, err: err}
+		}()
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, peerRequest)
+
+		cancelRequest()
+		synctest.Wait()
+		if err := <-firstDone; !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled RequestMessage() error = %v, want %v", err, context.Canceled)
+		}
+		peerResult := <-peerDone
+		peerFailure := apiServerErrorMessage(peerRequest)
+		if peerResult.err != nil || peerResult.response != peerFailure {
+			t.Fatalf(
+				"peer RequestMessage() = (%q, %v), want (%q, nil)",
+				peerResult.response,
+				peerResult.err,
+				peerFailure,
+			)
+		}
+		requireNoSupervisorReceive(t, conn)
+		if !firstWire.isClosed() || conn.IsConnected() {
+			t.Fatal("canceling a bound request did not retire its generation")
+		}
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+
+		type requestResult struct {
+			response string
+			err      error
+		}
+		secondDone := make(chan requestResult, 1)
+		go func() {
+			response, err := conn.RequestMessage(context.Background(), request)
+			secondDone <- requestResult{response: response, err: err}
+		}()
+		synctest.Wait()
+		requireSupervisorWrite(t, secondWire, websocket.TextMessage, request)
+
+		conn.readEvents <- wsReadEvent{
+			generation: 1,
+			data:       []byte(`{"ip":"203.0.113.42","asnumber":"STALE"}`),
+		}
+		synctest.Wait()
+		select {
+		case got := <-secondDone:
+			t.Fatalf("canceled generation response completed replacement request: %+v", got)
+		default:
+		}
+
+		const currentResponse = `{"ip":"203.0.113.42","asnumber":"CURRENT"}`
+		secondWire.reads <- supervisorTestRead{data: currentResponse}
+		synctest.Wait()
+		got := <-secondDone
+		if got.err != nil || got.response != currentResponse {
+			t.Fatalf("replacement RequestMessage() = (%q, %v), want (%q, nil)", got.response, got.err, currentResponse)
+		}
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
 func TestManagedCloseDeliversAcceptedPendingFailureBeforeClosingReceive(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		dialer := newSupervisorTestDialer()
@@ -748,7 +1011,7 @@ func TestManagedSendMessageWrittenBeforeResponseFailsOnceOnGenerationEnd(t *test
 	})
 }
 
-func TestManagedSendMessageContextCancelClearsPendingSilently(t *testing.T) {
+func TestManagedSendMessageContextCancelRetiresWrittenGenerationSilently(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		dialer := newSupervisorTestDialer()
 		wire := newSupervisorTestWire()
@@ -770,10 +1033,9 @@ func TestManagedSendMessageContextCancelClearsPendingSilently(t *testing.T) {
 		cancelRequest()
 		synctest.Wait()
 		requireNoSupervisorReceive(t, conn)
-
-		wire.reads <- supervisorTestRead{err: errors.New("connection ended after request cancellation")}
-		synctest.Wait()
-		requireNoSupervisorReceive(t, conn)
+		if !wire.isClosed() || conn.IsConnected() {
+			t.Fatal("canceling a written SendMessage did not retire its generation")
+		}
 	})
 }
 
@@ -835,6 +1097,51 @@ func TestManagedLegacyWriteSuccessDoesNotAwaitResponse(t *testing.T) {
 		wire.reads <- supervisorTestRead{err: errors.New("connection ended after legacy write")}
 		synctest.Wait()
 		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestLegacyGenerationCleanupObservesWriterSuccessBeforeWriteResult(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		rootCtx, cancelRoot := context.WithCancel(context.Background())
+		wire := newSupervisorTestWire()
+		conn := &WsConn{
+			MsgReceiveCh:   make(chan string, 1),
+			closeCh:        make(chan struct{}),
+			rootCtx:        rootCtx,
+			managedWriteCh: make(chan wsWriteJob, 1),
+			writeResults:   make(chan wsWriteResult, 1),
+		}
+		conn.workerWG.Add(1)
+		go conn.managedWriteLoop()
+
+		progress := &wsWriteProgress{}
+		job := wsWriteJob{
+			id:         1,
+			generation: 1,
+			wire:       wire,
+			kind:       wsWriteRequest,
+			msgType:    websocket.TextMessage,
+			data:       []byte("203.0.113.45"),
+			requestIP:  "203.0.113.45",
+			progress:   progress,
+		}
+		conn.managedWriteCh <- job
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, job.requestIP)
+		if !progress.succeeded.Load() || len(conn.writeResults) != 1 {
+			t.Fatal("writer success was not published before its queued result")
+		}
+
+		state := wsSupervisorState{pending: map[uint64]wsWriteJob{job.id: job}}
+		conn.failPendingGeneration(&state, job.generation)
+		if len(state.pending) != 0 {
+			t.Fatal("successful legacy marker remained pending after generation cleanup")
+		}
+		requireNoSupervisorReceive(t, conn)
+
+		cancelRoot()
+		synctest.Wait()
+		conn.workerWG.Wait()
 	})
 }
 
@@ -970,6 +1277,26 @@ func TestCompletePendingResponseUsesOldestMatchingRequest(t *testing.T) {
 		if _, ok := state.pending[id]; !ok {
 			t.Fatalf("pending request %d was completed unexpectedly", id)
 		}
+	}
+}
+
+func TestRegisterRequestBoundsPendingMarkers(t *testing.T) {
+	pending := make(map[uint64]wsWriteJob, wsClientWriteQueueSize)
+	for id := uint64(1); id <= wsClientWriteQueueSize; id++ {
+		pending[id] = wsWriteJob{id: id, generation: 1}
+	}
+	state := wsSupervisorState{
+		generation: &wsGeneration{id: 1},
+		pending:    pending,
+	}
+	conn := &WsConn{rootCtx: context.Background()}
+
+	err := conn.registerRequest(&state, "192.0.2.100", nil, false, nil)
+	if !errors.Is(err, errWriteQueueFull) {
+		t.Fatalf("registerRequest() error = %v, want %v", err, errWriteQueueFull)
+	}
+	if got := len(state.pending); got != wsClientWriteQueueSize {
+		t.Fatalf("pending markers = %d, want %d", got, wsClientWriteQueueSize)
 	}
 }
 

--- a/wshandle/supervisor_synctest_test.go
+++ b/wshandle/supervisor_synctest_test.go
@@ -1,0 +1,1111 @@
+package wshandle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var errSupervisorTestWireClosed = errors.New("supervisor test wire closed")
+
+type supervisorTestDialResult struct {
+	wire wsWire
+	err  error
+}
+
+type supervisorTestDialer struct {
+	calls   chan wsDialRequest
+	results chan supervisorTestDialResult
+}
+
+func newSupervisorTestDialer() *supervisorTestDialer {
+	return &supervisorTestDialer{
+		calls:   make(chan wsDialRequest, 16),
+		results: make(chan supervisorTestDialResult, 16),
+	}
+}
+
+func (d *supervisorTestDialer) dial(ctx context.Context, req wsDialRequest) (wsWire, *websocket.Conn, error) {
+	select {
+	case d.calls <- req:
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+
+	select {
+	case result := <-d.results:
+		return result.wire, nil, result.err
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+}
+
+type supervisorTestRead struct {
+	data string
+	err  error
+}
+
+type supervisorTestWrite struct {
+	messageType int
+	data        string
+}
+
+type supervisorTestWire struct {
+	reads      chan supervisorTestRead
+	writes     chan supervisorTestWrite
+	closed     chan struct{}
+	closeOnce  sync.Once
+	writeGate  <-chan struct{}
+	writeError error
+}
+
+func newSupervisorTestWire() *supervisorTestWire {
+	return &supervisorTestWire{
+		reads:  make(chan supervisorTestRead, wsClientReceiveBacklog+128),
+		writes: make(chan supervisorTestWrite, 32),
+		closed: make(chan struct{}),
+	}
+}
+
+func (w *supervisorTestWire) ReadMessage() (int, []byte, error) {
+	select {
+	case <-w.closed:
+		return 0, nil, errSupervisorTestWireClosed
+	default:
+	}
+
+	select {
+	case event := <-w.reads:
+		return websocket.TextMessage, []byte(event.data), event.err
+	case <-w.closed:
+		return 0, nil, errSupervisorTestWireClosed
+	}
+}
+
+func (w *supervisorTestWire) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (w *supervisorTestWire) WriteMessage(messageType int, data []byte) error {
+	write := supervisorTestWrite{messageType: messageType, data: string(append([]byte(nil), data...))}
+	select {
+	case w.writes <- write:
+	case <-w.closed:
+		return errSupervisorTestWireClosed
+	}
+
+	if w.writeGate != nil {
+		select {
+		case <-w.writeGate:
+		case <-w.closed:
+			return errSupervisorTestWireClosed
+		}
+	}
+	return w.writeError
+}
+
+func (w *supervisorTestWire) Close() error {
+	w.closeOnce.Do(func() {
+		close(w.closed)
+	})
+	return nil
+}
+
+func (w *supervisorTestWire) isClosed() bool {
+	select {
+	case <-w.closed:
+		return true
+	default:
+		return false
+	}
+}
+
+func installSupervisorTestDialer(dialer *supervisorTestDialer) func() {
+	oldDialFn := wsDialFn
+	oldEnvToken := envToken
+	wsDialFn = dialer.dial
+	envToken = "supervisor-test-token"
+	return func() {
+		wsDialFn = oldDialFn
+		envToken = oldEnvToken
+	}
+}
+
+func newSupervisorTestConn(ctx context.Context) *WsConn {
+	return newManagedWsConn(ctx, make(chan os.Signal, 1), wsEndpoint{
+		host:   "api.nxtrace.org",
+		port:   "443",
+		fastIP: "192.0.2.1",
+		direct: true,
+	})
+}
+
+func supervisorDialCallCount(dialer *supervisorTestDialer) int {
+	count := 0
+	for {
+		select {
+		case <-dialer.calls:
+			count++
+		default:
+			return count
+		}
+	}
+}
+
+func requireSupervisorWrite(t *testing.T, wire *supervisorTestWire, wantType int, wantData string) {
+	t.Helper()
+	select {
+	case got := <-wire.writes:
+		if got.messageType != wantType || got.data != wantData {
+			t.Fatalf("write = (%d, %q), want (%d, %q)", got.messageType, got.data, wantType, wantData)
+		}
+	default:
+		t.Fatalf("missing write (%d, %q)", wantType, wantData)
+	}
+}
+
+func requireNoSupervisorWrite(t *testing.T, wire *supervisorTestWire) {
+	t.Helper()
+	select {
+	case got := <-wire.writes:
+		t.Fatalf("unexpected write = (%d, %q)", got.messageType, got.data)
+	default:
+	}
+}
+
+func requireSupervisorReceive(t *testing.T, conn *WsConn, want string) {
+	t.Helper()
+	select {
+	case got := <-conn.MsgReceiveCh:
+		if got != want {
+			t.Fatalf("receive = %q, want %q", got, want)
+		}
+	default:
+		t.Fatalf("missing receive message %q", want)
+	}
+}
+
+func requireNoSupervisorReceive(t *testing.T, conn *WsConn) {
+	t.Helper()
+	select {
+	case got := <-conn.MsgReceiveCh:
+		t.Fatalf("unexpected receive message %q", got)
+	default:
+	}
+}
+
+func TestManagedSupervisorRetriesDialWithVirtualTime(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{err: errors.New("dial failed")}
+		dialer.results <- supervisorTestDialResult{err: errors.New("retry dial failed")}
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("initial dial calls = %d, want 1", got)
+		}
+		if conn.IsConnected() || conn.IsConnecting() {
+			t.Fatal("failed dial should enter retry wait")
+		}
+
+		time.Sleep(wsClientReconnectDelay - time.Nanosecond)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 0 {
+			t.Fatalf("early initial retry calls = %d, want 0", got)
+		}
+
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("initial retry dial calls = %d, want 1", got)
+		}
+		if conn.IsConnected() || conn.IsConnecting() {
+			t.Fatal("failed reconnect should enter retry wait")
+		}
+
+		time.Sleep(wsClientDialRetryDelay - time.Nanosecond)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 0 {
+			t.Fatalf("early subsequent retry calls = %d, want 0", got)
+		}
+
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("subsequent retry dial calls = %d, want 1", got)
+		}
+		if !conn.IsConnected() {
+			t.Fatal("successful retry should publish connected state")
+		}
+	})
+}
+
+func TestSyncFirstCredentialFailureReusesPreservedCacheOnRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		oldDialFn := wsDialFn
+		oldTokenFn := wsGetTokenFn
+		oldEnvToken := envToken
+		oldCacheToken := loadCachedToken()
+		defer func() {
+			wsDialFn = oldDialFn
+			wsGetTokenFn = oldTokenFn
+			envToken = oldEnvToken
+			storeCachedToken(oldCacheToken)
+		}()
+
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		wsDialFn = dialer.dial
+		envToken = ""
+		storeCachedToken("preserved-token")
+		var tokenCalls atomic.Int32
+		wsGetTokenFn = func(context.Context, string, string, string) (string, error) {
+			tokenCalls.Add(1)
+			return "", errors.New("fresh token failed")
+		}
+
+		conn := newManagedWsConnWithPolicy(
+			context.Background(),
+			make(chan os.Signal, 1),
+			wsEndpoint{host: "api.nxtrace.org", port: "443", fastIP: "192.0.2.1", direct: true},
+			true,
+		)
+		defer conn.Close()
+		synctest.Wait()
+		if got := tokenCalls.Load(); got != 1 {
+			t.Fatalf("fresh token calls = %d, want 1", got)
+		}
+		if got := loadCachedToken(); got != "preserved-token" {
+			t.Fatalf("cached token = %q, want preserved token", got)
+		}
+		if got := supervisorDialCallCount(dialer); got != 0 {
+			t.Fatalf("dial calls before credential retry = %d, want 0", got)
+		}
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := tokenCalls.Load(); got != 1 {
+			t.Fatalf("token calls after retry = %d, want cached reuse", got)
+		}
+		select {
+		case req := <-dialer.calls:
+			if got := req.Header.Get("Authorization"); got != "Bearer preserved-token" {
+				t.Fatalf("retry Authorization = %q", got)
+			}
+		default:
+			t.Fatal("credential retry did not dial")
+		}
+		if !conn.IsConnected() {
+			t.Fatal("credential retry did not install generation")
+		}
+	})
+}
+
+func TestManagedSupervisorParentCancelStopsRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		dialer.results <- supervisorTestDialResult{err: errors.New("dial failed")}
+		defer installSupervisorTestDialer(dialer)()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		conn := newSupervisorTestConn(ctx)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("initial dial calls = %d, want 1", got)
+		}
+
+		cancel()
+		synctest.Wait()
+		time.Sleep(10 * wsClientDialRetryDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 0 {
+			t.Fatalf("dial calls after parent cancel = %d, want 0", got)
+		}
+		select {
+		case <-conn.supervisorDone:
+		default:
+			t.Fatal("supervisor did not stop after parent cancel")
+		}
+		if conn.IsConnected() || conn.IsConnecting() {
+			t.Fatal("canceled supervisor retained a live connection state")
+		}
+		conn.Close()
+		conn.Close()
+	})
+}
+
+func TestManagedSupervisorStateChangeWakesWaiterImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("initial dial calls = %d, want 1", got)
+		}
+
+		waitResult := make(chan error, 1)
+		startedAt := time.Now()
+		go func() {
+			waitResult <- conn.WaitUntilConnected(context.Background())
+		}()
+		synctest.Wait()
+
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		synctest.Wait()
+		select {
+		case err := <-waitResult:
+			if err != nil {
+				t.Fatalf("WaitUntilConnected() error = %v", err)
+			}
+		default:
+			t.Fatal("state change did not wake WaitUntilConnected")
+		}
+		if elapsed := time.Since(startedAt); elapsed != 0 {
+			t.Fatalf("state notification required polling time: %v", elapsed)
+		}
+	})
+}
+
+func TestManagedSupervisorHeartbeatRequiresTwoFullMissingPongWindows(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		firstWire := newSupervisorTestWire()
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("initial dial calls = %d, want 1", got)
+		}
+
+		time.Sleep(wsClientPingInterval - time.Nanosecond)
+		synctest.Wait()
+		requireNoSupervisorWrite(t, firstWire)
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, "ping")
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, "ping")
+		if !conn.IsConnected() {
+			t.Fatal("connection ended after only one complete missing-pong window")
+		}
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		if !firstWire.isClosed() || conn.IsConnected() {
+			t.Fatal("connection did not end after two complete missing-pong windows")
+		}
+		if got := supervisorDialCallCount(dialer); got != 0 {
+			t.Fatalf("reconnect started before retry delay: %d calls", got)
+		}
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+		if !conn.IsConnected() || secondWire.isClosed() {
+			t.Fatal("replacement generation was not installed")
+		}
+	})
+}
+
+func TestManagedSupervisorLiteralCurrentPongResetsHeartbeat(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, "ping")
+		wire.reads <- supervisorTestRead{data: "pong"}
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, "ping")
+		wire.reads <- supervisorTestRead{data: "pong\n"}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, "pong\n")
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, "ping")
+		if !conn.IsConnected() {
+			t.Fatal("literal pong did not reset the missed-window count")
+		}
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		if !wire.isClosed() || conn.IsConnected() {
+			t.Fatal("non-literal pong unexpectedly reset the missed-window count")
+		}
+	})
+}
+
+func TestManagedSupervisorReadFailureReconnectsAndIgnoresStaleEvents(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		firstWire := newSupervisorTestWire()
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+		firstDone := conn.getDoneChan()
+
+		firstWire.reads <- supervisorTestRead{err: errors.New("read failed")}
+		synctest.Wait()
+		if !firstWire.isClosed() || conn.IsConnected() {
+			t.Fatal("read failure did not end the active generation")
+		}
+		select {
+		case <-firstDone:
+		default:
+			t.Fatal("read failure did not close generation Done")
+		}
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+		if !conn.IsConnected() {
+			t.Fatal("read failure did not install a replacement generation")
+		}
+		secondDone := conn.getDoneChan()
+		if secondDone == firstDone {
+			t.Fatal("replacement generation reused the closed Done channel")
+		}
+
+		conn.readEvents <- wsReadEvent{generation: 1, data: []byte("stale")}
+		conn.readEvents <- wsReadEvent{generation: 1, err: errors.New("stale read failure")}
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+		if !conn.IsConnected() {
+			t.Fatal("stale generation event ended the current generation")
+		}
+
+		time.Sleep(wsClientPingInterval)
+		synctest.Wait()
+		requireSupervisorWrite(t, secondWire, websocket.TextMessage, "ping")
+		conn.readEvents <- wsReadEvent{generation: 1, data: []byte("pong")}
+		synctest.Wait()
+
+		time.Sleep(2 * wsClientPingInterval)
+		synctest.Wait()
+		if !secondWire.isClosed() || conn.IsConnected() {
+			t.Fatal("stale generation pong reset the current heartbeat")
+		}
+	})
+}
+
+func TestManagedSupervisorWriteFailureReportsOnce(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		wire.writeError = errors.New("write failed")
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "198.51.100.10"
+		conn.MsgSendCh <- request
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+		requireSupervisorReceive(t, conn, apiServerErrorMessage(request))
+		requireNoSupervisorReceive(t, conn)
+		if !wire.isClosed() || conn.IsConnected() {
+			t.Fatal("write failure did not end the active generation")
+		}
+	})
+}
+
+func TestManagedSupervisorDoesNotReplayOldGenerationWrite(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		firstWire := newSupervisorTestWire()
+		firstWire.writeGate = writeGate
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.20"
+		conn.MsgSendCh <- request
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, request)
+
+		firstWire.reads <- supervisorTestRead{err: errors.New("generation ended")}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, apiServerErrorMessage(request))
+		requireNoSupervisorReceive(t, conn)
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+		if !conn.IsConnected() {
+			t.Fatal("replacement generation was not installed")
+		}
+		requireNoSupervisorWrite(t, secondWire)
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedSendMessageRejectsAfterClose(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+		conn.Close()
+
+		if err := conn.SendMessage(context.Background(), "192.0.2.10"); !errors.Is(err, errConnClosed) {
+			t.Fatalf("SendMessage() error = %v, want %v", err, errConnClosed)
+		}
+		requireNoSupervisorWrite(t, wire)
+	})
+}
+
+func TestManagedSendMessageDoesNotReplayAcceptedOldGenerationWrite(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		firstWire := newSupervisorTestWire()
+		firstWire.writeGate = writeGate
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.21"
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, request)
+
+		firstWire.reads <- supervisorTestRead{err: errors.New("generation ended")}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, apiServerErrorMessage(request))
+		requireNoSupervisorReceive(t, conn)
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+		if !conn.IsConnected() {
+			t.Fatal("replacement generation was not installed")
+		}
+		requireNoSupervisorWrite(t, secondWire)
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedCloseDeliversAcceptedPendingFailureBeforeClosingReceive(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		wire := newSupervisorTestWire()
+		wire.writeGate = writeGate
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.22"
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+
+		conn.Close()
+		got, ok := <-conn.MsgReceiveCh
+		if !ok || got != apiServerErrorMessage(request) {
+			t.Fatalf("pending failure = (%q, %v), want (%q, true)", got, ok, apiServerErrorMessage(request))
+		}
+		if _, ok := <-conn.MsgReceiveCh; ok {
+			t.Fatal("MsgReceiveCh remained open after pending failure was delivered")
+		}
+	})
+}
+
+func TestManagedSupervisorResponseSettlesPendingBeforeGenerationEnd(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		wire := newSupervisorTestWire()
+		wire.writeGate = writeGate
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.24"
+		const response = `{"ip":"203.0.113.24","asnumber":"64500"}`
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+
+		wire.reads <- supervisorTestRead{data: response}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, response)
+		wire.reads <- supervisorTestRead{err: errors.New("connection ended after response")}
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedSendMessageWrittenBeforeResponseFailsOnceOnGenerationEnd(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.28"
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+		wire.reads <- supervisorTestRead{err: errors.New("connection ended before response")}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, apiServerErrorMessage(request))
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedSendMessageContextCancelClearsPendingSilently(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		requestCtx, cancelRequest := context.WithCancel(context.Background())
+		const request = "203.0.113.29"
+		if err := conn.SendMessage(requestCtx, request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+		cancelRequest()
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+
+		wire.reads <- supervisorTestRead{err: errors.New("connection ended after request cancellation")}
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedWriterSkipsQueuedCanceledSendMessage(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		wire := newSupervisorTestWire()
+		wire.writeGate = writeGate
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const firstRequest = "203.0.113.35"
+		if err := conn.SendMessage(context.Background(), firstRequest); err != nil {
+			t.Fatalf("first SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, firstRequest)
+
+		requestCtx, cancelRequest := context.WithCancel(context.Background())
+		const canceledRequest = "203.0.113.36"
+		if err := conn.SendMessage(requestCtx, canceledRequest); err != nil {
+			t.Fatalf("second SendMessage() error = %v", err)
+		}
+		cancelRequest()
+		synctest.Wait()
+		close(writeGate)
+		synctest.Wait()
+
+		requireNoSupervisorWrite(t, wire)
+		requireNoSupervisorReceive(t, conn)
+		if !conn.IsConnected() || wire.isClosed() {
+			t.Fatal("skipping canceled queued request changed connection health")
+		}
+	})
+}
+
+func TestManagedLegacyWriteSuccessDoesNotAwaitResponse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.30"
+		conn.MsgSendCh <- request
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+		wire.reads <- supervisorTestRead{err: errors.New("connection ended after legacy write")}
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedCloseStopsAwaitResponseWatchers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		for _, request := range []string{"203.0.113.31", "203.0.113.32", "203.0.113.33", "203.0.113.34"} {
+			if err := conn.SendMessage(context.Background(), request); err != nil {
+				t.Fatalf("SendMessage(%q) error = %v", request, err)
+			}
+		}
+		synctest.Wait()
+
+		closed := make(chan struct{})
+		go func() {
+			conn.Close()
+			close(closed)
+		}()
+		synctest.Wait()
+		select {
+		case <-closed:
+		default:
+			t.Fatal("Close blocked with await-response context watchers")
+		}
+	})
+}
+
+func TestManagedSupervisorResponseReadFailureThenWriteSuccessDoesNotFailRequest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		wire := newSupervisorTestWire()
+		wire.writeGate = writeGate
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.25"
+		const response = `{"ip":"203.0.113.25","asnumber":"64501"}`
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
+
+		wire.reads <- supervisorTestRead{data: response}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, response)
+		wire.reads <- supervisorTestRead{err: errors.New("read failed after response")}
+		synctest.Wait()
+		conn.writeResults <- wsWriteResult{job: wsWriteJob{
+			id:         1,
+			generation: 1,
+			kind:       wsWriteRequest,
+			requestIP:  request,
+		}}
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+	})
+}
+
+func TestManagedSupervisorResponseThenWriteFailureReconnectsWithoutDuplicateError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		writeGate := make(chan struct{})
+		firstWire := newSupervisorTestWire()
+		firstWire.writeGate = writeGate
+		firstWire.writeError = errors.New("write failed after response")
+		secondWire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: firstWire}
+		dialer.results <- supervisorTestDialResult{wire: secondWire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		defer conn.Close()
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const request = "203.0.113.27"
+		const response = `{"ip":"203.0.113.27","asnumber":"64502"}`
+		if err := conn.SendMessage(context.Background(), request); err != nil {
+			t.Fatalf("SendMessage() error = %v", err)
+		}
+		synctest.Wait()
+		requireSupervisorWrite(t, firstWire, websocket.TextMessage, request)
+
+		firstWire.reads <- supervisorTestRead{data: response}
+		synctest.Wait()
+		requireSupervisorReceive(t, conn, response)
+		close(writeGate)
+		synctest.Wait()
+		requireNoSupervisorReceive(t, conn)
+		if !firstWire.isClosed() || conn.IsConnected() {
+			t.Fatal("write failure after response did not end the active generation")
+		}
+
+		time.Sleep(wsClientReconnectDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("reconnect dial calls = %d, want 1", got)
+		}
+		if !conn.IsConnected() || secondWire.isClosed() {
+			t.Fatal("write failure after response did not install a replacement generation")
+		}
+	})
+}
+
+func TestCompletePendingResponseUsesOldestMatchingRequest(t *testing.T) {
+	state := wsSupervisorState{pending: map[uint64]wsWriteJob{
+		2: {id: 2, generation: 1, requestIP: "192.0.2.1"},
+		3: {id: 3, generation: 1, requestIP: "192.0.2.2"},
+		4: {id: 4, generation: 1, requestIP: "192.0.2.1"},
+		5: {id: 5, generation: 2, requestIP: "192.0.2.1"},
+	}}
+
+	(&WsConn{}).completePendingResponse(&state, 1, []byte(`{"ip":"192.0.2.1"}`))
+	if _, ok := state.pending[2]; ok {
+		t.Fatal("oldest matching pending request was not completed")
+	}
+	for _, id := range []uint64{3, 4, 5} {
+		if _, ok := state.pending[id]; !ok {
+			t.Fatalf("pending request %d was completed unexpectedly", id)
+		}
+	}
+}
+
+func TestManagedSupervisorCloseWinsReconnectRace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		dialer.results <- supervisorTestDialResult{err: errors.New("dial failed")}
+		defer installSupervisorTestDialer(dialer)()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		conn := newSupervisorTestConn(ctx)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("initial dial calls = %d, want 1", got)
+		}
+
+		time.Sleep(wsClientDialRetryDelay)
+		synctest.Wait()
+		if got := supervisorDialCallCount(dialer); got != 1 {
+			t.Fatalf("blocked retry dial calls = %d, want 1", got)
+		}
+
+		closed := make(chan struct{}, 2)
+		go func() {
+			conn.Close()
+			closed <- struct{}{}
+		}()
+		go func() {
+			conn.Close()
+			closed <- struct{}{}
+		}()
+		cancel()
+		synctest.Wait()
+		if len(closed) != 2 {
+			t.Fatalf("completed Close calls = %d, want 2", len(closed))
+		}
+		if conn.IsConnected() || conn.IsConnecting() {
+			t.Fatal("shutdown/reconnect race retained a live state")
+		}
+		select {
+		case <-conn.supervisorDone:
+		default:
+			t.Fatal("supervisor did not finish during shutdown/reconnect race")
+		}
+		conn.Close()
+	})
+}
+
+func TestManagedSupervisorSlowConsumerDoesNotBlockShutdown(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		for i := 0; i < wsClientReceiveBacklog+64; i++ {
+			wire.reads <- supervisorTestRead{data: "queued"}
+		}
+		synctest.Wait()
+
+		closed := make(chan struct{}, 1)
+		go func() {
+			conn.Close()
+			closed <- struct{}{}
+		}()
+		synctest.Wait()
+		select {
+		case <-closed:
+		default:
+			t.Fatal("slow receive consumer blocked shutdown")
+		}
+		if !wire.isClosed() {
+			t.Fatal("shutdown did not close the active wire")
+		}
+		select {
+		case <-conn.supervisorDone:
+		default:
+			t.Fatal("supervisor did not finish with a slow consumer")
+		}
+		conn.Close()
+	})
+}
+
+func TestManagedSupervisorBackpressuresWithoutDroppingResponses(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dialer := newSupervisorTestDialer()
+		wire := newSupervisorTestWire()
+		dialer.results <- supervisorTestDialResult{wire: wire}
+		defer installSupervisorTestDialer(dialer)()
+
+		conn := newSupervisorTestConn(context.Background())
+		synctest.Wait()
+		_ = supervisorDialCallCount(dialer)
+
+		const extra = 64
+		const total = wsClientReceiveBacklog + extra
+		for i := range total {
+			wire.reads <- supervisorTestRead{data: fmt.Sprintf("response-%04d", i)}
+		}
+		synctest.Wait()
+
+		received := make([]string, 0, total)
+		drained := make(chan struct{})
+		go func() {
+			for range total {
+				received = append(received, <-conn.MsgReceiveCh)
+			}
+			close(drained)
+		}()
+		synctest.Wait()
+		select {
+		case <-drained:
+		default:
+			t.Fatal("backpressured responses did not drain")
+		}
+		for i, got := range received {
+			want := fmt.Sprintf("response-%04d", i)
+			if got != want {
+				t.Fatalf("response %d = %q, want %q", i, got, want)
+			}
+		}
+
+		closed := make(chan struct{})
+		go func() {
+			conn.Close()
+			close(closed)
+		}()
+		synctest.Wait()
+		select {
+		case <-closed:
+		default:
+			t.Fatal("shutdown blocked after receive backpressure recovered")
+		}
+	})
+}

--- a/wshandle/supervisor_synctest_test.go
+++ b/wshandle/supervisor_synctest_test.go
@@ -58,6 +58,11 @@ type supervisorTestWrite struct {
 	data        string
 }
 
+type supervisorTestRequestResult struct {
+	response string
+	err      error
+}
+
 type supervisorTestWire struct {
 	reads      chan supervisorTestRead
 	writes     chan supervisorTestWrite
@@ -697,14 +702,10 @@ func TestManagedRequestMessageIgnoresQueuedPreviousGenerationResponse(t *testing
 			t.Fatalf("reconnect dial calls = %d, want 1", got)
 		}
 
-		type requestResult struct {
-			response string
-			err      error
-		}
-		done := make(chan requestResult, 1)
+		done := make(chan supervisorTestRequestResult, 1)
 		go func() {
 			response, err := conn.RequestMessage(context.Background(), request)
-			done <- requestResult{response: response, err: err}
+			done <- supervisorTestRequestResult{response: response, err: err}
 		}()
 		synctest.Wait()
 		requireSupervisorWrite(t, secondWire, websocket.TextMessage, request)
@@ -754,14 +755,10 @@ func TestManagedRequestMessageDoesNotConsumeLegacySameIPResponse(t *testing.T) {
 		synctest.Wait()
 		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
 
-		type requestResult struct {
-			response string
-			err      error
-		}
-		done := make(chan requestResult, 1)
+		done := make(chan supervisorTestRequestResult, 1)
 		go func() {
 			response, err := conn.RequestMessage(context.Background(), request)
-			done <- requestResult{response: response, err: err}
+			done <- supervisorTestRequestResult{response: response, err: err}
 		}()
 		synctest.Wait()
 		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
@@ -800,16 +797,10 @@ func TestManagedRequestMessageGenerationFailureReturnsBoundAPIError(t *testing.T
 		_ = supervisorDialCallCount(dialer)
 
 		const request = "203.0.113.41"
-		done := make(chan struct {
-			response string
-			err      error
-		}, 1)
+		done := make(chan supervisorTestRequestResult, 1)
 		go func() {
 			response, err := conn.RequestMessage(context.Background(), request)
-			done <- struct {
-				response string
-				err      error
-			}{response: response, err: err}
+			done <- supervisorTestRequestResult{response: response, err: err}
 		}()
 		synctest.Wait()
 		requireSupervisorWrite(t, wire, websocket.TextMessage, request)
@@ -850,16 +841,10 @@ func TestManagedRequestMessageCancellationRotatesGeneration(t *testing.T) {
 		requireSupervisorWrite(t, firstWire, websocket.TextMessage, request)
 
 		const peerRequest = "203.0.113.43"
-		peerDone := make(chan struct {
-			response string
-			err      error
-		}, 1)
+		peerDone := make(chan supervisorTestRequestResult, 1)
 		go func() {
 			response, err := conn.RequestMessage(context.Background(), peerRequest)
-			peerDone <- struct {
-				response string
-				err      error
-			}{response: response, err: err}
+			peerDone <- supervisorTestRequestResult{response: response, err: err}
 		}()
 		synctest.Wait()
 		requireSupervisorWrite(t, firstWire, websocket.TextMessage, peerRequest)
@@ -890,14 +875,10 @@ func TestManagedRequestMessageCancellationRotatesGeneration(t *testing.T) {
 			t.Fatalf("reconnect dial calls = %d, want 1", got)
 		}
 
-		type requestResult struct {
-			response string
-			err      error
-		}
-		secondDone := make(chan requestResult, 1)
+		secondDone := make(chan supervisorTestRequestResult, 1)
 		go func() {
 			response, err := conn.RequestMessage(context.Background(), request)
-			secondDone <- requestResult{response: response, err: err}
+			secondDone <- supervisorTestRequestResult{response: response, err: err}
 		}()
 		synctest.Wait()
 		requireSupervisorWrite(t, secondWire, websocket.TextMessage, request)


### PR DESCRIPTION
### 问题

现有出站 WebSocket 连接由连接、发送、接收和心跳 goroutine 共同修改状态，并通过 20/50 ms polling 观察重连。write job 没有 generation 归属，断线与替换交错时存在旧消息重放、响应错配和重复关闭风险；NextTrace API v3 的 generationless receiver/IP pool 还可能把旧连接的同 IP 响应交给新请求。

### 前后调用链

- 调整前：`New -> createWsConn -> messageSendHandler / messageReceiveHandler / wsPingHandler`，多个 goroutine 共同收尾与重连；v3 响应经公开 channel 和 IP-only pool 关联请求。
- 调整后：`New -> supervisor -> dial generation -> reader/writer events -> supervisor`，唯一 supervisor 串行拥有 generation、连接替换、重试、心跳、状态通知和 `Done` 关闭。
- v3 查询：选择同一个 `WsConn` -> 等待连接 -> 确保兼容 stream 的唯一 receiver -> `RequestMessage(ctx, ip)` -> supervisor 按 generation、IP 和最早 pending request 直接交付响应。

### 兼容性

- 保留导出的 `Conn`、`Done`、`MsgSendCh`、`MsgReceiveCh`、`ConnMux` 以及旧结构体字面量/legacy channel 路径；`RequestMessage` 和 unsupported sentinel 为增量接口。
- 保持 54 秒文本 ping；只有当前 generation 的字面量 `pong` 生效，连续两个完整响应窗口缺失 pong 后重连。
- 旧 generation 消息不重放；未完成请求按既有 `API Server Error` JSON 路径失败一次。
- legacy `MsgSendCh` 使用有界 FIFO marker，避免其同 IP 响应命中后续 bound request；pending 总量上限 1024。
- v3 wire 没有 request ID。已开始 wire write 的 tracked request 取消时轮换 generation，其他 pending request 各收到一次既有 API error；未开始写的取消仍静默跳过。
- JSON schema、协议消息、Geo 字段、CLI 和三 flavor 依赖边界不变。64 KiB 首帧限制留给 PR-6B。

### 测试

- exact head `ac848e32136bea5fc0a00b72b2be3f590ddc883c`：default JSON 与 `nojsonv2` 全仓测试通过。
- `synctest` 覆盖 retry、两个 heartbeat 窗口、parent cancel、generation 唤醒、读写失败、慢消费者和 shutdown/reconnect race。
- reviewer 回归覆盖：同一连接跨 generation 的同 IP 响应、旧/新全局连接 handoff、legacy/bound 同 IP 混用、取消后的代际轮换、API error 单次投递、writer-success/read-error 逆序和 1024 pending 上限。
- reviewer 测试维护性 finding：统一复用 `supervisorTestRequestResult`，不改变测试语义或生产代码。
- 新增交错测试常规 200 次、race 50 次通过；wshandle/ipgeo 定向重复与 race 通过。
- Web 前端 15/15；tiny/ntr 测试与构建、module verify/tidy diff 通过。

### Race

- exact head `go test -race -count=1 ./...` 通过。
- request cancel callback 与 writer 均纳入统一 worker join；共享 write progress 使用 typed atomic，未复制已使用的 atomic。

### Benchstat

Apple M5、Go 1.27.1、`GOEXPERIMENT=nojsonv2`、`GOMAXPROCS=10`，parent/head 各 10 次、每次 1 秒：

- WebSocket JSON marshal：479.1 ns -> 465.9 ns，-2.73%，416 B/2 alloc 不变。
- WebSocket JSON unmarshal：2.418 us -> 2.353 us，-2.69%，656 B/15 alloc 不变。
- 全套未改包存在双向约 1%–6% 主机时序波动；稳定分配合同不变，不归因于本 PR。

### Profile

现有 30 秒 MTR Snapshot profile 只作全局交叉回归：parent/head 均为 49,152 B、257 alloc；heap alloc-space 集中于 `trace.cloneMTRStats`，CPU top 均为 Darwin runtime 调度、GC 和系统等待。本仓库 harness 尚无 lifecycle profile，因此不把该结果表述为 supervisor 热点分析。

### 产物大小

Go 1.27.1 `nojsonv2` Darwin arm64 release-style 未压缩产物：

- full：30,523,650 -> 30,110,162 B（-1.3546%）
- tiny：11,446,770 -> 11,050,018 B（-3.4661%）
- ntr：11,446,770 -> 11,050,018 B（-3.4661%）

### 平台与门禁

- exact head 本地 `go build ./...`、`go vet ./...`、golangci-lint v2.13.2（0 个新增问题）通过。
- default/nojsonv2 全仓测试、full/tiny/ntr 本地构建与专项测试通过；GitHub exact-head 全平台矩阵与 Linux 性能交叉参考均通过。
- CodeRabbit 已覆盖 exact head `ac848e32136bea5fc0a00b72b2be3f590ddc883c`，最新增量审查无 actionable finding；全部 review thread 已解决。
- 前一 source head 的 Linux amd64、Windows amd64、Darwin amd64/arm64 三 flavor 与 Linux UPX 校验通过。
- 6 个 Darwin slice 均恰好一个 `LC_BUILD_VERSION minos 13.0`；三个 universal 产物均包含 x86_64 与 arm64，且每个 slice 保持 minos 13.0。

主要风险集中在 generation 边界、慢消费者 backpressure、关闭期间 callback 交错，以及取消已写请求会使同 generation 的其他 pending request 失败一次；上述 synctest、压力和 race 已覆盖。

### 回退方案

逆序撤销本 PR 的生命周期实现、合同测试和证据提交即可。没有配置、JSON、协议或持久数据迁移；增量 API 没有替换既有导出签名。

### Commit 列表

- `313a14f refactor(wshandle): 统一 WebSocket 连接生命周期`
- `e721341 test(wshandle): 锁定重连心跳与代际隔离`
- `11e896d docs(wshandle): 更新生命周期与性能证据`
- `25e8f96 fix(ipgeo): 避免 v3 receiver 长期占用连接锁`
- `34292b2 fix(wshandle): 隔离 WebSocket 请求代际响应`
- `ac848e3 test(wshandle): 复用 supervisor 请求结果类型`

详细证据见 `docs/performance/go127-wshandle-lifecycle.md`。
