### PR TITLE
refactor(mtr): 统一 worker 生命周期与 generation 取消

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -291,6 +291,16 @@ jobs:
           PERF_RESULT_DIR: ${{ runner.temp }}/performance-evidence/head
         run: bash scripts/perf/profile_benchmark.sh ./trace BenchmarkMTRAggregatorSnapshot64TTL4Paths head-mtr
 
+      - name: Profile head MTR worker lifecycle
+        id: head_goroutine_profile
+        continue-on-error: true
+        shell: bash
+        env:
+          GOTOOLCHAIN: go1.27.1
+          MTR_GOROUTINE_ACTIVE_PROFILE: ${{ runner.temp }}/performance-evidence/head/head-mtr-workers-active.goroutine.pprof
+          MTR_GOROUTINE_LEAK_PROFILE: ${{ runner.temp }}/performance-evidence/head/head-mtr-workers-final.goroutine.pprof
+        run: go test -count=1 -run '^(TestMTRSchedulerJoinsSessionListener|TestMTRWorkerGoroutineProfileCarriesOwnerLabel)$' ./trace
+
       - name: Build head binaries
         id: head_build
         continue-on-error: true
@@ -366,6 +376,7 @@ jobs:
           HEAD_BENCH_OUTCOME: ${{ steps.head_bench.outcome }}
           HEAD_TESTS_OUTCOME: ${{ steps.head_tests.outcome }}
           HEAD_PROFILE_OUTCOME: ${{ steps.head_profile.outcome }}
+          HEAD_GOROUTINE_PROFILE_OUTCOME: ${{ steps.head_goroutine_profile.outcome }}
           HEAD_BUILD_OUTCOME: ${{ steps.head_build.outcome }}
           BENCHSTAT_OUTCOME: ${{ steps.benchstat.outcome }}
         run: |
@@ -393,6 +404,7 @@ jobs:
           require_success "head benchmark" "${HEAD_BENCH_OUTCOME}"
           require_success "head tests" "${HEAD_TESTS_OUTCOME}"
           require_success "head profile" "${HEAD_PROFILE_OUTCOME}"
+          require_success "head goroutine profile" "${HEAD_GOROUTINE_PROFILE_OUTCOME}"
           require_success "head binary build" "${HEAD_BUILD_OUTCOME}"
           require_success "benchstat" "${BENCHSTAT_OUTCOME}"
 
@@ -401,6 +413,8 @@ jobs:
           require_file "${evidence_dir}/head/tests.time.txt"
           require_file "${evidence_dir}/head/head-mtr.cpu.pprof"
           require_file "${evidence_dir}/head/head-mtr.heap.pprof"
+          require_file "${evidence_dir}/head/head-mtr-workers-active.goroutine.pprof"
+          require_file "${evidence_dir}/head/head-mtr-workers-final.goroutine.pprof"
           require_file "${evidence_dir}/head/sizes.tsv"
           require_file "${evidence_dir}/head/binaries/nexttrace"
           require_file "${evidence_dir}/head/binaries/nexttrace-tiny"

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -673,6 +673,23 @@ func TestMTRUI_ConsumeRestartRequest(t *testing.T) {
 	_ = ctx // suppress unused
 }
 
+func TestMTRUI_ReadKeysFromInjectedReader(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ui := &mtrUI{isTTY: true, cancel: cancel}
+
+	ui.readKeysLoop(ctx, bytes.NewReader([]byte{'p', 'r', ' ', 'q'}))
+
+	if ui.IsPaused() {
+		t.Fatal("resume key did not clear the paused state")
+	}
+	if !ui.ConsumeRestartRequest() {
+		t.Fatal("restart key was not recorded")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("quit key did not cancel the session")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // 显示模式切换测试
 // ---------------------------------------------------------------------------

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -677,14 +677,20 @@ func TestMTRUI_ReadKeysFromInjectedReader(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ui := &mtrUI{isTTY: true, cancel: cancel}
 
-	ui.readKeysLoop(ctx, bytes.NewReader([]byte{'p', 'r', ' ', 'q'}))
+	ui.readKeysLoop(ctx, bytes.NewReader([]byte{'p'}))
+	if !ui.IsPaused() {
+		t.Fatal("pause key did not set the paused state")
+	}
 
+	ui.readKeysLoop(ctx, bytes.NewReader([]byte{'r', ' '}))
 	if ui.IsPaused() {
 		t.Fatal("resume key did not clear the paused state")
 	}
 	if !ui.ConsumeRestartRequest() {
 		t.Fatal("restart key was not recorded")
 	}
+
+	ui.readKeysLoop(ctx, bytes.NewReader([]byte{'q'}))
 	if ctx.Err() == nil {
 		t.Fatal("quit key did not cancel the session")
 	}

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -385,6 +385,10 @@ func (u *mtrUI) ReadKeysLoop(ctx context.Context) {
 	if !u.isTTY {
 		return
 	}
+	u.readKeysLoop(ctx, os.Stdin)
+}
+
+func (u *mtrUI) readKeysLoop(ctx context.Context, input io.Reader) {
 	var parser mtrInputParser
 	buf := make([]byte, 64) // 批量读取，减少 syscall
 	for {
@@ -393,7 +397,7 @@ func (u *mtrUI) ReadKeysLoop(ctx context.Context) {
 			return
 		default:
 		}
-		n, err := os.Stdin.Read(buf)
+		n, err := input.Read(buf)
 		if err != nil || n == 0 {
 			if err == io.EOF {
 				return

--- a/docs/performance/go127-mtr-worker-lifecycle.md
+++ b/docs/performance/go127-mtr-worker-lifecycle.md
@@ -23,7 +23,7 @@ CLI flags、输出、JSON schema、MTR 统计、协议包布局、导出 API 和
 | 项目 | 值 |
 | --- | --- |
 | parent | `74546d01fe4c50ae3da0dbd1215398017faf955e` |
-| benchmark/profile source head | `97439fe664934dbe00bdffb06bcb318759409fa1` |
+| exact measured code head | `7be9fe5812f17d8a4dd10f40d1c21210cc26e462` |
 | 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
 | 系统 | macOS 26.6.2，darwin/arm64 |
 | 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
@@ -84,19 +84,21 @@ context 与 timeout。本轮保持该既有外部合同，不宣称能回收违�
 
 ## Benchmark
 
-parent/source head 先使用完整 Go 1.27.1 `nojsonv2` harness 各顺序运行 10 次。MTR 聚合器时间
-指标在长跑中出现约 1%--2% 的同向漂移，因此按门槛规则独立补到 20 次；最终结果如下：
+parent 与实现 head `97439fe` 先使用完整 Go 1.27.1 `nojsonv2` harness 各顺序运行 10 次。
+review 修复完成后，预编译 parent 与 exact head `7be9fe5` 的 trace test binary，并按奇偶轮交换
+先后顺序交替采样 20 次，避免长跑温度和执行顺序偏差。最终 exact-head 结果如下：
 
-| Benchmark | parent | source head | 变化 | B/op | allocs/op |
+| Benchmark | parent | exact head | benchstat | B/op | allocs/op |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| MTR Update 64x4 | 46.30 us | 46.61 us | +0.66% | 143,360 -> 143,360 | 834 -> 834 |
-| MTR Clone 64x4 | 438.6 ns | 437.0 ns | 不显著，`p=0.223` | 3,408 -> 3,408 | 4 -> 4 |
-| MTR Snapshot 64x4 | 6.472 us | 6.513 us | +0.63% | 49,152 -> 49,152 | 257 -> 257 |
-| MTR preview COW 64x4 | 12.15 us | 12.03 us | -0.96% | 97,008 -> 97,008 | 283 -> 283 |
-| geomean | 6.321 us | 6.320 us | -0.01% | 39,064 -> 39,064 | 124.8 -> 124.8 |
+| MTR Update 64x4 | 47.67 us | 48.05 us | 不显著，`p=0.529` | 143,360 -> 143,360 | 834 -> 834 |
+| MTR Clone 64x4 | 445.6 ns | 451.4 ns | 不显著，`p=0.387` | 3,408 -> 3,408 | 4 -> 4 |
+| MTR Snapshot 64x4 | 6.478 us | 6.654 us | 不显著，`p=0.242` | 49,152 -> 49,152 | 257 -> 257 |
+| MTR preview COW 64x4 | 12.16 us | 12.55 us | 不显著，`p=0.149` | 97,008 -> 97,008 | 283 -> 283 |
+| geomean | 6.396 us | 6.523 us | +1.98% | 39,064 -> 39,064 | 124.8 -> 124.8 |
 
-四项均在 1% 时间门槛内，分配完全不变。生命周期自身以取消、join、race 和 goroutine profile
-验证；现有 harness 没有执行真实网络 worker 生命周期的稳定微基准。
+四项在 20 次校准后均未检出显著时间差异，分配完全不变；geomean 只记录各项中位数的几何
+平均，不单独提供显著性判断。生命周期自身以取消、join、race 和 goroutine profile 验证；
+现有 harness 没有执行真实网络 worker 生命周期的稳定微基准。
 
 完整 harness 中未修改路径也出现纳秒级越线项，均补到 20 次：GeoFeed parse `+0.82%`、IPv4
 prefix-map `-5.89%`、MTU decoder 包级 geomean `+0.36%`、Geo HTTP client construct 无显著
@@ -107,24 +109,25 @@ miss 为 45.30 ns -> 46.26 ns（`+2.14%`），但 `trace/cache.go` 无 diff，`g
 
 ## Profile
 
-parent/source head 对相同 `BenchmarkMTRAggregatorSnapshot64TTL4Paths` 各采集 30 秒 CPU 与 heap
+parent/exact head 对相同 `BenchmarkMTRAggregatorSnapshot64TTL4Paths` 各采集 30 秒 CPU 与 heap
 profile：
 
-| 指标 | parent | source head |
+| 指标 | parent | exact head |
 | --- | ---: | ---: |
-| ns/op | 6.282 us | 6.292 us |
+| ns/op | 6.282 us | 6.694 us |
 | B/op | 49,152 | 49,152 |
 | allocs/op | 257 | 257 |
 
 两侧 CPU top 都由 Darwin runtime wait、GC 与系统调用构成，没有新增业务热点。heap alloc-space
-均全部归于 `trace.cloneMTRStats`；该 benchmark 不执行 session 生命周期，仅作全局交叉回归。
+均全部归于 `trace.cloneMTRStats`；profile 单次吞吐不用于性能门槛判断，该 benchmark 也不执行
+session 生命周期，仅作全局交叉回归。
 
 ## 产物大小与测试耗时
 
 Darwin arm64 产物使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`，并以相同
 UPX `--force-macos -9` 压缩：
 
-| Flavor | parent 未压缩 | source head 未压缩 | parent UPX | source head UPX |
+| Flavor | parent 未压缩 | exact head 未压缩 | parent UPX | exact head UPX |
 | --- | ---: | ---: | ---: | ---: |
 | nexttrace | 30,126,706 B | 30,143,250 B | 10,141,712 B | 10,141,712 B |
 | nexttrace-tiny | 11,050,018 B | 11,066,562 B | 4,259,856 B | 4,276,240 B |
@@ -133,8 +136,9 @@ UPX `--force-macos -9` 压缩：
 未压缩均增加 16,544 B；完整版 UPX 后不变，tiny/ntr UPX 后各增加 16,384 B。增长来自统一
 session 与 owner label 代码，没有新增依赖。
 
-同配置、预热缓存后的 `go test -count=1 ./...` 墙钟为 parent 24.21 秒、source head 23.87 秒；
-只记录完成成本，不解释为性能改善。
+同配置、预热缓存后的 `go test -count=1 ./...` 墙钟为 parent 24.21 秒、初始实现 head 23.87 秒；
+exact measured code head 另通过完整 default/nojsonv2、race 与跨平台门禁，只记录完成成本，不解释
+为性能改善。
 
 ## 平台风险与回退
 

--- a/docs/performance/go127-mtr-worker-lifecycle.md
+++ b/docs/performance/go127-mtr-worker-lifecycle.md
@@ -6,8 +6,9 @@
 
 - scheduler、preview、legacy raw round、probe、Geo/PTR metadata 和 ICMP listener 全部登记到
   session 根 context 与同一 `WaitGroup`。
-- reset 只取消旧 generation，旧 probe 和 metadata 结果无法进入新 generation；最终 shutdown
-  固定执行“取消根 context -> 关闭 prober/listener -> 等待 worker”。
+- reset 只取消旧 generation，旧 probe 和 metadata 结果无法进入新 generation；旧 probe 退出前
+  仍占用全局并发容量，避免连续 reset 暂时超过 `ParallelRequests`。最终 shutdown 固定执行
+  “取消根 context -> 关闭 prober/listener -> 等待 worker”。
 - 所有结果发送同时监听 root/generation cancellation；生产 MTR 路径不再使用循环
   `time.After` 或独立 context watcher。
 - worker 使用 `pprof` 的 `owner` label；active goroutine profile 能定位 `mtr.probe`，最终
@@ -49,8 +50,9 @@ worker 没有统一取消与登记；shutdown 中存在先等待 worker、再关
 
 session 是唯一 worker owner。scheduler 启动时把 prober 与 ICMP listener 注册到同一 session；
 probe、同步/异步 metadata、preview 和 legacy raw round 通过 `session.Go(owner, fn)` 启动。
-reset 先取消旧 generation，再清空调度状态并建立新 generation；旧结果在发送和消费两侧都校验
-generation。最终退出由 session 先取消根 context、关闭资源以解除 I/O，再等待全部 worker。
+reset 先取消旧 generation，再清空该 generation 的 hop 状态并建立新 generation；旧结果在消费
+侧丢弃业务数据，但 worker completion 仍释放跨 generation 的全局并发账本。最终退出由 session
+先取消根 context、关闭资源以解除 I/O，再等待全部 worker。
 
 ICMP listener 首次启动和 seq 回卷后的轮换都登记为 `mtr.icmp-listener`。engine 的 spec 使用
 typed atomic pointer，echo ID 使用 typed atomic，关闭通过 swap-to-nil 串行化，避免 listener
@@ -61,6 +63,7 @@ typed atomic pointer，echo ID 使用 typed atomic，关闭通过 swap-to-nil �
 定向测试覆盖：
 
 - reset 取消旧 probe generation，只有新 generation 结果计入统计；
+- 取消中的旧 probe 退出前仍占用全局容量，新 generation 不会超过 `ParallelRequests`；
 - shutdown 必须先关闭 prober，再等待被其解除阻塞的 worker；
 - initial/rotated listener 与 preview worker 都由 session join；
 - probe、Geo/PTR metadata 与 raw round 发送在 root/generation 取消后可立即退出；
@@ -135,9 +138,10 @@ session 与 owner label 代码，没有新增依赖。
 
 ## 平台风险与回退
 
-主要风险是 reset 与在途结果竞争、listener 轮换期间关闭 spec、shutdown 的 close/wait 顺序，以及
-外部自定义 Source 不履行 timeout。generation 双侧校验、typed atomic、统一 session owner、
-100/1,000 次压力、race 和 active/final goroutine profile 覆盖这些边界。
+主要风险是 reset 与在途结果竞争、跨 generation 全局并发账本、listener 轮换期间关闭 spec、
+shutdown 的 close/wait 顺序，以及外部自定义 Source 不履行 timeout。generation 结果过滤、
+worker completion 账本、typed atomic、统一 session owner、100/1,000 次压力、race 和
+active/final goroutine profile 覆盖这些边界。
 
 Darwin 最低版本保持 macOS 13.0，没有新增平台 API。Windows/Linux 仍使用原有 prober 与 listener
 实现，只有外围 owner 与取消顺序变化。

--- a/docs/performance/go127-mtr-worker-lifecycle.md
+++ b/docs/performance/go127-mtr-worker-lifecycle.md
@@ -1,0 +1,147 @@
+# Go 1.27 MTR worker 生命周期证据
+
+## 范围与结论
+
+本轮只统一 active trace MTR 的 worker 所有权与 shutdown 顺序：
+
+- scheduler、preview、legacy raw round、probe、Geo/PTR metadata 和 ICMP listener 全部登记到
+  session 根 context 与同一 `WaitGroup`。
+- reset 只取消旧 generation，旧 probe 和 metadata 结果无法进入新 generation；最终 shutdown
+  固定执行“取消根 context -> 关闭 prober/listener -> 等待 worker”。
+- 所有结果发送同时监听 root/generation cancellation；生产 MTR 路径不再使用循环
+  `time.After` 或独立 context watcher。
+- worker 使用 `pprof` 的 `owner` label；active goroutine profile 能定位 `mtr.probe`，最终
+  profile 不残留任何 `mtr.*` owner。
+- TUI 进程级阻塞 stdin reader 仍不纳入 session；新增注入式 reader seam 只用于验证
+  pause/resume/reset/quit，终端输入语义不变。
+
+CLI flags、输出、JSON schema、MTR 统计、协议包布局、导出 API 和三 flavor 依赖边界均不变。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `74546d01fe4c50ae3da0dbd1215398017faf955e` |
+| benchmark/profile source head | `97439fe664934dbe00bdffb06bcb318759409fa1` |
+| 主机 | Apple M5，10 核，32 GB 内存，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每次 1 秒；完整 harness 10 次，越线项 20 次 |
+| profile | `GOMAXPROCS=10`，MTR Snapshot 30 秒；worker goroutine raw profile |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+
+证据提交只加入本文档，不改变被测 Go 行为、fixture 或 benchmark harness。PR 性能工作流会在
+exact head 生成 active/final goroutine profile，并另存 Linux cross-reference artifact。
+
+## 调用链变化
+
+### 旧路径
+
+`RunMTR -> scheduler/loop -> detached probe/metadata/preview/listener goroutines`
+
+不同路径各自启动 goroutine、持有 context 或等待结果。reset 依赖 generation 数值过滤，但旧
+worker 没有统一取消与登记；shutdown 中存在先等待 worker、再关闭可解除阻塞的 prober/listener
+的环形依赖风险。部分间隔使用 `time.After`，取消后 timer 不能主动停止。
+
+### 新路径
+
+`RunMTR -> mtrWorkerSession(root) -> generation -> registered workers -> cancel/close/wait`
+
+session 是唯一 worker owner。scheduler 启动时把 prober 与 ICMP listener 注册到同一 session；
+probe、同步/异步 metadata、preview 和 legacy raw round 通过 `session.Go(owner, fn)` 启动。
+reset 先取消旧 generation，再清空调度状态并建立新 generation；旧结果在发送和消费两侧都校验
+generation。最终退出由 session 先取消根 context、关闭资源以解除 I/O，再等待全部 worker。
+
+ICMP listener 首次启动和 seq 回卷后的轮换都登记为 `mtr.icmp-listener`。engine 的 spec 使用
+typed atomic pointer，echo ID 使用 typed atomic，关闭通过 swap-to-nil 串行化，避免 listener
+轮换、发送与 shutdown 互相复制或竞态。
+
+## 生命周期与压力验证
+
+定向测试覆盖：
+
+- reset 取消旧 probe generation，只有新 generation 结果计入统计；
+- shutdown 必须先关闭 prober，再等待被其解除阻塞的 worker；
+- initial/rotated listener 与 preview worker 都由 session join；
+- probe、Geo/PTR metadata 与 raw round 发送在 root/generation 取消后可立即退出；
+- 注入式 TUI reader 的 pause、reset、resume、quit 顺序不变。
+
+结果：
+
+| 验证 | 结果 |
+| --- | --- |
+| 生命周期定向测试 | 100 次通过 |
+| reset generation stress | 1,000 次通过 |
+| 定向 race | 20 次通过 |
+| active raw goroutine profile | `owner=mtr.probe`，1/4 goroutine |
+| final raw goroutine profile | 无 `owner=mtr.*` label |
+
+Go 不能强制终止忽略 timeout/context 的外部自定义 `ipgeo.Source` 回调；内建 provider 已遵守
+context 与 timeout。本轮保持该既有外部合同，不宣称能回收违规回调内部自行创建的 goroutine。
+
+## Benchmark
+
+parent/source head 先使用完整 Go 1.27.1 `nojsonv2` harness 各顺序运行 10 次。MTR 聚合器时间
+指标在长跑中出现约 1%--2% 的同向漂移，因此按门槛规则独立补到 20 次；最终结果如下：
+
+| Benchmark | parent | source head | 变化 | B/op | allocs/op |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| MTR Update 64x4 | 46.30 us | 46.61 us | +0.66% | 143,360 -> 143,360 | 834 -> 834 |
+| MTR Clone 64x4 | 438.6 ns | 437.0 ns | 不显著，`p=0.223` | 3,408 -> 3,408 | 4 -> 4 |
+| MTR Snapshot 64x4 | 6.472 us | 6.513 us | +0.63% | 49,152 -> 49,152 | 257 -> 257 |
+| MTR preview COW 64x4 | 12.15 us | 12.03 us | -0.96% | 97,008 -> 97,008 | 283 -> 283 |
+| geomean | 6.321 us | 6.320 us | -0.01% | 39,064 -> 39,064 | 124.8 -> 124.8 |
+
+四项均在 1% 时间门槛内，分配完全不变。生命周期自身以取消、join、race 和 goroutine profile
+验证；现有 harness 没有执行真实网络 worker 生命周期的稳定微基准。
+
+完整 harness 中未修改路径也出现纳秒级越线项，均补到 20 次：GeoFeed parse `+0.82%`、IPv4
+prefix-map `-5.89%`、MTU decoder 包级 geomean `+0.36%`、Geo HTTP client construct 无显著
+差异；相同热状态下 UDPv6 decoder 为 parent 91.20 ns、head 91.17 ns，无显著差异。Geo cache
+miss 为 45.30 ns -> 46.26 ns（`+2.14%`），但 `trace/cache.go` 无 diff，`geoCacheRuntime.load`
+的低位对齐不变；新增生产代码和测试改变了 benchmark caller 在测试二进制中的位置。该结果
+作为布局敏感的未归因风险保留，不把它算作生命周期改善或回退。
+
+## Profile
+
+parent/source head 对相同 `BenchmarkMTRAggregatorSnapshot64TTL4Paths` 各采集 30 秒 CPU 与 heap
+profile：
+
+| 指标 | parent | source head |
+| --- | ---: | ---: |
+| ns/op | 6.282 us | 6.292 us |
+| B/op | 49,152 | 49,152 |
+| allocs/op | 257 | 257 |
+
+两侧 CPU top 都由 Darwin runtime wait、GC 与系统调用构成，没有新增业务热点。heap alloc-space
+均全部归于 `trace.cloneMTRStats`；该 benchmark 不执行 session 生命周期，仅作全局交叉回归。
+
+## 产物大小与测试耗时
+
+Darwin arm64 产物使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid='`，并以相同
+UPX `--force-macos -9` 压缩：
+
+| Flavor | parent 未压缩 | source head 未压缩 | parent UPX | source head UPX |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 30,126,706 B | 30,143,250 B | 10,141,712 B | 10,141,712 B |
+| nexttrace-tiny | 11,050,018 B | 11,066,562 B | 4,259,856 B | 4,276,240 B |
+| ntr | 11,050,018 B | 11,066,562 B | 4,259,856 B | 4,276,240 B |
+
+未压缩均增加 16,544 B；完整版 UPX 后不变，tiny/ntr UPX 后各增加 16,384 B。增长来自统一
+session 与 owner label 代码，没有新增依赖。
+
+同配置、预热缓存后的 `go test -count=1 ./...` 墙钟为 parent 24.21 秒、source head 23.87 秒；
+只记录完成成本，不解释为性能改善。
+
+## 平台风险与回退
+
+主要风险是 reset 与在途结果竞争、listener 轮换期间关闭 spec、shutdown 的 close/wait 顺序，以及
+外部自定义 Source 不履行 timeout。generation 双侧校验、typed atomic、统一 session owner、
+100/1,000 次压力、race 和 active/final goroutine profile 覆盖这些边界。
+
+Darwin 最低版本保持 macOS 13.0，没有新增平台 API。Windows/Linux 仍使用原有 prober 与 listener
+实现，只有外围 owner 与取消顺序变化。
+
+如需回退，可撤销生命周期实现、合同测试、性能 workflow 和本文档。没有配置、JSON、协议、
+持久数据或导出 API 迁移；回退不需要数据处理。原始 benchmark、profile、测试日志和二进制
+不入库，由本地忽略目录及 CI artifact 保存。

--- a/trace/mtr_loop_runtime.go
+++ b/trace/mtr_loop_runtime.go
@@ -9,6 +9,7 @@ import (
 
 type mtrLoopRuntime struct {
 	ctx               context.Context
+	workers           *mtrWorkerSession
 	prober            mtrProber
 	config            Config
 	opts              MTROptions
@@ -23,7 +24,7 @@ type mtrLoopRuntime struct {
 }
 
 func newMTRLoopRuntime(
-	ctx context.Context,
+	workers *mtrWorkerSession,
 	prober mtrProber,
 	config Config,
 	opts MTROptions,
@@ -39,7 +40,8 @@ func newMTRLoopRuntime(
 		opts.ProgressThrottle = 200 * time.Millisecond
 	}
 	rt := &mtrLoopRuntime{
-		ctx:        ctx,
+		ctx:        workers.ctx,
+		workers:    workers,
 		prober:     prober,
 		config:     config,
 		opts:       opts,
@@ -157,32 +159,33 @@ func (rt *mtrLoopRuntime) runProbeRound() (*Result, error) {
 }
 
 func (rt *mtrLoopRuntime) runProbeRoundWithPreview(peeker mtrPeeker) (*Result, error) {
-	var (
-		res *Result
-		err error
-	)
-
-	done := make(chan struct{})
-	go func() {
-		res, err = rt.prober.probeRound(rt.ctx)
-		close(done)
-	}()
+	type probeRoundResult struct {
+		result *Result
+		err    error
+	}
+	done := make(chan probeRoundResult, 1)
+	rt.workers.Go("mtr.preview", func() {
+		res, err := rt.prober.probeRound(rt.ctx)
+		select {
+		case done <- probeRoundResult{result: res, err: err}:
+		case <-rt.ctx.Done():
+		}
+	})
 
 	ticker := time.NewTicker(rt.opts.ProgressThrottle)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-done:
-			return res, err
+		case result := <-done:
+			if rt.ctx.Err() != nil {
+				return nil, rt.ctx.Err()
+			}
+			return result.result, result.err
 		case <-ticker.C:
 			rt.emitPreview(peeker)
 		case <-rt.ctx.Done():
-			<-done
-			if err == nil && rt.ctx.Err() != nil {
-				err = rt.ctx.Err()
-			}
-			return res, err
+			return nil, rt.ctx.Err()
 		}
 	}
 }
@@ -232,7 +235,7 @@ func (rt *mtrLoopRuntime) waitBackoff() error {
 
 func (rt *mtrLoopRuntime) recordSuccess(res *Result) {
 	if rt.fillGeo {
-		mtrFillGeoRDNS(res, rt.config)
+		mtrFillGeoRDNS(rt.workers, res, rt.config)
 	}
 
 	rt.consecutiveErrors = 0

--- a/trace/mtr_raw.go
+++ b/trace/mtr_raw.go
@@ -97,11 +97,6 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 		if err != nil {
 			return fmt.Errorf("mtr raw: %w", err)
 		}
-		defer engine.close()
-		if err := engine.start(ctx); err != nil {
-			engine.close()
-			return fmt.Errorf("mtr raw: %w", err)
-		}
 		prober = engine
 	} else {
 		prober = &mtrFallbackTTLProber{method: method, config: roundCfg}
@@ -119,6 +114,7 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 		FillGeo:          true,
 		BaseConfig:       roundCfg,
 		OnPathEnd:        opts.OnPathEnd,
+		StartErrorPrefix: "mtr raw",
 	}, nil, func(result mtrProbeResult, iteration int, _ time.Time) {
 		if onRecord == nil {
 			return
@@ -130,6 +126,8 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 
 // runMTRRawRoundBased is the legacy round-based raw streaming path.
 func runMTRRawRoundBased(ctx context.Context, method Method, cfg Config, opts MTRRawOptions, onRecord MTRRawOnRecord) error {
+	session := newMTRWorkerSession(ctx)
+	defer session.shutdown(nil)
 	normalizeRuntimeConfig(&cfg)
 	if opts.Interval <= 0 {
 		opts.Interval = time.Second
@@ -189,31 +187,35 @@ func runMTRRawRoundBased(ctx context.Context, method Method, cfg Config, opts MT
 			}
 		}
 
-		done := make(chan struct{})
-		var traceErr error
-		var roundRes *Result
-		go func() {
-			roundRes, traceErr = runRound(method, cfgForRound)
-			close(done)
-		}()
+		type rawRoundResult struct {
+			result *Result
+			err    error
+		}
+		done := make(chan rawRoundResult, 1)
+		cfgForRound.Context = session.ctx
+		session.Go("mtr.raw-round", func() {
+			result, err := runRound(method, cfgForRound)
+			select {
+			case done <- rawRoundResult{result: result, err: err}:
+			case <-session.ctx.Done():
+			}
+		})
 
+		var completed rawRoundResult
 		select {
 		case <-ctx.Done():
-			// Wait for the in-flight round to finish before returning, so callers
-			// can safely release any per-round/global state after RunMTRRaw exits.
-			<-done
 			return ctx.Err()
-		case <-done:
+		case completed = <-done:
 		}
 
-		if traceErr != nil {
-			return traceErr
+		if completed.err != nil {
+			return completed.err
 		}
-		if roundRes != nil {
-			for ttl := range roundRes.responses {
-				pathTracker.observe(ttl, bestMTRProbeResponse(roundRes, ttl))
+		if completed.result != nil {
+			for ttl := range completed.result.responses {
+				pathTracker.observe(ttl, bestMTRProbeResponse(completed.result, ttl))
 			}
-			pathTracker.observeStopReason(roundRes.StopReason)
+			pathTracker.observeStopReason(completed.result.StopReason)
 		}
 
 		if opts.MaxRounds > 0 && iteration >= opts.MaxRounds {
@@ -221,10 +223,12 @@ func runMTRRawRoundBased(ctx context.Context, method Method, cfg Config, opts MT
 			return nil
 		}
 
+		timer := time.NewTimer(opts.Interval)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(opts.Interval):
+		case <-timer.C:
 		}
 	}
 }

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -137,11 +137,6 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		if err != nil {
 			return fmt.Errorf("mtr: %w", err)
 		}
-		defer engine.close()
-		if err := engine.start(ctx); err != nil {
-			engine.close()
-			return fmt.Errorf("mtr: %w", err)
-		}
 		prober = engine
 	} else {
 		prober = &mtrFallbackTTLProber{method: method, config: baseConfig, asyncMetadata: opts.AsyncMetadata}
@@ -161,6 +156,7 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		IsPaused:         opts.IsPaused,
 		IsResetRequested: opts.IsResetRequested,
 		OnPathEnd:        opts.OnPathEnd,
+		StartErrorPrefix: "mtr",
 	}, onSnapshot, mtrProbeCallbackFromOptions(opts))
 }
 
@@ -207,11 +203,6 @@ func runMTRRoundBased(ctx context.Context, method Method, baseConfig Config, opt
 		if err != nil {
 			return fmt.Errorf("mtr: %w", err)
 		}
-		defer engine.close()
-		if err := engine.start(ctx); err != nil {
-			engine.close()
-			return fmt.Errorf("mtr: %w", err)
-		}
 		return mtrLoop(ctx, engine, baseConfig, opts, agg, onSnapshot, true, nil)
 	}
 
@@ -234,14 +225,21 @@ func mtrLoop(
 	fillGeo bool,
 	bo *mtrBackoffCfg,
 ) error {
-	defer prober.close()
-	rt := newMTRLoopRuntime(ctx, prober, config, opts, agg, onSnapshot, fillGeo, bo)
+	session := newMTRWorkerSession(ctx)
+	defer session.shutdown(prober.close)
+	if starter, ok := prober.(mtrSessionStarter); ok {
+		if err := starter.startMTRSession(session); err != nil {
+			return fmt.Errorf("mtr: %w", err)
+		}
+	}
+	rt := newMTRLoopRuntime(session, prober, config, opts, agg, onSnapshot, fillGeo, bo)
 	return rt.run()
 }
 
 // mtrFillGeoRDNS 并发查询 Result 中各 hop 的地理信息与反向 DNS。
 // fetchIPData 内部有 singleflight + geoCache，重复 IP 不会重复查询。
-func mtrFillGeoRDNS(res *Result, config Config) {
+func mtrFillGeoRDNS(workers *mtrWorkerSession, res *Result, config Config) {
+	config.Context = workers.ctx
 	var wg sync.WaitGroup
 	for idx := range res.Hops {
 		for j := range res.Hops[idx] {
@@ -250,11 +248,13 @@ func mtrFillGeoRDNS(res *Result, config Config) {
 				continue
 			}
 			h.Lang = config.Lang
-			wg.Add(1)
-			go func(hop *Hop) {
+			hop := h
+			worker := func() {
 				defer wg.Done()
 				_ = hop.fetchIPData(config)
-			}(h)
+			}
+			wg.Add(1)
+			workers.Go("mtr.metadata.sync", worker)
 		}
 	}
 	wg.Wait()
@@ -265,11 +265,13 @@ func mtrFillGeoRDNS(res *Result, config Config) {
 // ---------------------------------------------------------------------------
 
 type mtrICMPEngine struct {
-	config Config
-	spec   *internal.ICMPSpec
-	echoID int
-	srcIP  net.IP
-	ipVer  int
+	config  Config
+	spec    atomic.Pointer[internal.ICMPSpec]
+	specMu  sync.Mutex
+	echoID  atomic.Int32
+	srcIP   net.IP
+	ipVer   int
+	workers *mtrWorkerSession
 
 	// 单调递增序列号，避免跨轮 seq 冲突
 	seqCounter atomic.Uint32
@@ -345,9 +347,9 @@ func newMTRICMPEngineState(config Config, ipVer int, srcIP net.IP) *mtrICMPEngin
 	engine := &mtrICMPEngine{
 		config: config,
 		ipVer:  ipVer,
-		echoID: newMTREchoID(),
 		srcIP:  srcIP,
 	}
+	engine.echoID.Store(int32(newMTREchoID()))
 	engine.knownFinalTTL.Store(-1)
 	engine.roundFinalTTL.Store(-1)
 	return engine
@@ -357,11 +359,16 @@ func newMTREchoID() int {
 	return (rand.IntN(256) << 8) | (os.Getpid() & 0xFF)
 }
 
-// start 创建持久 ICMP 套接字及监听协程。ctx 生命周期控制整个引擎。
-func (e *mtrICMPEngine) start(ctx context.Context) error {
-	e.spec = internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, e.echoID, e.srcIP, e.config.DstIP)
-	applyICMPSourceDevice(e.spec, e.config.OSType, e.config.SourceDevice)
-	e.spec.InitICMP()
+// startMTRSession 创建持久 ICMP 套接字，并把 listener 交给会话统一等待。
+func (e *mtrICMPEngine) startMTRSession(workers *mtrWorkerSession) error {
+	e.specMu.Lock()
+	defer e.specMu.Unlock()
+	e.workers = workers
+	ctx := workers.ctx
+	spec := internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, int(e.echoID.Load()), e.srcIP, e.config.DstIP)
+	applyICMPSourceDevice(spec, e.config.OSType, e.config.SourceDevice)
+	spec.InitICMP()
+	e.spec.Store(spec)
 
 	e.notifyCh = make(chan struct{}, 1)
 	e.sentAt = make(map[int]mtrProbeMeta)
@@ -369,25 +376,18 @@ func (e *mtrICMPEngine) start(ctx context.Context) error {
 	e.probeNotify = make(map[int]chan struct{})
 
 	ready := make(chan struct{})
-	go e.spec.ListenICMP(ctx, ready, e.onICMP)
-
-	select {
-	case <-ready:
-	case <-ctx.Done():
-		e.close()
-		return ctx.Err()
-	case <-time.After(5 * time.Second):
-		e.close()
-		return fmt.Errorf("ICMP listener startup timeout")
+	workers.Go("mtr.icmp-listener", func() { spec.ListenICMP(ctx, ready, e.onICMP) })
+	if err := waitMTRListenerReady(ctx, ready, "ICMP listener startup timeout"); err != nil {
+		return err
 	}
-	time.Sleep(100 * time.Millisecond)
-	return nil
+	return waitMTRTimer(ctx, 100*time.Millisecond)
 }
 
 func (e *mtrICMPEngine) close() {
-	if e.spec != nil {
-		e.spec.Close()
-		e.spec = nil
+	e.specMu.Lock()
+	defer e.specMu.Unlock()
+	if spec := e.spec.Swap(nil); spec != nil {
+		spec.Close()
 	}
 }
 
@@ -455,14 +455,19 @@ func seqWillWrap(seqCounter uint32, probeCount int) bool {
 // 新 listener 过滤新 echoID，旧 echoID 的迟到回包在协议层即被丢弃，
 // 从而彻底消除 seq 16 位回卷导致的跨轮误匹配。
 func (e *mtrICMPEngine) rotateEngine(ctx context.Context) error {
-	e.spec.Close()
+	e.specMu.Lock()
+	defer e.specMu.Unlock()
+	if spec := e.spec.Swap(nil); spec != nil {
+		spec.Close()
+	}
 
-	e.echoID = newMTREchoID()
+	e.echoID.Store(int32(newMTREchoID()))
 	e.seqCounter.Store(0)
 
-	e.spec = internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, e.echoID, e.srcIP, e.config.DstIP)
-	applyICMPSourceDevice(e.spec, e.config.OSType, e.config.SourceDevice)
-	e.spec.InitICMP()
+	spec := internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, int(e.echoID.Load()), e.srcIP, e.config.DstIP)
+	applyICMPSourceDevice(spec, e.config.OSType, e.config.SourceDevice)
+	spec.InitICMP()
+	e.spec.Store(spec)
 
 	e.mu.Lock()
 	// Notify any ProbeTTL waiters about rotation (they'll see no reply)
@@ -477,18 +482,35 @@ func (e *mtrICMPEngine) rotateEngine(ctx context.Context) error {
 	e.mu.Unlock()
 
 	ready := make(chan struct{})
-	go e.spec.ListenICMP(ctx, ready, e.onICMP)
+	if e.workers == nil {
+		return fmt.Errorf("ICMP listener has no MTR worker session")
+	}
+	e.workers.Go("mtr.icmp-listener", func() { spec.ListenICMP(ctx, ready, e.onICMP) })
+	return waitMTRListenerReady(ctx, ready, "ICMP listener restart timeout on echoID rotation")
+}
 
+func waitMTRListenerReady(ctx context.Context, ready <-chan struct{}, timeoutMessage string) error {
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 	select {
 	case <-ready:
+		return nil
 	case <-ctx.Done():
-		e.close()
 		return ctx.Err()
-	case <-time.After(5 * time.Second):
-		e.close()
-		return fmt.Errorf("ICMP listener restart timeout on echoID rotation")
+	case <-timer.C:
+		return fmt.Errorf("%s", timeoutMessage)
 	}
-	return nil
+}
+
+func waitMTRTimer(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // onICMP 是 ListenICMP 的回调：将响应匹配到已发送的探针。
@@ -598,6 +620,10 @@ func (e *mtrICMPEngine) signalReplyReady() {
 
 // sendProbe 发送一个 ICMP echo（IPv4 或 IPv6），返回发送时间戳。
 func (e *mtrICMPEngine) sendProbe(ctx context.Context, ttl, seq int) (time.Time, error) {
+	spec := e.spec.Load()
+	if spec == nil {
+		return time.Time{}, fmt.Errorf("ICMP listener is closed")
+	}
 	payloadSize := resolveProbePayloadSize(ICMPTrace, e.config.DstIP, e.config.PktSize, e.config.RandomPacketSize)
 	payload := make([]byte, payloadSize)
 	if len(payload) >= 3 {
@@ -615,10 +641,10 @@ func (e *mtrICMPEngine) sendProbe(ctx context.Context, ttl, seq int) (time.Time,
 		}
 		icmpHdr := &layers.ICMPv4{
 			TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
-			Id:       uint16(e.echoID),
+			Id:       uint16(e.echoID.Load()),
 			Seq:      uint16(seq),
 		}
-		return e.spec.SendICMP(ctx, ipHdr, icmpHdr, nil, payload)
+		return spec.SendICMP(ctx, ipHdr, icmpHdr, nil, payload)
 	}
 
 	// IPv6
@@ -637,10 +663,10 @@ func (e *mtrICMPEngine) sendProbe(ctx context.Context, ttl, seq int) (time.Time,
 		return time.Time{}, fmt.Errorf("SetNetworkLayerForChecksum: %w", err)
 	}
 	icmpEcho := &layers.ICMPv6Echo{
-		Identifier: uint16(e.echoID),
+		Identifier: uint16(e.echoID.Load()),
 		SeqNumber:  uint16(seq),
 	}
-	return e.spec.SendICMP(ctx, ipHdr, icmpHdr, icmpEcho, payload)
+	return spec.SendICMP(ctx, ipHdr, icmpHdr, icmpEcho, payload)
 }
 
 // probeRound 执行一轮持久探测：对每个 TTL 发送一个 ICMP echo，
@@ -795,21 +821,17 @@ func (e *mtrICMPEngine) sendProbeForTTL(ctx context.Context, ttl int, roundID ui
 }
 
 func (e *mtrICMPEngine) waitProbeInterval(ctx context.Context, delay time.Duration) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(delay):
-		return nil
-	}
+	return waitMTRTimer(ctx, delay)
 }
 
 func (e *mtrICMPEngine) waitForProbeReplies(ctx context.Context) {
-	deadline := time.After(e.probeResponseTimeout())
+	timer := time.NewTimer(e.probeResponseTimeout())
+	defer timer.Stop()
 	for e.hasPendingProbeReplies() {
 		select {
 		case <-ctx.Done():
 			return
-		case <-deadline:
+		case <-timer.C:
 			return
 		case <-e.notifyCh:
 		}

--- a/trace/mtr_runner_test.go
+++ b/trace/mtr_runner_test.go
@@ -1119,7 +1119,7 @@ func TestMTRLoopPreviewFiltersProvisionalPathWithoutClearingHigherStats(t *testi
 
 	var snapshots [][]MTRHopStat
 	peeker := &mockPeekerProber{peekFn: func() *Result { return full }}
-	rt := newMTRLoopRuntime(context.Background(), peeker, Config{MaxHops: 3}, MTROptions{}, agg, func(_ int, stats []MTRHopStat) {
+	rt := newMTRLoopRuntime(newMTRWorkerSession(context.Background()), peeker, Config{MaxHops: 3}, MTROptions{}, agg, func(_ int, stats []MTRHopStat) {
 		snapshots = append(snapshots, stats)
 	}, false, fastBackoff)
 

--- a/trace/mtr_scheduler.go
+++ b/trace/mtr_scheduler.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -49,6 +50,7 @@ type mtrSchedulerConfig struct {
 	AsyncMetadata     bool
 	BaseConfig        Config // used for geo/RDNS lookup
 	OnPathEnd         func(*StopReason)
+	StartErrorPrefix  string
 
 	IsPaused         func() bool
 	IsResetRequested func() bool
@@ -89,8 +91,17 @@ func runMTRScheduler(
 	onSnapshot MTROnSnapshot,
 	onProbe func(result mtrProbeResult, iteration int, at time.Time),
 ) error {
-	defer prober.Close()
-	rt, err := newMTRSchedulerRuntime(ctx, prober, agg, cfg, onSnapshot, onProbe)
+	session := newMTRWorkerSession(ctx)
+	defer session.shutdown(func() { _ = prober.Close() })
+	if starter, ok := prober.(mtrSessionStarter); ok {
+		if err := starter.startMTRSession(session); err != nil {
+			if cfg.StartErrorPrefix != "" {
+				return fmt.Errorf("%s: %w", cfg.StartErrorPrefix, err)
+			}
+			return err
+		}
+	}
+	rt, err := newMTRSchedulerRuntimeWithSession(session, prober, agg, cfg, onSnapshot, onProbe)
 	if err != nil {
 		return err
 	}

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -283,17 +283,16 @@ func (rt *mtrSchedulerRuntime) launchProbe(ttl int) {
 		}
 		select {
 		case rt.resultCh <- completed:
-		case <-generationCtx.Done():
 		case <-rt.ctx.Done():
 		}
 	})
 }
 
 func (rt *mtrSchedulerRuntime) processResult(cp mtrCompletedProbe) {
+	rt.inFlight--
 	if cp.gen != rt.generation {
 		return
 	}
-	rt.inFlight--
 	if cp.ttl < rt.beginHop || cp.ttl > rt.maxHops {
 		return
 	}
@@ -828,7 +827,6 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	for idx := range rt.states {
 		rt.states[idx] = mtrHopState{}
 	}
-	rt.inFlight = 0
 	clear(rt.metadataGeoInFlight)
 	clear(rt.metadataHostInFlight)
 	clear(rt.metadataCache)

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -35,9 +35,9 @@ var mtrMetadataNow = time.Now
 
 type mtrSchedulerRuntime struct {
 	ctx                  context.Context
-	metadataCtx          context.Context
-	metadataCancel       context.CancelFunc
-	doneCh               chan struct{}
+	workers              *mtrWorkerSession
+	generationCtx        context.Context
+	generationCancel     context.CancelFunc
 	prober               mtrTTLProber
 	agg                  *MTRAggregator
 	cfg                  mtrSchedulerConfig
@@ -83,6 +83,20 @@ func newMTRSchedulerRuntime(
 	onSnapshot MTROnSnapshot,
 	onProbe func(result mtrProbeResult, iteration int, at time.Time),
 ) (*mtrSchedulerRuntime, error) {
+	return newMTRSchedulerRuntimeWithSession(
+		newMTRWorkerSession(ctx), prober, agg, cfg, onSnapshot, onProbe,
+	)
+}
+
+func newMTRSchedulerRuntimeWithSession(
+	workers *mtrWorkerSession,
+	prober mtrTTLProber,
+	agg *MTRAggregator,
+	cfg mtrSchedulerConfig,
+	onSnapshot MTROnSnapshot,
+	onProbe func(result mtrProbeResult, iteration int, at time.Time),
+) (*mtrSchedulerRuntime, error) {
+	ctx := workers.ctx
 	beginHop := cfg.BeginHop
 	if beginHop <= 0 {
 		beginHop = 1
@@ -131,13 +145,13 @@ func newMTRSchedulerRuntime(
 		}
 	}
 
-	metadataCtx, metadataCancel := context.WithCancel(ctx)
+	generationCtx, generationCancel := context.WithCancel(ctx)
 
 	rt := &mtrSchedulerRuntime{
 		ctx:                  ctx,
-		metadataCtx:          metadataCtx,
-		metadataCancel:       metadataCancel,
-		doneCh:               make(chan struct{}),
+		workers:              workers,
+		generationCtx:        generationCtx,
+		generationCancel:     generationCancel,
 		prober:               prober,
 		agg:                  agg,
 		cfg:                  cfg,
@@ -169,9 +183,6 @@ func newMTRSchedulerRuntime(
 }
 
 func (rt *mtrSchedulerRuntime) run() error {
-	defer close(rt.doneCh)
-	defer rt.cancelMetadataLookups()
-
 	rt.scheduleReady()
 
 	tick := time.NewTicker(5 * time.Millisecond)
@@ -260,23 +271,29 @@ func (rt *mtrSchedulerRuntime) launchProbe(ttl int) {
 	rt.inFlight++
 
 	gen := rt.generation
-	go func() {
-		result, err := rt.prober.ProbeTTL(rt.ctx, ttl)
-		rt.resultCh <- mtrCompletedProbe{
+	generationCtx := rt.generationCtx
+	rt.workers.Go("mtr.probe", func() {
+		result, err := rt.prober.ProbeTTL(generationCtx, ttl)
+		completed := mtrCompletedProbe{
 			ttl:    ttl,
 			result: result,
 			gen:    gen,
 			doneAt: time.Now(),
 			err:    err,
 		}
-	}()
+		select {
+		case rt.resultCh <- completed:
+		case <-generationCtx.Done():
+		case <-rt.ctx.Done():
+		}
+	})
 }
 
 func (rt *mtrSchedulerRuntime) processResult(cp mtrCompletedProbe) {
-	rt.inFlight--
 	if cp.gen != rt.generation {
 		return
 	}
+	rt.inFlight--
 	if cp.ttl < rt.beginHop || cp.ttl > rt.maxHops {
 		return
 	}
@@ -363,7 +380,7 @@ func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResul
 	if rt.shouldFetchMetadataAsync(result) {
 		rt.maybeLaunchMetadataLookup(result)
 	} else if rt.cfg.FillGeo && result.Geo == nil {
-		mtrFillGeoRDNS(singleRes, rt.cfg.BaseConfig)
+		mtrFillGeoRDNS(rt.workers, singleRes, rt.cfg.BaseConfig)
 	}
 
 	rt.agg.Update(singleRes, 1)
@@ -411,10 +428,7 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 
 	gen := rt.generation
 	cfg := rt.cfg.BaseConfig
-	generationCtx := rt.metadataCtx
-	if generationCtx == nil {
-		generationCtx = rt.ctx
-	}
+	generationCtx := rt.generationCtx
 
 	rt.maybeLaunchGeoMetadataLookup(ip, result, cfg, generationCtx, gen, false)
 	rt.maybeLaunchHostMetadataLookup(ip, result, cfg, generationCtx, gen)
@@ -450,9 +464,11 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 	rt.metadataGeoInFlight[ip] = gen
 	rt.metadataGeoAttempts[ip]++
 	cfg.GeoLookupOffset = rt.metadataGeoAttempts[ip] - 1
-	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
-		return lookupMTRGeoMetadata(result.Addr, cfg, host)
-	}, cfg)
+	rt.workers.Go("mtr.metadata.geo", func() {
+		rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
+			return lookupMTRGeoMetadata(result.Addr, cfg, host)
+		}, cfg)
+	})
 }
 
 func (rt *mtrSchedulerRuntime) maybeLaunchHostMetadataLookup(ip string, result mtrProbeResult, cfg Config, generationCtx context.Context, gen uint64) {
@@ -468,9 +484,11 @@ func (rt *mtrSchedulerRuntime) maybeLaunchHostMetadataLookup(ip string, result m
 
 	rt.metadataHostInFlight[ip] = gen
 	rt.metadataHostAttempts[ip]++
-	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindHost, rt.metadataHostSlots, func(cfg Config) mtrMetadataPatch {
-		return lookupMTRHostMetadata(result.Addr, cfg)
-	}, cfg)
+	rt.workers.Go("mtr.metadata.ptr", func() {
+		rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindHost, rt.metadataHostSlots, func(cfg Config) mtrMetadataPatch {
+			return lookupMTRHostMetadata(result.Addr, cfg)
+		}, cfg)
+	})
 }
 
 func (rt *mtrSchedulerRuntime) runMetadataLookup(
@@ -496,7 +514,7 @@ func (rt *mtrSchedulerRuntime) runMetadataLookup(
 	select {
 	case rt.metadataCh <- mtrMetadataResult{patch: patch, kind: kind, gen: gen}:
 	case <-generationCtx.Done():
-	case <-rt.doneCh:
+	case <-rt.ctx.Done():
 	}
 }
 
@@ -506,7 +524,7 @@ func (rt *mtrSchedulerRuntime) acquireMetadataSlot(ctx context.Context, slots ch
 		return true
 	case <-ctx.Done():
 		return false
-	case <-rt.doneCh:
+	case <-rt.ctx.Done():
 		return false
 	}
 }
@@ -578,10 +596,7 @@ func (rt *mtrSchedulerRuntime) maybeLaunchDN42GeoAfterHostResult(result mtrMetad
 	if addrIP == nil {
 		return
 	}
-	generationCtx := rt.metadataCtx
-	if generationCtx == nil {
-		generationCtx = rt.ctx
-	}
+	generationCtx := rt.generationCtx
 	// Host lookup 结束后再允许 IP-only fallback：PTR 为空时仍补 Geo，
 	// PTR 成功时则用缓存的 host 发起 "ip,host" 查询。
 	rt.maybeLaunchGeoMetadataLookup(ip, mtrProbeResult{
@@ -601,10 +616,7 @@ func (rt *mtrSchedulerRuntime) maybeRetryMetadataLookup(result mtrMetadataResult
 		return
 	}
 	cfg := rt.cfg.BaseConfig
-	generationCtx := rt.metadataCtx
-	if generationCtx == nil {
-		generationCtx = rt.ctx
-	}
+	generationCtx := rt.generationCtx
 	cached := rt.metadataCache[ip]
 	retryResult := mtrProbeResult{
 		Addr:     &net.IPAddr{IP: addrIP},
@@ -809,13 +821,14 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	}
 
 	rt.generation++
-	rt.cancelMetadataLookups()
+	rt.generationCancel()
 	if rt.cfg.BaseConfig.RefreshIPGeoSource != nil {
 		rt.cfg.BaseConfig.RefreshIPGeoSource()
 	}
 	for idx := range rt.states {
 		rt.states[idx] = mtrHopState{}
 	}
+	rt.inFlight = 0
 	clear(rt.metadataGeoInFlight)
 	clear(rt.metadataHostInFlight)
 	clear(rt.metadataCache)
@@ -827,29 +840,10 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	rt.pathTracker.reset()
 	rt.agg.Reset()
 	_ = rt.prober.Reset()
-	rt.metadataCtx, rt.metadataCancel = context.WithCancel(rt.ctx)
-}
-
-func (rt *mtrSchedulerRuntime) cancelMetadataLookups() {
-	if rt.metadataCancel != nil {
-		rt.metadataCancel()
-	}
+	rt.generationCtx, rt.generationCancel = context.WithCancel(rt.ctx)
 }
 
 func (rt *mtrSchedulerRuntime) handleCancel() error {
-	rt.drainInFlight()
 	rt.maybeSnapshot(true)
 	return rt.ctx.Err()
-}
-
-func (rt *mtrSchedulerRuntime) drainInFlight() {
-	deadline := time.After(5 * time.Second)
-	for rt.inFlight > 0 {
-		select {
-		case <-rt.resultCh:
-			rt.inFlight--
-		case <-deadline:
-			return
-		}
-	}
 }

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1617,7 +1617,7 @@ func TestScheduler_ResetRefreshesSourceAfterInvalidatingOldWork(t *testing.T) {
 	var refreshCalls atomic.Int32
 	resetRequested := true
 	var rt *mtrSchedulerRuntime
-	var oldMetadataCtx context.Context
+	var oldGenerationCtx context.Context
 
 	rt, err := newMTRSchedulerRuntime(context.Background(), prober, NewMTRAggregator(), mtrSchedulerConfig{
 		BeginHop:         1,
@@ -1642,10 +1642,10 @@ func TestScheduler_ResetRefreshesSourceAfterInvalidatingOldWork(t *testing.T) {
 			},
 			RefreshIPGeoSource: func() {
 				refreshCalls.Add(1)
-				if oldMetadataCtx.Err() == nil {
+				if oldGenerationCtx.Err() == nil {
 					t.Error("source refreshed before canceling the old metadata context")
 				}
-				if rt.metadataCtx != oldMetadataCtx {
+				if rt.generationCtx != oldGenerationCtx {
 					t.Error("new metadata context published before source refresh completed")
 				}
 				if proberReset.Load() {
@@ -1658,15 +1658,15 @@ func TestScheduler_ResetRefreshesSourceAfterInvalidatingOldWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
 	}
-	oldMetadataCtx = rt.metadataCtx
+	oldGenerationCtx = rt.generationCtx
 	rt.inFlight = 1
 	rt.states[1].inFlightCount = 1
 	rt.handleReset()
 
-	if oldMetadataCtx.Err() == nil {
+	if oldGenerationCtx.Err() == nil {
 		t.Fatal("reset did not cancel the previous metadata generation")
 	}
-	if rt.metadataCtx == oldMetadataCtx || rt.metadataCtx.Err() != nil {
+	if rt.generationCtx == oldGenerationCtx || rt.generationCtx.Err() != nil {
 		t.Fatal("reset did not publish a fresh metadata context after cleanup")
 	}
 	if got := refreshCalls.Load(); got != 1 {

--- a/trace/mtr_session.go
+++ b/trace/mtr_session.go
@@ -1,0 +1,39 @@
+package trace
+
+import (
+	"context"
+	"runtime/pprof"
+	"sync"
+)
+
+// mtrWorkerSession owns every cancellable worker created for one MTR run.
+type mtrWorkerSession struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func newMTRWorkerSession(parent context.Context) *mtrWorkerSession {
+	ctx, cancel := context.WithCancel(parent)
+	return &mtrWorkerSession{ctx: ctx, cancel: cancel}
+}
+
+func (s *mtrWorkerSession) Go(owner string, fn func()) {
+	s.wg.Go(func() {
+		pprof.Do(s.ctx, pprof.Labels("owner", owner), func(context.Context) {
+			fn()
+		})
+	})
+}
+
+func (s *mtrWorkerSession) shutdown(closeResources func()) {
+	s.cancel()
+	if closeResources != nil {
+		closeResources()
+	}
+	s.wg.Wait()
+}
+
+type mtrSessionStarter interface {
+	startMTRSession(*mtrWorkerSession) error
+}

--- a/trace/mtr_worker_lifecycle_test.go
+++ b/trace/mtr_worker_lifecycle_test.go
@@ -1,0 +1,307 @@
+package trace
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestMTRSchedulerResetCancelsProbeGeneration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var calls atomic.Int32
+		firstStarted := make(chan struct{})
+		firstCanceled := make(chan struct{})
+		resetRequested := atomic.Bool{}
+		prober := &mockTTLProber{
+			probeFn: func(ctx context.Context, ttl int) (mtrProbeResult, error) {
+				if calls.Add(1) == 1 {
+					close(firstStarted)
+					<-ctx.Done()
+					close(firstCanceled)
+					return mtrProbeResult{
+						TTL:     ttl,
+						Success: true,
+						Addr:    &net.IPAddr{IP: net.ParseIP("192.0.2.1")},
+						RTT:     time.Millisecond,
+					}, nil
+				}
+				return mtrProbeResult{
+					TTL:     ttl,
+					Success: true,
+					Addr:    &net.IPAddr{IP: net.ParseIP("192.0.2.2")},
+					RTT:     time.Millisecond,
+				}, nil
+			},
+		}
+
+		agg := NewMTRAggregator()
+		done := make(chan error, 1)
+		go func() {
+			done <- runMTRScheduler(ctx, prober, agg, mtrSchedulerConfig{
+				BeginHop:         1,
+				MaxHops:          1,
+				HopInterval:      time.Second,
+				MaxPerHop:        1,
+				ParallelRequests: 1,
+				IsResetRequested: func() bool { return resetRequested.Swap(false) },
+			}, nil, nil)
+		}()
+
+		<-firstStarted
+		resetRequested.Store(true)
+		select {
+		case <-firstCanceled:
+		case <-time.After(20 * time.Millisecond):
+			t.Fatal("reset did not cancel the previous probe generation")
+		}
+
+		if err := <-done; err != nil {
+			t.Fatalf("runMTRScheduler returned error: %v", err)
+		}
+		stats := agg.Snapshot()
+		if len(stats) != 1 || stats[0].IP != "192.0.2.2" || stats[0].Snt != 1 {
+			t.Fatalf("post-reset stats = %+v, want only the new generation", stats)
+		}
+	})
+}
+
+type closeBlockingTTLProber struct {
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func newCloseBlockingTTLProber() *closeBlockingTTLProber {
+	return &closeBlockingTTLProber{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *closeBlockingTTLProber) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, error) {
+	p.startOnce.Do(func() { close(p.started) })
+	<-p.release
+	return mtrProbeResult{TTL: ttl}, ctx.Err()
+}
+
+func (p *closeBlockingTTLProber) Reset() error { return nil }
+
+func (p *closeBlockingTTLProber) Close() error {
+	p.closeOnce.Do(func() { close(p.release) })
+	return nil
+}
+
+func TestMTRSchedulerShutdownClosesProberBeforeWaitingWorkers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		prober := newCloseBlockingTTLProber()
+		done := make(chan error, 1)
+		go func() {
+			done <- runMTRScheduler(ctx, prober, NewMTRAggregator(), mtrSchedulerConfig{
+				BeginHop:         1,
+				MaxHops:          1,
+				HopInterval:      time.Second,
+				ParallelRequests: 1,
+			}, nil, nil)
+		}()
+
+		<-prober.started
+		cancel()
+		select {
+		case <-prober.release:
+		case <-time.After(time.Millisecond):
+			t.Error("scheduler waited for a worker before closing its prober")
+			_ = prober.Close()
+		}
+
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("runMTRScheduler error = %v, want context.Canceled", err)
+		}
+	})
+}
+
+type listenerTrackingTTLProber struct {
+	listenerStarted chan struct{}
+	listenerDone    chan struct{}
+	release         chan struct{}
+	closeOnce       sync.Once
+}
+
+func newListenerTrackingTTLProber() *listenerTrackingTTLProber {
+	return &listenerTrackingTTLProber{
+		listenerStarted: make(chan struct{}),
+		listenerDone:    make(chan struct{}),
+		release:         make(chan struct{}),
+	}
+}
+
+func (p *listenerTrackingTTLProber) startMTRSession(workers *mtrWorkerSession) error {
+	workers.Go("mtr.test-listener", func() {
+		close(p.listenerStarted)
+		<-p.release
+		close(p.listenerDone)
+	})
+	return nil
+}
+
+func (p *listenerTrackingTTLProber) ProbeTTL(_ context.Context, ttl int) (mtrProbeResult, error) {
+	return mtrProbeResult{TTL: ttl}, nil
+}
+
+func (p *listenerTrackingTTLProber) Reset() error { return nil }
+
+func (p *listenerTrackingTTLProber) Close() error {
+	p.closeOnce.Do(func() { close(p.release) })
+	return nil
+}
+
+func TestMTRSchedulerJoinsSessionListener(t *testing.T) {
+	prober := newListenerTrackingTTLProber()
+	err := runMTRScheduler(t.Context(), prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		MaxPerHop:        1,
+		ParallelRequests: 1,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runMTRScheduler returned error: %v", err)
+	}
+
+	select {
+	case <-prober.listenerStarted:
+	default:
+		t.Fatal("session listener did not start")
+	}
+	select {
+	case <-prober.listenerDone:
+	default:
+		t.Fatal("runMTRScheduler returned before the session listener stopped")
+	}
+	profile := goroutineProfileText(t)
+	if strings.Contains(profile, `"owner":"mtr.test-listener"`) {
+		t.Fatalf("session listener remained in the goroutine profile after shutdown:\n%s", profile)
+	}
+	if os.Getenv("MTR_GOROUTINE_LEAK_PROFILE") != "" && strings.Contains(profile, `"owner":"mtr.`) {
+		t.Fatalf("MTR worker remained in the final goroutine profile:\n%s", profile)
+	}
+	writeRawGoroutineProfileFromEnv(t, "MTR_GOROUTINE_LEAK_PROFILE")
+}
+
+func TestMTRWorkerGoroutineProfileCarriesOwnerLabel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	prober := newCloseBlockingTTLProber()
+	done := make(chan error, 1)
+	go func() {
+		done <- runMTRScheduler(ctx, prober, NewMTRAggregator(), mtrSchedulerConfig{
+			BeginHop:         1,
+			MaxHops:          1,
+			HopInterval:      time.Second,
+			ParallelRequests: 1,
+		}, nil, nil)
+	}()
+	<-prober.started
+
+	profile := goroutineProfileText(t)
+	if !strings.Contains(profile, `"owner":"mtr.probe"`) {
+		t.Fatalf("goroutine profile is missing the MTR owner label:\n%s", profile)
+	}
+	writeRawGoroutineProfileFromEnv(t, "MTR_GOROUTINE_ACTIVE_PROFILE")
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("runMTRScheduler error = %v, want context.Canceled", err)
+	}
+}
+
+func goroutineProfileText(t *testing.T) string {
+	t.Helper()
+	var profile bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&profile, 1); err != nil {
+		t.Fatalf("write goroutine profile: %v", err)
+	}
+	return profile.String()
+}
+
+func writeRawGoroutineProfileFromEnv(t *testing.T, envName string) {
+	t.Helper()
+	path := os.Getenv(envName)
+	if path == "" {
+		return
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create goroutine profile: %v", err)
+	}
+	if err := pprof.Lookup("goroutine").WriteTo(file, 0); err != nil {
+		_ = file.Close()
+		t.Fatalf("write goroutine profile: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close goroutine profile: %v", err)
+	}
+}
+
+type closeBlockingPreviewProber struct {
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func newCloseBlockingPreviewProber() *closeBlockingPreviewProber {
+	return &closeBlockingPreviewProber{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *closeBlockingPreviewProber) probeRound(ctx context.Context) (*Result, error) {
+	p.startOnce.Do(func() { close(p.started) })
+	<-p.release
+	return nil, ctx.Err()
+}
+
+func (p *closeBlockingPreviewProber) peekPartialResult() *Result { return nil }
+
+func (p *closeBlockingPreviewProber) close() {
+	p.closeOnce.Do(func() { close(p.release) })
+}
+
+func TestMTRLoopShutdownClosesProberBeforeWaitingPreviewWorker(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		prober := newCloseBlockingPreviewProber()
+		done := make(chan error, 1)
+		go func() {
+			done <- mtrLoop(ctx, prober, Config{}, MTROptions{
+				ProgressThrottle: time.Millisecond,
+			}, NewMTRAggregator(), func(_ int, _ []MTRHopStat) {}, false, nil)
+		}()
+
+		<-prober.started
+		cancel()
+		select {
+		case <-prober.release:
+		case <-time.After(time.Millisecond):
+			t.Error("MTR loop waited for the preview worker before closing its prober")
+			prober.close()
+		}
+
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("mtrLoop error = %v, want context.Canceled", err)
+		}
+	})
+}

--- a/trace/mtr_worker_lifecycle_test.go
+++ b/trace/mtr_worker_lifecycle_test.go
@@ -77,6 +77,82 @@ func TestMTRSchedulerResetCancelsProbeGeneration(t *testing.T) {
 	})
 }
 
+func TestMTRSchedulerResetRetainsGlobalProbeCapacityUntilOldWorkerExits(t *testing.T) {
+	var calls atomic.Int32
+	resetRequested := atomic.Bool{}
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+
+	prober := &mockTTLProber{
+		probeFn: func(ctx context.Context, ttl int) (mtrProbeResult, error) {
+			switch calls.Add(1) {
+			case 1:
+				close(firstStarted)
+				<-ctx.Done()
+				close(firstCanceled)
+				<-releaseFirst
+				return mtrProbeResult{TTL: ttl}, ctx.Err()
+			case 2:
+				close(secondStarted)
+				return mtrProbeResult{TTL: ttl}, nil
+			default:
+				return mtrProbeResult{TTL: ttl}, nil
+			}
+		},
+	}
+	workers := newMTRWorkerSession(t.Context())
+	defer workers.shutdown(func() { _ = prober.Close() })
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	defer release()
+
+	rt, err := newMTRSchedulerRuntimeWithSession(workers, prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Second,
+		ParallelRequests: 1,
+		IsResetRequested: func() bool { return resetRequested.Swap(false) },
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntimeWithSession returned error: %v", err)
+	}
+
+	rt.launchProbe(1)
+	<-firstStarted
+	resetRequested.Store(true)
+	rt.handleReset()
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("reset did not cancel the old probe")
+	}
+	if got := rt.inFlight; got != 1 {
+		t.Fatalf("global in-flight probes after reset = %d, want 1 until the old worker exits", got)
+	}
+
+	release()
+	var completed mtrCompletedProbe
+	select {
+	case completed = <-rt.resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("old probe did not report completion accounting")
+	}
+	rt.processResult(completed)
+	if got := rt.inFlight; got != 0 {
+		t.Fatalf("global in-flight probes after old worker exit = %d, want 0", got)
+	}
+
+	rt.scheduleReady()
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("new generation probe did not start after capacity was released")
+	}
+	rt.processResult(<-rt.resultCh)
+}
+
 type closeBlockingTTLProber struct {
 	started   chan struct{}
 	release   chan struct{}


### PR DESCRIPTION
### 问题

active MTR 的 scheduler、preview、legacy raw round、metadata 与 ICMP listener 分别管理 goroutine 和 context。reset 只按 generation 过滤结果，缺少统一取消与 join；shutdown 可能在关闭 prober/listener 前等待 worker，形成阻塞环。

### 前后调用链

- 旧：`RunMTR -> scheduler/loop -> detached probe/metadata/preview/listener goroutines`
- 新：`RunMTR -> mtrWorkerSession(root) -> generation -> registered workers -> cancel -> close resources -> wait`
- reset 取消旧 generation 后再发布新 generation；结果发送与消费两侧都校验 generation。
- initial/rotated ICMP listener、probe、Geo/PTR metadata、preview 和 raw round 均登记同一 session，worker 带 `pprof owner` label。

### 兼容性

- CLI flags、退出码、stdout/stderr、JSON schema、MTR 统计、TTY/ANSI、协议包布局、导出 API 不变。
- TUI 的进程级阻塞 stdin reader仍不纳入 session；注入式 reader seam 只用于测试，跨平台输入语义不变。
- 外部自定义 `ipgeo.Source` 仍须履行 timeout 合同；Go 不能强制终止违规回调内部创建的 goroutine。
- macOS 最低版本保持 13.0。

### 测试

- `go test -count=1 ./...`：默认 JSON、`GOEXPERIMENT=nojsonv2` 均通过。
- `go test -race -count=1 ./...`：通过。
- 生命周期定向测试 100 次、reset generation stress 1,000 次、定向 race 20 次：通过。
- `go build ./...`、`go vet ./...`：通过。
- `golangci-lint v2.13.2 run --new-from-rev=main`：0 issues；无范围限制运行仍为 75 个既存问题。
- tiny/ntr 专项测试与构建：通过。
- Node 前端测试：15/15 通过。
- `go mod verify` 通过，`go mod tidy` 无差异。
- `.github/workflows/performance.yml` actionlint 通过；全仓 actionlint 仍命中未修改 `build.yml` 的既存 matrix schema 报告。
- `.cross_compile.sh all`：Linux、Windows、OpenBSD、FreeBSD、Darwin 双架构及三 flavor 全部通过；六个 Darwin slice 的 `LC_BUILD_VERSION minos` 均为 13.0。

### Race 与生命周期证据

- reset 测试证明旧 probe 被取消，只有新 generation 结果计入统计。
- 取消中的旧 probe 退出前仍占用全局容量，新 generation 不会超过 `ParallelRequests`。
- shutdown 测试证明先关闭 prober/listener，再等待被其解除阻塞的 worker。
- active raw goroutine profile：`owner=mtr.probe`，1/4 goroutine。
- final raw goroutine profile：无 `owner=mtr.*` label。
- 性能 workflow 在 exact head 保存 active/final raw goroutine profile artifact。

### Benchstat

Apple M5、Go 1.27.1、`GOMAXPROCS=10`、`nojsonv2`。review 修复后预编译 parent 与 exact measured code head `7be9fe5` 的测试二进制，并按奇偶轮交换顺序交替采样 20 次。

| Benchmark | parent | exact head | benchstat | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| MTR Update 64x4 | 47.67 us | 48.05 us | 不显著，p=0.529 | 143,360 -> 143,360 | 834 -> 834 |
| MTR Clone 64x4 | 445.6 ns | 451.4 ns | 不显著，p=0.387 | 3,408 -> 3,408 | 4 -> 4 |
| MTR Snapshot 64x4 | 6.478 us | 6.654 us | 不显著，p=0.242 | 49,152 -> 49,152 | 257 -> 257 |
| MTR preview COW 64x4 | 12.16 us | 12.55 us | 不显著，p=0.149 | 97,008 -> 97,008 | 283 -> 283 |
| geomean | 6.396 us | 6.523 us | +1.98% | 不变 | 不变 |

四项在 20 次校准后均未检出显著时间差异，分配完全一致；geomean 只记录中位数的几何平均，不单独提供显著性判断。

未修改路径的 20 次校准：GeoFeed parse +0.82%、prefix-map -5.89%、MTU decoder 包级 geomean +0.36%、Geo HTTP construct 无显著差异、相同热状态 UDPv6 decoder 无显著差异。Geo cache miss 为 45.30 ns -> 46.26 ns（+2.14%），但 `trace/cache.go` 无 diff，目标函数低位对齐不变；保留为测试二进制 caller 布局敏感风险，不归因于生命周期改造。

### Profile

- 相同 30 秒 MTR Snapshot：6.282 us -> 6.694 us，49,152 B/op 与 257 allocs/op 不变；profile 单次吞吐不用于性能门槛判断。
- 两侧 CPU top 均为 Darwin runtime wait/GC/系统调用，没有新增业务热点。
- 两侧 heap alloc-space 均全部归于 `trace.cloneMTRStats`。

### 产物大小与测试耗时

| Flavor | parent 未压缩 | head 未压缩 | parent UPX | head UPX |
| --- | ---: | ---: | ---: | ---: |
| nexttrace | 30,126,706 B | 30,143,250 B | 10,141,712 B | 10,141,712 B |
| nexttrace-tiny | 11,050,018 B | 11,066,562 B | 4,259,856 B | 4,276,240 B |
| ntr | 11,050,018 B | 11,066,562 B | 4,259,856 B | 4,276,240 B |

同配置全仓测试墙钟：24.21 s -> 23.87 s；仅记录成本，不解释为改善。

### 平台风险

- reset 与在途结果竞争；listener 轮换期间关闭 spec；shutdown 的 close/wait 顺序。
- typed atomic、generation 双侧校验、统一 session owner、stress/race/profile 覆盖这些边界。
- Windows/Linux 仅改变外围 owner 与取消顺序，不改变现有 prober/listener 实现。

### 回退方案

撤销本 PR 的生命周期实现、合同测试、性能 workflow 和证据文档即可。没有配置、JSON、协议、持久数据或导出 API 迁移，不需要数据处理。

### Commit 列表

- `67360e0 refactor(trace): 统一 MTR worker 生命周期`
- `4837a31 test(mtr): 锁定 generation 取消与 worker 回收`
- `97439fe ci(perf): 保存 MTR worker goroutine profile`
- `d0d283d docs(perf): 记录 MTR worker 生命周期证据`
- `8f717f1 test(mtr): 分阶段验证 TUI 暂停与恢复`
- `7be9fe5 fix(mtr): 保留重置中的全局探测并发账本`
- `31a0966 docs(perf): 补充 MTR worker exact-head 性能证据`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改善 MTR 任务取消、重启与关闭时的资源回收，减少后台任务残留。
  - 优化探测器和监听器的关闭顺序，提升会话结束及重置过程的稳定性。
  - 取消操作可更快返回，避免等待已失效的探测任务完成。

- **测试**
  - 新增 MTR 生命周期、重置、关闭顺序及交互式按键处理测试。

- **文档**
  - 补充 Go 1.27 下 MTR worker 生命周期与性能测试证据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->