### PR TITLE
refactor(server): 统一 deploy WebSocket 会话生命周期

### DIFF
--- a/docs/performance/go127-deploy-ws-session.md
+++ b/docs/performance/go127-deploy-ws-session.md
@@ -23,7 +23,7 @@ JSON schema、消息顺序、CLI、REST、MCP、三 flavor 依赖边界和导出
 | 项目 | 值 |
 | --- | --- |
 | parent | `acfffd84e74c1745b4e10a284979c1facc194439` |
-| benchmark/profile source head | `c098446193b2671f5d625af27d6455fb6c5ee781` |
+| benchmark/profile source head | `9ba52ea12dbf3172c9ee13f40f52fe6476ac89ed` |
 | 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
 | 系统 | macOS 26.6.2，darwin/arm64 |
 | 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
@@ -62,15 +62,15 @@ session 使用 `open -> draining/aborting -> closed` 状态机：
 ## Benchmark
 
 parent/source head 先使用完整 Go 1.27.1 `nojsonv2` harness 各顺序运行 10 次。该轮 WS JSON
-marshal 显示 `+2.66%`，但本 PR 没有修改 benchmark 或 JSON 编解码路径，且同轮未修改模块也
+marshal 显示 `+2.55%`，但本 PR 没有修改 benchmark 或 JSON 编解码路径，且同轮未修改模块也
 存在双向漂移。按门槛规则，随后预编译两侧 server test binary，并交替顺序采样 20 次，避免
 整套长跑的温度和执行顺序偏差。以下以校准结果作为 WS 判定依据：
 
 | Benchmark | parent | source head | benchstat | B/op | allocs/op |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| WebSocket JSON marshal | 473.5 ns | 470.1 ns | 不显著，`p=0.304` | 416 -> 416 | 2 -> 2 |
-| WebSocket JSON unmarshal | 2.336 us | 2.358 us | 不显著，`p=0.560` | 656 -> 656 | 15 -> 15 |
-| geomean | 1.052 us | 1.053 us | +0.10% | 522.4 -> 522.4 | 5.477 -> 5.477 |
+| WebSocket JSON marshal | 472.9 ns | 471.6 ns | 不显著，`p=0.743` | 416 -> 416 | 2 -> 2 |
+| WebSocket JSON unmarshal | 2.357 us | 2.369 us | 不显著，`p=0.606` | 656 -> 656 | 15 -> 15 |
+| geomean | 1.056 us | 1.057 us | +0.11% | 522.4 -> 522.4 | 5.477 -> 5.477 |
 
 现有 benchmark harness 没有对网络连接生命周期做微基准。该路径以确定性交错、worker join 和
 race 证明正确性；WS JSON 只用于确认完整 server 构建没有编解码或分配回退，不归因于本轮
@@ -79,12 +79,12 @@ race 证明正确性；WS JSON 只用于确认完整 server 构建没有编解�
 ## Profile
 
 parent/source head 对相同 `BenchmarkWebSocketJSONMarshalEnvelope` 各采集 30 秒 CPU 与 heap
-profile。单次读数为 460.0 ns/op 和 469.6 ns/op，不用于门槛判断；20 次交替 benchstat 才是
+profile。单次读数为 460.0 ns/op 和 473.8 ns/op，不用于门槛判断；20 次交替 benchstat 才是
 统计结论。
 
 两侧 CPU top 都由 Darwin runtime wait 与 `encoding/json` 主导；该 profile 不执行会话
 生命周期，不能用来判断 session、reader、writer 或终止状态机热点，只作为 JSON 路径的
-交叉回归证据。heap alloc-space 构成一致：约 84.6% 来自 `encoding/json.Marshal`，其余来自
+交叉回归证据。heap alloc-space 构成一致：约 84.8% 来自 `encoding/json.Marshal`，其余来自
 benchmark 调用；每次操作仍为 416 B、2 allocs。
 
 ## 产物大小与测试耗时
@@ -102,8 +102,8 @@ Go 1.27.1、`nojsonv2`，Darwin 不执行 UPX。
 
 | 指标 | parent | source head |
 | --- | ---: | ---: |
-| 墙钟 | 23.46 s | 22.88 s |
-| maximum resident set size | 448,102,400 B | 446,382,080 B |
+| 墙钟 | 23.46 s | 25.76 s |
+| maximum resident set size | 448,102,400 B | 434,044,928 B |
 
 测试耗时和 RSS 只记录完成成本，不解释为性能改善。
 

--- a/docs/performance/go127-deploy-ws-session.md
+++ b/docs/performance/go127-deploy-ws-session.md
@@ -1,0 +1,135 @@
+# Go 1.27 deploy WebSocket 会话生命周期证据
+
+## 范围与结论
+
+本轮只统一 deploy 入站 WebSocket 会话的生命周期：
+
+- init JSON 读取成功后立即建立 `context.WithCancelCause` 根 context；session 统一拥有
+  reader、writer、trace worker 和连接关闭。
+- 正常完成进入 draining，按 FIFO 排空发送队列后关闭连接；异常完成进入 aborting，取消
+  trace、丢弃尚未开始写的消息，再由唯一 writer 发送既有 close frame 并关闭连接。
+- slow consumer、reader error、writer error 和 parent cancel 共用幂等终止状态机；删除
+  `writeLoop` 的宽泛 panic recovery。
+- `WriteJSON`、`WriteControl` 和会话期 `Close` 只由 writer 执行，避免 data frame 与 close
+  frame 并发写入 Gorilla WebSocket。
+- 既有 64 KiB init 首帧上限不改值；新增真实 Gorilla 连接的 65,536/65,537 字节边界测试。
+
+JSON schema、消息顺序、CLI、REST、MCP、三 flavor 依赖边界和导出 API 均不变。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `acfffd84e74c1745b4e10a284979c1facc194439` |
+| benchmark/profile source head | `c098446193b2671f5d625af27d6455fb6c5ee781` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每次 1 秒；完整 harness 10 次，WS 校准 20 次 |
+| profile | `GOMAXPROCS=10`，WS JSON marshal 30 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+
+证据提交只加入本文档，不改变被测 Go 行为、fixture 或 benchmark harness。PR 性能工作流会在
+exact head 另存 Linux cross-reference artifact。
+
+## 调用链变化
+
+### 旧路径
+
+`handler -> read init -> detached reader/cancel -> create writer session -> trace on handler stack`
+
+reader goroutine 不属于 session；session 只等待 writer。正常、读错、写错、慢消费者和请求取消
+分别修改 channel、context 与连接，`WriteControl`/`Close` 也可能从非 writer 路径执行。
+`writeLoop` 依靠 recover 兜住关闭交错。
+
+### 新路径
+
+`handler -> read init -> create session root -> reader/writer workers -> registered trace worker`
+
+session 使用 `open -> draining/aborting -> closed` 状态机：
+
+- `send` 与 `close(sendCh)` 共用状态锁，队列满后先释放锁再请求 abort，不会自锁或
+  send-on-closed-channel。
+- 正常 `finish` 关闭发送入口，writer 排空队列、取消根 context、关闭连接并解除 reader，最后
+  等待所有已登记 worker。
+- 异常路径先记录首次 cause 并取消根 context；writer 不再开始写队列尾部，只在当前 write
+  返回后串行发送 close frame、关闭连接。
+- parent cancel 保持不发送额外 close frame；reader、slow consumer、writer error 分别保持
+  1000、1013、1011 及原有 reason。
+
+## Benchmark
+
+parent/source head 先使用完整 Go 1.27.1 `nojsonv2` harness 各顺序运行 10 次。该轮 WS JSON
+marshal 显示 `+2.66%`，但本 PR 没有修改 benchmark 或 JSON 编解码路径，且同轮未修改模块也
+存在双向漂移。按门槛规则，随后预编译两侧 server test binary，并交替顺序采样 20 次，避免
+整套长跑的温度和执行顺序偏差。以下以校准结果作为 WS 判定依据：
+
+| Benchmark | parent | source head | benchstat | B/op | allocs/op |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| WebSocket JSON marshal | 473.5 ns | 470.1 ns | 不显著，`p=0.304` | 416 -> 416 | 2 -> 2 |
+| WebSocket JSON unmarshal | 2.336 us | 2.358 us | 不显著，`p=0.560` | 656 -> 656 | 15 -> 15 |
+| geomean | 1.052 us | 1.053 us | +0.10% | 522.4 -> 522.4 | 5.477 -> 5.477 |
+
+现有 benchmark harness 没有对网络连接生命周期做微基准。该路径以确定性交错、worker join 和
+race 证明正确性；WS JSON 只用于确认完整 server 构建没有编解码或分配回退，不归因于本轮
+状态机重构。
+
+## Profile
+
+parent/source head 对相同 `BenchmarkWebSocketJSONMarshalEnvelope` 各采集 30 秒 CPU 与 heap
+profile。单次读数为 460.0 ns/op 和 469.6 ns/op，不用于门槛判断；20 次交替 benchstat 才是
+统计结论。
+
+两侧 CPU top 都由 Darwin runtime wait 与 `encoding/json` 主导；该 profile 不执行会话
+生命周期，不能用来判断 session、reader、writer 或终止状态机热点，只作为 JSON 路径的
+交叉回归证据。heap alloc-space 构成一致：约 84.6% 来自 `encoding/json.Marshal`，其余来自
+benchmark 调用；每次操作仍为 416 B、2 allocs。
+
+## 产物大小与测试耗时
+
+Darwin arm64 产物使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`；两侧均为
+Go 1.27.1、`nojsonv2`，Darwin 不执行 UPX。
+
+| Flavor | parent | source head | 变化 |
+| --- | ---: | ---: | ---: |
+| nexttrace | 30,126,690 B | 30,126,706 B | +16 B / +0.00005% |
+| nexttrace-tiny | 11,050,018 B | 11,050,018 B | 0 B |
+| ntr | 11,050,018 B | 11,050,018 B | 0 B |
+
+同配置、预热缓存后的 `go test -count=1 ./...`：
+
+| 指标 | parent | source head |
+| --- | ---: | ---: |
+| 墙钟 | 23.46 s | 22.88 s |
+| maximum resident set size | 448,102,400 B | 446,382,080 B |
+
+测试耗时和 RSS 只记录完成成本，不解释为性能改善。
+
+## 验证
+
+`testing/synctest` 与真实 Gorilla 集成测试覆盖：
+
+- 正常 drain 严格保持 `start -> hop -> complete`，并等待 reader、writer、trace 全部退出；
+- slow consumer、reader error、writer error、parent cancel 取消 trace 并丢弃尾队列；
+- data/control write 最大并发为 1；并发 finish/close 只关闭一次且不混合终态；
+- 65,536 字节合法 init 进入 trace，65,537 字节收到 1009 且不会调用 tracer；
+- 既有 MTR `path_end -> mtr_raw -> path_end(null) -> complete`、single trace stop reason
+  和 provider canonicalization 合同保持不变。
+
+source head 已通过定向测试 100 次、race 压力、默认 JSON/nojsonv2 server 测试、全仓普通与
+race 测试、build、vet、diff-aware lint、tiny/ntr 测试与构建、Node 15 项测试、module
+verify/tidy，以及 Linux、Windows、Darwin 三平台构建。Darwin 三 flavor 的
+`LC_BUILD_VERSION` 均为 macOS 13.0。
+
+仓库当前的无范围限制 `golangci-lint run` 会报告 78 个既存问题；CI 使用
+`only-new-issues`，本 PR 的 `--new-from-rev main` 检查为 0 个新增问题。
+
+## 平台风险与回退
+
+主要风险是 normal drain 与 reader/parent cancel 的竞争、blocked write 期间的 abort，以及
+`WaitGroup.Go` 登记和最终 `Wait` 的顺序。生产路径只在 handler 调用 `finish` 前登记 trace；
+状态锁、可取消根 context、5 秒 write deadline、synctest 与 race 共同覆盖这些边界。
+
+如需回退，可撤销生命周期实现、合同测试和本文档。没有配置、JSON、协议、持久数据或导出
+API 迁移；回退不需要数据处理。原始 benchmark、profile、测试日志和二进制不入库，由本地
+忽略目录及 CI artifact 保存。

--- a/docs/performance/go127-deploy-ws-session.md
+++ b/docs/performance/go127-deploy-ws-session.md
@@ -9,9 +9,11 @@
 - 正常完成进入 draining，按 FIFO 排空发送队列后关闭连接；异常完成进入 aborting，取消
   trace、丢弃尚未开始写的消息，再由唯一 writer 发送既有 close frame 并关闭连接。
 - slow consumer、reader error、writer error 和 parent cancel 共用幂等终止状态机；删除
-  `writeLoop` 的宽泛 panic recovery。
-- `WriteJSON`、`WriteControl` 和会话期 `Close` 只由 writer 执行，避免 data frame 与 close
-  frame 并发写入 Gorilla WebSocket。
+  `writeLoop` 的宽泛 panic recovery；trace worker 边界仅将未捕获 panic 转为 1011/internal
+  error，避免 panic 越过 Gin recovery 终止进程。
+- 会话主动发出的 `WriteJSON`、close frame 和会话期 `Close` 由 writer 串行执行；reader 只调用
+  `NextReader`。Gorilla 可能在读调用内自动发送 control frame，此时依赖其对 `WriteControl` 和
+  `Close` 的并发安全保证。
 - 既有 64 KiB init 首帧上限不改值；新增真实 Gorilla 连接的 65,536/65,537 字节边界测试。
 
 JSON schema、消息顺序、CLI、REST、MCP、三 flavor 依赖边界和导出 API 均不变。
@@ -111,7 +113,8 @@ Go 1.27.1、`nojsonv2`，Darwin 不执行 UPX。
 
 - 正常 drain 严格保持 `start -> hop -> complete`，并等待 reader、writer、trace 全部退出；
 - slow consumer、reader error、writer error、parent cancel 取消 trace 并丢弃尾队列；
-- data/control write 最大并发为 1；并发 finish/close 只关闭一次且不混合终态；
+- 会话主动发出的 data/close write 最大并发为 1；并发 finish/close 只关闭一次且不混合终态；
+- trace worker panic 被限制在 worker 边界，转换为单次 1011/internal error 并完整 join；
 - 65,536 字节合法 init 进入 trace，65,537 字节收到 1009 且不会调用 tracer；
 - 既有 MTR `path_end -> mtr_raw -> path_end(null) -> complete`、single trace stop reason
   和 provider canonicalization 合同保持不变。

--- a/server/ws_handler.go
+++ b/server/ws_handler.go
@@ -33,10 +33,11 @@ const (
 )
 
 var (
-	errWSSlowConsumer  = errors.New("websocket client too slow for mtr stream")
-	errWSSessionClosed = errors.New("websocket session closed")
-	traceTracerouteFn  = trace.Traceroute
-	traceRunMTRRawFn   = trace.RunMTRRaw
+	errWSSlowConsumer    = errors.New("websocket client too slow for mtr stream")
+	errWSSessionClosed   = errors.New("websocket session closed")
+	errWSSessionFinished = errors.New("websocket session finished")
+	traceTracerouteFn    = trace.Traceroute
+	traceRunMTRRawFn     = trace.RunMTRRaw
 )
 
 // sanitizeLogParam 清理用户输入中的换行和控制字符，防止日志注入。
@@ -56,11 +57,11 @@ func sanitizeLogParam(s string) string {
 	return b.String()
 }
 
-func newWSSessionContext(parent context.Context) (context.Context, context.CancelFunc) {
+func newWSSessionContext(parent context.Context) (context.Context, context.CancelCauseFunc) {
 	if parent == nil {
 		parent = context.Background()
 	}
-	return context.WithCancel(parent)
+	return context.WithCancelCause(parent)
 }
 
 type wsEnvelope struct {
@@ -84,32 +85,54 @@ type wsInitConn interface {
 	ReadMessage() (messageType int, p []byte, err error)
 }
 
-type wsTraceSession struct {
-	conn       wsConn
-	sendMu     sync.Mutex
-	sendCh     chan wsEnvelope
-	stopCh     chan struct{}
-	writerDone chan struct{}
-	closeOnce  sync.Once
-	finishOnce sync.Once
-	closed     atomic.Bool
-	lang       string
-	seen       map[int]int
+type traceWSConn interface {
+	wsConn
+	wsInitConn
 }
 
-func newWSTraceSession(conn wsConn, lang string, queueSize int) *wsTraceSession {
+type wsSessionState uint8
+
+const (
+	wsSessionOpen wsSessionState = iota
+	wsSessionDraining
+	wsSessionAborting
+	wsSessionClosed
+)
+
+type wsSessionCloseRequest struct {
+	code   int
+	reason string
+}
+
+type wsTraceSession struct {
+	conn         wsConn
+	ctx          context.Context
+	cancel       context.CancelCauseFunc
+	stateMu      sync.Mutex
+	state        wsSessionState
+	sendCh       chan wsEnvelope
+	workers      sync.WaitGroup
+	closed       atomic.Bool
+	closeRequest wsSessionCloseRequest
+	lang         string
+	seen         map[int]int
+}
+
+func newWSTraceSession(parent context.Context, conn wsConn, lang string, queueSize int) *wsTraceSession {
 	if queueSize <= 0 {
 		queueSize = wsSendQueueSize
 	}
+	ctx, cancel := newWSSessionContext(parent)
 	s := &wsTraceSession{
-		conn:       conn,
-		sendCh:     make(chan wsEnvelope, queueSize),
-		stopCh:     make(chan struct{}),
-		writerDone: make(chan struct{}),
-		lang:       lang,
-		seen:       make(map[int]int),
+		conn:   conn,
+		ctx:    ctx,
+		cancel: cancel,
+		sendCh: make(chan wsEnvelope, queueSize),
+		lang:   lang,
+		seen:   make(map[int]int),
 	}
-	go s.writeLoop()
+	s.workers.Go(s.writeLoop)
+	s.workers.Go(s.readLoop)
 	return s
 }
 
@@ -129,70 +152,175 @@ func readWSInitMessage(conn wsInitConn) ([]byte, error) {
 }
 
 func (s *wsTraceSession) writeLoop() {
-	defer close(s.writerDone)
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("[deploy] writeLoop panic: %v", r)
-			s.closeWithCode(websocket.CloseInternalServerErr, "internal error")
-		}
-	}()
 	for {
 		select {
-		case <-s.stopCh:
+		case <-s.ctx.Done():
+			s.requestAbort(context.Cause(s.ctx), 0, "")
+			s.finishAbort()
 			return
 		case msg, ok := <-s.sendCh:
 			if !ok {
+				if !s.finishDrain() {
+					s.finishAbort()
+				}
+				return
+			}
+			if !s.writeAllowed() {
+				s.requestAbort(context.Cause(s.ctx), 0, "")
+				s.finishAbort()
 				return
 			}
 			deadline := time.Now().Add(wsWriteTimeout)
 			_ = s.conn.SetWriteDeadline(deadline)
 			err := s.conn.WriteJSON(msg)
 			if err != nil {
-				s.closeWithCode(websocket.CloseInternalServerErr, "write failed")
+				s.requestAbort(err, websocket.CloseInternalServerErr, "write failed")
+				s.finishAbort()
 				return
 			}
 		}
 	}
 }
 
+func (s *wsTraceSession) readLoop() {
+	for {
+		if _, _, err := s.conn.NextReader(); err != nil {
+			if s.ctx.Err() != nil {
+				s.requestAbort(context.Cause(s.ctx), 0, "")
+			} else {
+				s.requestAbort(err, websocket.CloseNormalClosure, "client disconnected")
+			}
+			return
+		}
+	}
+}
+
 func (s *wsTraceSession) send(msg wsEnvelope) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	if s.closed.Load() {
+	s.stateMu.Lock()
+	if s.state != wsSessionOpen || s.ctx.Err() != nil {
+		s.stateMu.Unlock()
 		return errWSSessionClosed
 	}
 	select {
 	case s.sendCh <- msg:
+		s.stateMu.Unlock()
 		return nil
 	default:
-		s.closeWithCode(websocket.CloseTryAgainLater, "client too slow for mtr stream")
+		s.stateMu.Unlock()
+		s.requestAbort(errWSSlowConsumer, websocket.CloseTryAgainLater, "client too slow for mtr stream")
 		return errWSSlowConsumer
 	}
 }
 
 func (s *wsTraceSession) closeWithCode(code int, reason string) {
-	s.closed.Store(true)
-	s.closeOnce.Do(func() {
-		close(s.stopCh)
-		deadline := time.Now().Add(wsWriteTimeout)
-		_ = s.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(code, reason), deadline)
-		_ = s.conn.Close()
-	})
+	s.requestAbort(errWSSessionClosed, code, reason)
 }
 
 func (s *wsTraceSession) finish() {
-	s.finishOnce.Do(func() {
-		s.sendMu.Lock()
-		wasClosed := s.closed.Swap(true)
-		if !wasClosed {
-			close(s.sendCh)
-		}
-		s.sendMu.Unlock()
-		<-s.writerDone
-		s.closeOnce.Do(func() {
-			_ = s.conn.Close()
-		})
+	s.requestDrain()
+	s.workers.Wait()
+}
+
+func (s *wsTraceSession) runTrace(run func(context.Context)) {
+	done := make(chan struct{})
+	s.workers.Go(func() {
+		defer close(done)
+		run(s.ctx)
 	})
+	<-done
+}
+
+func (s *wsTraceSession) requestDrain() {
+	s.stateMu.Lock()
+	if s.state != wsSessionOpen {
+		s.stateMu.Unlock()
+		return
+	}
+	if s.ctx.Err() != nil {
+		s.stateMu.Unlock()
+		s.requestAbort(context.Cause(s.ctx), 0, "")
+		return
+	}
+	s.state = wsSessionDraining
+	s.closed.Store(true)
+	close(s.sendCh)
+	s.stateMu.Unlock()
+}
+
+func (s *wsTraceSession) requestAbort(cause error, code int, reason string) {
+	if cause == nil {
+		cause = errWSSessionClosed
+	}
+
+	s.stateMu.Lock()
+	if s.state == wsSessionAborting || s.state == wsSessionClosed {
+		s.stateMu.Unlock()
+		return
+	}
+	if s.ctx.Err() != nil {
+		cause = context.Cause(s.ctx)
+		code = 0
+		reason = ""
+	}
+	s.state = wsSessionAborting
+	s.closeRequest = wsSessionCloseRequest{code: code, reason: reason}
+	s.closed.Store(true)
+	s.stateMu.Unlock()
+	s.cancel(cause)
+}
+
+func (s *wsTraceSession) writeAllowed() bool {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	return (s.state == wsSessionOpen || s.state == wsSessionDraining) && s.ctx.Err() == nil
+}
+
+func (s *wsTraceSession) finishDrain() bool {
+	if s.ctx.Err() != nil {
+		s.requestAbort(context.Cause(s.ctx), 0, "")
+		return false
+	}
+
+	s.stateMu.Lock()
+	if s.state != wsSessionDraining || s.ctx.Err() != nil {
+		s.stateMu.Unlock()
+		if s.ctx.Err() != nil {
+			s.requestAbort(context.Cause(s.ctx), 0, "")
+		}
+		return false
+	}
+	s.state = wsSessionClosed
+	s.stateMu.Unlock()
+
+	s.cancel(errWSSessionFinished)
+	_ = s.conn.Close()
+	return true
+}
+
+func (s *wsTraceSession) finishAbort() {
+	s.stateMu.Lock()
+	if s.state == wsSessionClosed {
+		s.stateMu.Unlock()
+		return
+	}
+	if s.state != wsSessionAborting {
+		s.state = wsSessionAborting
+		s.closeRequest = wsSessionCloseRequest{}
+		s.closed.Store(true)
+	}
+	closeRequest := s.closeRequest
+	s.state = wsSessionClosed
+	s.stateMu.Unlock()
+
+	if closeRequest.code != 0 {
+		deadline := time.Now().Add(wsWriteTimeout)
+		_ = s.conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(closeRequest.code, closeRequest.reason),
+			deadline,
+		)
+	}
+	_ = s.conn.Close()
 }
 
 func traceWebsocketHandler(c *gin.Context) {
@@ -201,38 +329,27 @@ func traceWebsocketHandler(c *gin.Context) {
 		log.Printf("[deploy] websocket upgrade failed: %v", err)
 		return
 	}
-	defer func() {
-		_ = conn.Close()
-	}()
+	serveTraceWebsocket(c.Request.Context(), conn)
+}
 
+func serveTraceWebsocket(parent context.Context, conn traceWSConn) {
 	message, err := readWSInitMessage(conn)
 	if err != nil {
 		log.Printf("[deploy] websocket read failed: %v", err)
+		_ = conn.Close()
 		return
 	}
+
+	session := newWSTraceSession(parent, conn, "", wsSendQueueSize)
+	defer session.finish()
 
 	var req traceRequest
 	if err := json.Unmarshal(message, &req); err != nil {
-		_ = conn.WriteJSON(wsEnvelope{Type: "error", Error: "invalid request payload", Status: 400})
+		_ = session.send(wsEnvelope{Type: "error", Error: "invalid request payload", Status: 400})
 		return
 	}
 
-	sessionCtx, cancel := newWSSessionContext(c.Request.Context())
-	defer cancel()
-	var sessionRef atomic.Pointer[wsTraceSession]
-	go func() {
-		for {
-			if _, _, err := conn.NextReader(); err != nil {
-				cancel()
-				if session := sessionRef.Load(); session != nil {
-					session.closeWithCode(websocket.CloseNormalClosure, "client disconnected")
-				}
-				return
-			}
-		}
-	}()
-
-	setup, statusCode, err := prepareTrace(sessionCtx, req)
+	setup, statusCode, err := prepareTrace(session.ctx, req)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return
@@ -241,13 +358,11 @@ func traceWebsocketHandler(c *gin.Context) {
 			statusCode = 500
 		}
 		log.Printf("[deploy] websocket prepare trace failed target=%s error=%v", sanitizeLogParam(req.Target), err)
-		_ = conn.WriteJSON(wsEnvelope{Type: "error", Error: err.Error(), Status: statusCode})
+		_ = session.send(wsEnvelope{Type: "error", Error: err.Error(), Status: statusCode})
 		return
 	}
 
-	session := newWSTraceSession(conn, setup.Config.Lang, wsSendQueueSize)
-	sessionRef.Store(session)
-	defer session.finish()
+	session.lang = setup.Config.Lang
 
 	startPayload := gin.H{
 		"target":        setup.Target,
@@ -269,12 +384,14 @@ func traceWebsocketHandler(c *gin.Context) {
 		mode = "single"
 	}
 
-	switch mode {
-	case "mtr", "continuous":
-		runMTRTrace(sessionCtx, session, setup)
-	default:
-		runSingleTrace(sessionCtx, session, setup)
-	}
+	session.runTrace(func(sessionCtx context.Context) {
+		switch mode {
+		case "mtr", "continuous":
+			runMTRTrace(sessionCtx, session, setup)
+		default:
+			runSingleTrace(sessionCtx, session, setup)
+		}
+	})
 }
 
 func runSingleTrace(ctx context.Context, session *wsTraceSession, setup *traceExecution) {

--- a/server/ws_handler.go
+++ b/server/ws_handler.go
@@ -33,11 +33,12 @@ const (
 )
 
 var (
-	errWSSlowConsumer    = errors.New("websocket client too slow for mtr stream")
-	errWSSessionClosed   = errors.New("websocket session closed")
-	errWSSessionFinished = errors.New("websocket session finished")
-	traceTracerouteFn    = trace.Traceroute
-	traceRunMTRRawFn     = trace.RunMTRRaw
+	errWSSlowConsumer     = errors.New("websocket client too slow for mtr stream")
+	errWSSessionClosed    = errors.New("websocket session closed")
+	errWSSessionFinished  = errors.New("websocket session finished")
+	errWSTraceWorkerPanic = errors.New("websocket trace worker panic")
+	traceTracerouteFn     = trace.Traceroute
+	traceRunMTRRawFn      = trace.RunMTRRaw
 )
 
 // sanitizeLogParam 清理用户输入中的换行和控制字符，防止日志注入。
@@ -225,6 +226,12 @@ func (s *wsTraceSession) runTrace(run func(context.Context)) {
 	done := make(chan struct{})
 	s.workers.Go(func() {
 		defer close(done)
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				log.Printf("[deploy] websocket trace worker panic: %v", recovered)
+				s.requestAbort(errWSTraceWorkerPanic, websocket.CloseInternalServerErr, "internal error")
+			}
+		}()
 		run(s.ctx)
 	})
 	<-done

--- a/server/ws_handler_test.go
+++ b/server/ws_handler_test.go
@@ -26,13 +26,15 @@ type fakeWSConn struct {
 	writeStarted  chan struct{}
 	writeBlock    chan struct{}
 	closeOnce     sync.Once
+	writeOnce     sync.Once
+	closed        chan struct{}
 	closeCount    int
 	controlCount  int
 	deadlineCount int
 }
 
 func newFakeWSConn(blockWrites bool) *fakeWSConn {
-	conn := &fakeWSConn{}
+	conn := &fakeWSConn{closed: make(chan struct{})}
 	if blockWrites {
 		conn.writeStarted = make(chan struct{})
 		conn.writeBlock = make(chan struct{})
@@ -82,19 +84,24 @@ func (f *fakeWSConn) WriteControl(messageType int, data []byte, deadline time.Ti
 }
 
 func (f *fakeWSConn) Close() error {
+	f.mu.Lock()
+	f.closeCount++
+	f.mu.Unlock()
 	f.closeOnce.Do(func() {
-		f.mu.Lock()
-		f.closeCount++
-		f.mu.Unlock()
-		if f.writeBlock != nil {
-			close(f.writeBlock)
-		}
+		close(f.closed)
 	})
 	return nil
 }
 
 func (f *fakeWSConn) NextReader() (messageType int, r io.Reader, err error) {
+	<-f.closed
 	return 0, nil, io.EOF
+}
+
+func (f *fakeWSConn) releaseWrites() {
+	if f.writeBlock != nil {
+		f.writeOnce.Do(func() { close(f.writeBlock) })
+	}
 }
 
 type fakeWSInitConn struct {
@@ -232,7 +239,7 @@ func TestTraceWebsocketCanonicalizesLegacyProviderInStartAndComplete(t *testing.
 func TestNewWSSessionContextInheritsParentCancellation(t *testing.T) {
 	parent, cancelParent := context.WithCancel(context.Background())
 	ctx, cancel := newWSSessionContext(parent)
-	defer cancel()
+	defer cancel(nil)
 
 	cancelParent()
 
@@ -248,8 +255,11 @@ func TestNewWSSessionContextInheritsParentCancellation(t *testing.T) {
 
 func TestWSTraceSessionSend_QueueOverflowReturnsErrSlowConsumer(t *testing.T) {
 	conn := newFakeWSConn(true)
-	session := newWSTraceSession(conn, "cn", 1)
-	defer session.finish()
+	session := newWSTraceSession(context.Background(), conn, "cn", 1)
+	defer func() {
+		conn.releaseWrites()
+		session.finish()
+	}()
 
 	if err := session.send(wsEnvelope{Type: "first"}); err != nil {
 		t.Fatalf("first send returned error: %v", err)
@@ -267,11 +277,12 @@ func TestWSTraceSessionSend_QueueOverflowReturnsErrSlowConsumer(t *testing.T) {
 	if !session.closed.Load() {
 		t.Fatal("session should be marked closed after queue overflow")
 	}
+	conn.releaseWrites()
 }
 
 func TestWSTraceSessionWriter_PreservesEnvelopeOrder(t *testing.T) {
 	conn := newFakeWSConn(false)
-	session := newWSTraceSession(conn, "cn", 4)
+	session := newWSTraceSession(context.Background(), conn, "cn", 4)
 
 	if err := session.send(wsEnvelope{Type: "start"}); err != nil {
 		t.Fatalf("first send returned error: %v", err)
@@ -294,7 +305,7 @@ func TestWSTraceSessionWriter_PreservesEnvelopeOrder(t *testing.T) {
 
 func TestWSTraceSessionClose_IsIdempotent(t *testing.T) {
 	conn := newFakeWSConn(false)
-	session := newWSTraceSession(conn, "cn", 4)
+	session := newWSTraceSession(context.Background(), conn, "cn", 4)
 
 	session.closeWithCode(websocket.CloseTryAgainLater, "slow consumer")
 	session.closeWithCode(websocket.CloseTryAgainLater, "slow consumer")
@@ -325,7 +336,7 @@ func TestRunMTRTraceStreamsPathEndAndCompleteState(t *testing.T) {
 	}
 
 	conn := newFakeWSConn(false)
-	session := newWSTraceSession(conn, "en", 8)
+	session := newWSTraceSession(context.Background(), conn, "en", 8)
 	runMTRTrace(context.Background(), session, &traceExecution{
 		Method: trace.ICMPTrace,
 		Config: trace.Config{MaxHops: 5},
@@ -372,7 +383,7 @@ func TestRunMTRTraceCancellationDoesNotInventPathEnd(t *testing.T) {
 	}
 
 	conn := newFakeWSConn(false)
-	session := newWSTraceSession(conn, "en", 8)
+	session := newWSTraceSession(context.Background(), conn, "en", 8)
 	runMTRTrace(context.Background(), session, &traceExecution{
 		Method: trace.ICMPTrace,
 		Config: trace.Config{MaxHops: 5},
@@ -409,7 +420,7 @@ func TestRunSingleTraceCompleteUsesSnakeCaseStopReason(t *testing.T) {
 	}
 
 	conn := newFakeWSConn(false)
-	session := newWSTraceSession(conn, "en", 4)
+	session := newWSTraceSession(context.Background(), conn, "en", 4)
 	runSingleTrace(context.Background(), session, &traceExecution{
 		Target:       "example.test",
 		Protocol:     "ICMP",

--- a/server/ws_init_limit_integration_test.go
+++ b/server/ws_init_limit_integration_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestTraceWebsocketInitMessageSizeBoundary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldLookup := traceDomainLookupFn
+	oldTraceroute := traceTracerouteFn
+	oldEnsure := ensureNextTraceAPIV3ConnectionFn
+	defer func() {
+		traceDomainLookupFn = oldLookup
+		traceTracerouteFn = oldTraceroute
+		ensureNextTraceAPIV3ConnectionFn = oldEnsure
+	}()
+
+	traceDomainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		return net.ParseIP("192.0.2.1"), nil
+	}
+	var tracerCalls atomic.Int32
+	traceTracerouteFn = func(trace.Method, trace.Config) (*trace.Result, error) {
+		tracerCalls.Add(1)
+		return &trace.Result{}, nil
+	}
+	ensureNextTraceAPIV3ConnectionFn = func() {}
+
+	router := gin.New()
+	router.GET("/ws", traceWebsocketHandler)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	t.Run("accepts exactly 65536 bytes", func(t *testing.T) {
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("websocket dial: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		payload := paddedWSInitPayload(t, maxWSInitMessageBytes)
+		if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+			t.Fatalf("write init message: %v", err)
+		}
+
+		for _, wantType := range []string{"start", "complete"} {
+			var envelope wsEnvelope
+			if err := conn.ReadJSON(&envelope); err != nil {
+				t.Fatalf("read %s envelope: %v", wantType, err)
+			}
+			if envelope.Type != wantType {
+				t.Fatalf("envelope type = %q, want %q", envelope.Type, wantType)
+			}
+		}
+		if got := tracerCalls.Load(); got != 1 {
+			t.Fatalf("tracer calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("rejects 65537 bytes", func(t *testing.T) {
+		callsBefore := tracerCalls.Load()
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("websocket dial: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		payload := paddedWSInitPayload(t, maxWSInitMessageBytes+1)
+		if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+			t.Fatalf("write oversized init message: %v", err)
+		}
+
+		_, _, err = conn.ReadMessage()
+		var closeErr *websocket.CloseError
+		if !errors.As(err, &closeErr) || closeErr.Code != websocket.CloseMessageTooBig {
+			t.Fatalf("read oversized response error = %v, want close code %d", err, websocket.CloseMessageTooBig)
+		}
+		if got := tracerCalls.Load(); got != callsBefore {
+			t.Fatalf("oversized message invoked tracer: calls %d -> %d", callsBefore, got)
+		}
+	})
+}
+
+func paddedWSInitPayload(t *testing.T, size int) []byte {
+	t.Helper()
+	base := []byte(`{"target":"192.0.2.1","data_provider":"disable-geoip","disable_maptrace":true}`)
+	if len(base) > size {
+		t.Fatalf("base init payload size = %d, exceeds target %d", len(base), size)
+	}
+	payload := make([]byte, size)
+	copy(payload, base)
+	for i := len(base); i < len(payload); i++ {
+		payload[i] = ' '
+	}
+	if !json.Valid(payload) {
+		t.Fatal("padded init payload is not valid JSON")
+	}
+	return payload
+}

--- a/server/ws_session_synctest_test.go
+++ b/server/ws_session_synctest_test.go
@@ -421,6 +421,36 @@ func TestWSTraceSessionSerializesDataAndCloseWrites(t *testing.T) {
 	})
 }
 
+func TestWSTraceSessionTracePanicAborts(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn := newWSSessionTestConn()
+		session := newWSTraceSession(t.Context(), conn, "en", 2)
+		<-conn.readerStarted
+
+		session.runTrace(func(context.Context) {
+			panic("scripted trace failure")
+		})
+		session.finish()
+		synctest.Wait()
+
+		if !errors.Is(context.Cause(session.ctx), errWSTraceWorkerPanic) {
+			t.Fatalf("session cause = %v, want errWSTraceWorkerPanic", context.Cause(session.ctx))
+		}
+		requireWSTestChannelClosed(t, conn.readerExited, "reader")
+		writes, frames, closeCalls, maxWriters := conn.snapshot()
+		requireWSTestEnvelopeTypes(t, writes)
+		if len(frames) != 1 || frames[0].code != websocket.CloseInternalServerErr || frames[0].reason != "internal error" {
+			t.Fatalf("close frames = %#v, want one internal-error frame", frames)
+		}
+		if closeCalls != 1 {
+			t.Fatalf("Close calls = %d, want 1", closeCalls)
+		}
+		if maxWriters != 1 {
+			t.Fatalf("maximum concurrent writers = %d, want 1", maxWriters)
+		}
+	})
+}
+
 func TestWSTraceSessionConcurrentFinishAndCloseIsIdempotent(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		conn := newWSSessionTestConn()

--- a/server/ws_session_synctest_test.go
+++ b/server/ws_session_synctest_test.go
@@ -1,0 +1,481 @@
+package server
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type wsSessionWritePlan struct {
+	entered chan struct{}
+	release <-chan struct{}
+	err     error
+}
+
+type wsSessionCloseFrame struct {
+	code   int
+	reason string
+}
+
+type wsSessionTestConn struct {
+	mu sync.Mutex
+
+	writePlans chan wsSessionWritePlan
+	readError  chan error
+	closed     chan struct{}
+
+	closeSignalOnce sync.Once
+	readerStartOnce sync.Once
+	readerExitOnce  sync.Once
+	readerStarted   chan struct{}
+	readerExited    chan struct{}
+
+	writes               []wsEnvelope
+	closeFrames          []wsSessionCloseFrame
+	closeCalls           int
+	activeWriters        int
+	maxConcurrentWriters int
+}
+
+func newWSSessionTestConn() *wsSessionTestConn {
+	return &wsSessionTestConn{
+		writePlans:    make(chan wsSessionWritePlan, 8),
+		readError:     make(chan error, 1),
+		closed:        make(chan struct{}),
+		readerStarted: make(chan struct{}),
+		readerExited:  make(chan struct{}),
+	}
+}
+
+func (c *wsSessionTestConn) planWrite(plan wsSessionWritePlan) {
+	c.writePlans <- plan
+}
+
+func (c *wsSessionTestConn) failRead(err error) {
+	c.readError <- err
+}
+
+func (c *wsSessionTestConn) beginWrite() {
+	c.mu.Lock()
+	c.activeWriters++
+	if c.activeWriters > c.maxConcurrentWriters {
+		c.maxConcurrentWriters = c.activeWriters
+	}
+	c.mu.Unlock()
+}
+
+func (c *wsSessionTestConn) endWrite() {
+	c.mu.Lock()
+	c.activeWriters--
+	c.mu.Unlock()
+}
+
+func (c *wsSessionTestConn) WriteJSON(value interface{}) error {
+	c.beginWrite()
+	defer c.endWrite()
+
+	var plan wsSessionWritePlan
+	select {
+	case plan = <-c.writePlans:
+	default:
+	}
+	if plan.entered != nil {
+		close(plan.entered)
+	}
+	if plan.release != nil {
+		select {
+		case <-plan.release:
+		case <-c.closed:
+			return io.ErrClosedPipe
+		}
+	}
+	if plan.err != nil {
+		return plan.err
+	}
+
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	var envelope wsEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.writes = append(c.writes, envelope)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *wsSessionTestConn) SetWriteDeadline(time.Time) error {
+	c.beginWrite()
+	defer c.endWrite()
+	return nil
+}
+
+func (c *wsSessionTestConn) WriteControl(messageType int, data []byte, _ time.Time) error {
+	c.beginWrite()
+	defer c.endWrite()
+
+	if messageType != websocket.CloseMessage {
+		return nil
+	}
+	frame := wsSessionCloseFrame{}
+	if len(data) >= 2 {
+		frame.code = int(binary.BigEndian.Uint16(data[:2]))
+		frame.reason = string(data[2:])
+	}
+	c.mu.Lock()
+	c.closeFrames = append(c.closeFrames, frame)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *wsSessionTestConn) Close() error {
+	c.mu.Lock()
+	c.closeCalls++
+	c.mu.Unlock()
+	c.closeSignalOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *wsSessionTestConn) NextReader() (messageType int, r io.Reader, err error) {
+	c.readerStartOnce.Do(func() { close(c.readerStarted) })
+	defer c.readerExitOnce.Do(func() { close(c.readerExited) })
+
+	select {
+	case err := <-c.readError:
+		return 0, nil, err
+	case <-c.closed:
+		return 0, nil, io.EOF
+	}
+}
+
+func (c *wsSessionTestConn) snapshot() ([]wsEnvelope, []wsSessionCloseFrame, int, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]wsEnvelope(nil), c.writes...),
+		append([]wsSessionCloseFrame(nil), c.closeFrames...),
+		c.closeCalls,
+		c.maxConcurrentWriters
+}
+
+func startBlockingWSTrace(session *wsTraceSession, release <-chan struct{}) (<-chan context.Context, <-chan struct{}) {
+	started := make(chan context.Context, 1)
+	exited := make(chan struct{})
+	go func() {
+		session.runTrace(func(ctx context.Context) {
+			started <- ctx
+			<-ctx.Done()
+			if release != nil {
+				<-release
+			}
+		})
+		close(exited)
+	}()
+	return started, exited
+}
+
+func finishWSSessionAsync(session *wsTraceSession) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		session.finish()
+		close(done)
+	}()
+	return done
+}
+
+func requireWSTestChannelOpen(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("%s closed too early", name)
+	default:
+	}
+}
+
+func requireWSTestChannelClosed(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		t.Fatalf("%s is still open", name)
+	}
+}
+
+func requireWSTestEnvelopeTypes(t *testing.T, writes []wsEnvelope, want ...string) {
+	t.Helper()
+	if len(writes) != len(want) {
+		t.Fatalf("writes = %#v, want envelope types %v", writes, want)
+	}
+	for i := range want {
+		if writes[i].Type != want[i] {
+			t.Fatalf("write %d type = %q, want %q (all writes: %#v)", i, writes[i].Type, want[i], writes)
+		}
+	}
+}
+
+func TestWSTraceSessionNormalFinishDrainsAndJoins(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn := newWSSessionTestConn()
+		writeEntered := make(chan struct{})
+		writeRelease := make(chan struct{})
+		conn.planWrite(wsSessionWritePlan{entered: writeEntered, release: writeRelease})
+
+		session := newWSTraceSession(t.Context(), conn, "en", 4)
+		traceRelease := make(chan struct{})
+		traceStarted, traceExited := startBlockingWSTrace(session, traceRelease)
+		traceCtx := <-traceStarted
+		<-conn.readerStarted
+
+		for _, messageType := range []string{"start", "hop", "complete"} {
+			if err := session.send(wsEnvelope{Type: messageType}); err != nil {
+				t.Fatalf("send %q: %v", messageType, err)
+			}
+		}
+		<-writeEntered
+
+		finished := finishWSSessionAsync(session)
+		synctest.Wait()
+		requireWSTestChannelOpen(t, finished, "finish result")
+		requireWSTestChannelOpen(t, traceExited, "trace worker")
+		if err := traceCtx.Err(); err != nil {
+			t.Fatalf("trace context canceled before normal drain completed: %v", err)
+		}
+
+		close(writeRelease)
+		synctest.Wait()
+		requireWSTestChannelOpen(t, finished, "finish result before trace joins")
+		if !errors.Is(traceCtx.Err(), context.Canceled) {
+			t.Fatalf("trace context error after drain = %v, want context.Canceled", traceCtx.Err())
+		}
+		close(traceRelease)
+		<-finished
+		synctest.Wait()
+
+		requireWSTestChannelClosed(t, traceExited, "trace worker")
+		requireWSTestChannelClosed(t, conn.readerExited, "reader")
+		writes, frames, closeCalls, maxWriters := conn.snapshot()
+		requireWSTestEnvelopeTypes(t, writes, "start", "hop", "complete")
+		if len(frames) != 0 {
+			t.Fatalf("normal finish wrote close frames: %#v", frames)
+		}
+		if closeCalls != 1 {
+			t.Fatalf("Close calls = %d, want 1", closeCalls)
+		}
+		if maxWriters != 1 {
+			t.Fatalf("maximum concurrent writers = %d, want 1", maxWriters)
+		}
+	})
+}
+
+func TestWSTraceSessionAbnormalTerminationDiscardsQueuedMessages(t *testing.T) {
+	tests := []struct {
+		name       string
+		trigger    string
+		wantCode   int
+		wantReason string
+	}{
+		{name: "slow consumer", trigger: "slow", wantCode: websocket.CloseTryAgainLater, wantReason: "client too slow for mtr stream"},
+		{name: "reader error", trigger: "reader", wantCode: websocket.CloseNormalClosure, wantReason: "client disconnected"},
+		{name: "writer error", trigger: "writer", wantCode: websocket.CloseInternalServerErr, wantReason: "write failed"},
+		{name: "parent cancellation", trigger: "parent"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				parent, cancelParent := context.WithCancel(t.Context())
+				defer cancelParent()
+				conn := newWSSessionTestConn()
+				writeEntered := make(chan struct{})
+				writeRelease := make(chan struct{})
+				releaseWrite := sync.OnceFunc(func() { close(writeRelease) })
+				defer releaseWrite()
+				writeErr := error(nil)
+				if test.trigger == "writer" {
+					writeErr = errors.New("scripted write failure")
+				}
+				conn.planWrite(wsSessionWritePlan{entered: writeEntered, release: writeRelease, err: writeErr})
+
+				session := newWSTraceSession(parent, conn, "en", 1)
+				traceStarted, traceExited := startBlockingWSTrace(session, nil)
+				traceCtx := <-traceStarted
+				<-conn.readerStarted
+
+				if err := session.send(wsEnvelope{Type: "in_flight"}); err != nil {
+					t.Fatalf("send in-flight message: %v", err)
+				}
+				<-writeEntered
+				if err := session.send(wsEnvelope{Type: "queued"}); err != nil {
+					t.Fatalf("send queued message: %v", err)
+				}
+
+				switch test.trigger {
+				case "slow":
+					err := session.send(wsEnvelope{Type: "overflow"})
+					if !errors.Is(err, errWSSlowConsumer) {
+						t.Fatalf("overflow error = %v, want errWSSlowConsumer", err)
+					}
+				case "reader":
+					conn.failRead(errors.New("scripted read failure"))
+				case "writer":
+					releaseWrite()
+				case "parent":
+					cancelParent()
+				default:
+					t.Fatalf("unknown trigger %q", test.trigger)
+				}
+
+				synctest.Wait()
+				if !errors.Is(traceCtx.Err(), context.Canceled) {
+					t.Fatalf("trace context error = %v, want context.Canceled", traceCtx.Err())
+				}
+				requireWSTestChannelClosed(t, traceExited, "trace worker")
+
+				finished := finishWSSessionAsync(session)
+				if test.trigger != "writer" {
+					synctest.Wait()
+					requireWSTestChannelOpen(t, finished, "finish result before in-flight write exits")
+					releaseWrite()
+				}
+				<-finished
+				synctest.Wait()
+
+				if err := session.send(wsEnvelope{Type: "after_close"}); !errors.Is(err, errWSSessionClosed) {
+					t.Fatalf("send after termination = %v, want errWSSessionClosed", err)
+				}
+				requireWSTestChannelClosed(t, conn.readerExited, "reader")
+				writes, frames, closeCalls, maxWriters := conn.snapshot()
+				if test.trigger == "writer" {
+					requireWSTestEnvelopeTypes(t, writes)
+				} else {
+					requireWSTestEnvelopeTypes(t, writes, "in_flight")
+				}
+				if test.wantCode == 0 {
+					if len(frames) != 0 {
+						t.Fatalf("parent cancellation wrote close frames: %#v", frames)
+					}
+				} else if len(frames) != 1 || frames[0].code != test.wantCode || frames[0].reason != test.wantReason {
+					t.Fatalf("close frames = %#v, want one code=%d reason=%q", frames, test.wantCode, test.wantReason)
+				}
+				if closeCalls != 1 {
+					t.Fatalf("Close calls = %d, want 1", closeCalls)
+				}
+				if maxWriters != 1 {
+					t.Fatalf("maximum concurrent writers = %d, want 1", maxWriters)
+				}
+			})
+		})
+	}
+}
+
+func TestWSTraceSessionSerializesDataAndCloseWrites(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn := newWSSessionTestConn()
+		writeEntered := make(chan struct{})
+		writeRelease := make(chan struct{})
+		conn.planWrite(wsSessionWritePlan{entered: writeEntered, release: writeRelease})
+
+		session := newWSTraceSession(t.Context(), conn, "en", 2)
+		if err := session.send(wsEnvelope{Type: "in_flight"}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		<-writeEntered
+
+		session.closeWithCode(websocket.CloseInternalServerErr, "forced close")
+		synctest.Wait()
+		_, frames, _, maxWriters := conn.snapshot()
+		if len(frames) != 0 {
+			t.Fatalf("close control overtook blocked data write: %#v", frames)
+		}
+		if maxWriters != 1 {
+			t.Fatalf("maximum concurrent writers while blocked = %d, want 1", maxWriters)
+		}
+
+		finished := finishWSSessionAsync(session)
+		close(writeRelease)
+		<-finished
+		synctest.Wait()
+
+		writes, frames, closeCalls, maxWriters := conn.snapshot()
+		requireWSTestEnvelopeTypes(t, writes, "in_flight")
+		if len(frames) != 1 || frames[0].code != websocket.CloseInternalServerErr || frames[0].reason != "forced close" {
+			t.Fatalf("close frames = %#v, want one serialized forced-close frame", frames)
+		}
+		if closeCalls != 1 {
+			t.Fatalf("Close calls = %d, want 1", closeCalls)
+		}
+		if maxWriters != 1 {
+			t.Fatalf("maximum concurrent writers = %d, want 1", maxWriters)
+		}
+	})
+}
+
+func TestWSTraceSessionConcurrentFinishAndCloseIsIdempotent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn := newWSSessionTestConn()
+		writeEntered := make(chan struct{})
+		writeRelease := make(chan struct{})
+		conn.planWrite(wsSessionWritePlan{entered: writeEntered, release: writeRelease})
+
+		session := newWSTraceSession(t.Context(), conn, "en", 2)
+		if err := session.send(wsEnvelope{Type: "in_flight"}); err != nil {
+			t.Fatalf("send in-flight: %v", err)
+		}
+		<-writeEntered
+		if err := session.send(wsEnvelope{Type: "queued"}); err != nil {
+			t.Fatalf("send queued: %v", err)
+		}
+
+		start := make(chan struct{})
+		var callers sync.WaitGroup
+		for range 4 {
+			callers.Go(func() {
+				<-start
+				session.finish()
+			})
+			callers.Go(func() {
+				<-start
+				session.closeWithCode(websocket.CloseTryAgainLater, "forced race")
+			})
+		}
+		close(start)
+		synctest.Wait()
+		close(writeRelease)
+		callers.Wait()
+		synctest.Wait()
+
+		writes, frames, closeCalls, maxWriters := conn.snapshot()
+		if len(frames) == 0 {
+			requireWSTestEnvelopeTypes(t, writes, "in_flight", "queued")
+		} else {
+			if len(frames) != 1 || frames[0].code != websocket.CloseTryAgainLater || frames[0].reason != "forced race" {
+				t.Fatalf("close frames = %#v, want one forced-race frame", frames)
+			}
+			requireWSTestEnvelopeTypes(t, writes, "in_flight")
+		}
+		if closeCalls != 1 {
+			t.Fatalf("Close calls = %d, want 1", closeCalls)
+		}
+		if maxWriters != 1 {
+			t.Fatalf("maximum concurrent writers = %d, want 1", maxWriters)
+		}
+
+		session.finish()
+		session.closeWithCode(websocket.CloseInternalServerErr, "late close")
+		_, framesAfter, closeCallsAfter, _ := conn.snapshot()
+		if len(framesAfter) != len(frames) || closeCallsAfter != closeCalls {
+			t.Fatalf("late termination changed close calls/frames: before=(%d,%d) after=(%d,%d)", closeCalls, len(frames), closeCallsAfter, len(framesAfter))
+		}
+	})
+}


### PR DESCRIPTION
## 问题

deploy 入站 WebSocket 的 reader、writer、trace 与连接关闭此前由不同路径分别管理：reader 是 detached goroutine，session 只等待 writer，正常完成、慢消费者、读写错误和 parent cancel 各自收尾。关闭交错依赖 `writeLoop` 的宽泛 panic recovery，data frame 与主动 close frame 也缺少统一 owner。

## 前后调用链

旧路径：

`handler -> read init -> detached reader/cancel -> create writer session -> trace on handler stack`

新路径：

`handler -> read init -> create session root -> reader/writer workers -> registered trace worker`

session 使用 `open -> draining/aborting -> closed` 状态机。正常完成由 writer 排空发送队列后关闭；异常完成先取消 trace、丢弃尚未开始写的尾队列，再由 writer 串行发送主动 close frame 并关闭连接。

## 变更

- init JSON 读取成功后立即建立 `context.WithCancelCause` 根 context。
- session 统一登记 reader、writer 和 trace worker，并在结束时 join。
- slow consumer、reader error、writer error、parent cancel 进入同一幂等终止路径。
- 会话主动发出的 `WriteJSON`、close frame 和会话期 `Close` 由 writer 串行执行；Gorilla 在读调用内自动发送的 control frame 继续依赖其并发安全保证。
- 删除 `writeLoop` 的宽泛 panic recovery；仅在 trace worker 边界将未捕获 panic 转为 1011/internal error，避免越过 Gin recovery 终止进程。
- 增加 `testing/synctest` 交错测试及真实 Gorilla 65,536/65,537 字节首帧边界测试。
- 增加 [Go 1.27 deploy WebSocket 会话生命周期证据](https://github.com/nxtrace/NTrace-dev/blob/codex/own-deploy-ws-session/docs/performance/go127-deploy-ws-session.md)。

## 兼容性

- JSON schema、字段顺序、消息顺序、CLI、REST、MCP、导出 API 与三 flavor 依赖边界不变。
- reader error、slow consumer、writer error 分别保持 close code 1000、1013、1011 及原 reason。
- trace worker panic 使用 1011/internal error，不向客户端泄露 panic 内容；首次终止 cause 仍优先。
- parent cancel 仍不新增 close frame。
- 既有 64 KiB init 首帧上限不改值；仅补真实边界验证。
- 既有 MTR `path_end -> mtr_raw -> path_end(null) -> complete` 合同保持不变。

## 测试与门禁

本地 exact head：`fab0aa6eefdcc721096e5655aca54fa517bd72e3`

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`
- 定向生命周期测试 100 次及定向 race 20 次
- `go build ./...`
- `go vet ./...`
- default/nojsonv2 下 tiny、ntr 专项测试与构建
- `node --test server/web/assets/*.test.cjs`：15/15
- `go mod verify`、`go mod tidy` 幂等
- `golangci-lint v2.13.2 --new-from-rev main`：0 个新增问题
- Linux/Windows/Darwin，amd64/arm64，三 flavor：18/18 构建通过
- Darwin 6 个产物：`LC_BUILD_VERSION minos 13.0`

仓库无范围限制的 `golangci-lint run` 仍报告 78 个既存问题；CI 使用 `only-new-issues`，本 PR 未修改或掩盖这些基线问题。

## Benchmark

环境：Apple M5 / 10 核 / 32 GB / AC；macOS 26.6.2；Go 1.27.1；`GOEXPERIMENT=nojsonv2`；`GOMAXPROCS=10`。

完整 harness 的顺序 10 次测量出现 WS JSON marshal `+2.55%`，但本 PR 未修改 JSON 路径，且同轮未改模块存在双向漂移。按门槛规则预编译 parent/head 并奇偶反转顺序交替采样 20 次后：

| Benchmark | parent | head | benchstat | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| WS JSON marshal | 472.9 ns | 471.6 ns | 不显著，`p=0.743` | 416 -> 416 | 2 -> 2 |
| WS JSON unmarshal | 2.357 us | 2.369 us | 不显著，`p=0.606` | 656 -> 656 | 15 -> 15 |
| geomean | 1.056 us | 1.057 us | +0.11% | 不变 | 不变 |

现有 harness 没有生命周期微基准；该路径的正确性由 synctest、worker join 和 race 验证。WS JSON 只作编解码与分配交叉回归。

## Profile 与大小

- parent/head 各采集 30 秒 WS JSON marshal CPU/heap profile。该 profile 不执行生命周期状态机，只验证 JSON 路径；exact source head 单次为 473.8 ns/op，heap alloc-space 中约 84.8% 来自 `encoding/json.Marshal`，每次仍为 416 B、2 allocs。
- stripped Darwin arm64：
  - nexttrace：30,126,690 -> 30,126,706 B（+16 B）
  - nexttrace-tiny：11,050,018 -> 11,050,018 B
  - ntr：11,050,018 -> 11,050,018 B
- 同配置全仓测试：23.46 -> 25.76 秒；峰值 RSS：448,102,400 -> 434,044,928 B。只记录完成成本，不解释为性能改善。

## 平台风险

重点风险是 normal drain 与 reader/parent cancel 的竞争、blocked write 期间的 abort、trace panic，以及 `WaitGroup.Go` 登记和最终 `Wait` 的顺序。生产路径在调用 `finish` 前完成 trace 登记；状态锁、根 context、5 秒 write deadline、窄 worker recovery、synctest 与 race 覆盖这些边界。没有新增平台 API，Darwin 最低版本仍为 macOS 13.0。

## 回退

可整体撤销本 PR 的生命周期实现、合同测试和证据文档。没有配置、JSON、协议、持久数据或导出 API 迁移，不需要数据处理。

## Commit 列表

- `6aa983f refactor(server): 统一 deploy WebSocket 会话生命周期`
- `c098446 test(server): 锁定 WebSocket 会话终止与首帧边界`
- `c8aad29 docs(server): 记录 deploy WebSocket 会话证据`
- `9ba52ea fix(server): 隔离 WebSocket trace worker panic`
- `fab0aa6 docs(server): 刷新 WebSocket exact-head 证据`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - WebSocket 会话支持正常排空、异常中止和安全关闭，提升连接结束时的处理一致性。
  - 初始化消息继续支持最大 64 KiB；超出限制的消息将被拒绝。

- **稳定性改进**
  - 改善并发读写、取消和关闭处理，减少异常会话及资源未释放问题。
  - Trace 处理异常时将安全关闭连接并返回内部错误。

- **测试**
  - 新增会话生命周期、并发写入、异常终止及初始化消息大小边界测试。

- **文档**
  - 新增 WebSocket 会话生命周期与性能验证说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->