### PR TITLE
test(fuzz): 覆盖核心协议与输入解析器

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,68 @@
+name: Parser Fuzz Nightly
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "23 18 * * *"
+  workflow_dispatch:
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GOTOOLCHAIN: go1.27.1
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: ./cmd
+            target: FuzzMTRInputParser
+          - package: ./trace/internal
+            target: FuzzParseSocketICMPMessage
+          - package: ./trace/internal
+            target: FuzzExtractEmbeddedICMPSeq
+          - package: ./trace/internal
+            target: FuzzDecodeTCPProbePacket
+          - package: ./trace/mtu
+            target: FuzzParseEmbeddedUDPPacket
+          - package: ./trace
+            target: FuzzExtractMPLS
+          - package: ./dn42
+            target: FuzzParseGeoFeedRecord
+          - package: ./internal/nali
+            target: FuzzFindIPSpans
+          - package: ./internal/dnsclient
+            target: FuzzParseServer
+          - package: ./server
+            target: FuzzDecodeWSInitRequest
+          - package: ./ipgeo
+            target: FuzzDecodeNextTraceAPIV3Message
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v7
+
+      - name: Set up Go (built-in cache)
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.27.1'
+          check-latest: true
+          cache: true
+
+      - name: Fuzz parser
+        run: >-
+          go test "${{ matrix.package }}" -run '^$'
+          -fuzz '^${{ matrix.target }}$' -fuzztime=30s
+          -fuzzminimizetime=10s -parallel=1
+
+      - name: Upload minimized crash input
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: ${{ matrix.package }}/testdata/fuzz/${{ matrix.target }}
+          if-no-files-found: ignore
+          retention-days: 14

--- a/cmd/mtr_ui_fuzz_test.go
+++ b/cmd/mtr_ui_fuzz_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import "testing"
+
+const fuzzMTRInputMaxBytes = 4096
+
+func FuzzMTRInputParser(f *testing.F) {
+	f.Add([]byte("p rynedgq"))
+	f.Add([]byte{0x1b, '[', '2', '0', '0', '~', 0x1b, ']', '0', ';', 'x', 0x07})
+	f.Add([]byte{0x1b, '[', 'M', 0x20, 0x30, 0x30, 0x1b, 'O', 'P'})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > fuzzMTRInputMaxBytes {
+			data = data[:fuzzMTRInputMaxBytes]
+		}
+
+		var parser mtrInputParser
+		for _, b := range data {
+			action := parser.Feed(b)
+			if action < mtrActionNone || action > mtrActionHistoryChart {
+				t.Fatalf("action = %d, outside known range", action)
+			}
+		}
+		if parser.state < mtrStateGround || parser.state > mtrStateSGRMouse {
+			t.Fatalf("state = %d, outside known range", parser.state)
+		}
+		if parser.csiN < 0 || parser.csiN > mtrParserMaxCSI+1 {
+			t.Fatalf("CSI byte count = %d, want 0..%d", parser.csiN, mtrParserMaxCSI+1)
+		}
+	})
+}

--- a/dn42/geofeed_fuzz_test.go
+++ b/dn42/geofeed_fuzz_test.go
@@ -1,0 +1,64 @@
+package dn42
+
+import (
+	"bytes"
+	"encoding/csv"
+	"testing"
+)
+
+const fuzzGeoFeedRowMaxBytes = 64 << 10
+
+func FuzzParseGeoFeedRecord(f *testing.F) {
+	f.Add([]byte("10.0.0.0/8,na,US,Test City\n"))
+	f.Add([]byte("2001:db8::/32,eu,DE,Berlin,AS4242420000,example\n"))
+	f.Add([]byte("bad-cidr,na,US,Invalid\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > fuzzGeoFeedRowMaxBytes {
+			data = data[:fuzzGeoFeedRowMaxBytes]
+		}
+		reader := csv.NewReader(bytes.NewReader(data))
+		reader.FieldsPerRecord = -1
+		row, err := reader.Read()
+		if err != nil {
+			return
+		}
+		record, ok := parseGeoFeedRecord(row)
+		if !ok {
+			return
+		}
+		if !record.Prefix.IsValid() || record.Prefix != record.Prefix.Masked() {
+			t.Fatalf("record prefix = %v, want valid masked prefix", record.Prefix)
+		}
+		if len(row) != 4 && len(row) < 6 {
+			t.Fatalf("accepted unsupported row width %d", len(row))
+		}
+		if record.CIDR != row[0] {
+			t.Fatalf("record CIDR = %q, want original %q", record.CIDR, row[0])
+		}
+		index := buildGeoFeedIndex([]GeoFeedRecord{record}, geoFeedFileIdentity{}, 1)
+		if found, exists := index.Lookup(record.Prefix.Addr()); !exists || found != record {
+			t.Fatalf("indexed record = (%+v, %v), want %+v", found, exists, record)
+		}
+
+		var encoded bytes.Buffer
+		writer := csv.NewWriter(&encoded)
+		if err := writer.Write(row); err != nil {
+			t.Fatalf("encode CSV row: %v", err)
+		}
+		writer.Flush()
+		if err := writer.Error(); err != nil {
+			t.Fatalf("flush CSV row: %v", err)
+		}
+		roundTripReader := csv.NewReader(&encoded)
+		roundTripReader.FieldsPerRecord = -1
+		roundTripRow, err := roundTripReader.Read()
+		if err != nil {
+			t.Fatalf("decode encoded CSV row: %v", err)
+		}
+		roundTrip, valid := parseGeoFeedRecord(roundTripRow)
+		if !valid || roundTrip != record {
+			t.Fatalf("GeoFeed round-trip = (%+v, %v), want %+v", roundTrip, valid, record)
+		}
+	})
+}

--- a/docs/performance/go127-parser-fuzzing.md
+++ b/docs/performance/go127-parser-fuzzing.md
@@ -1,0 +1,159 @@
+# Go 1.27 解析器 fuzz 证据
+
+## 范围与结论
+
+本轮为已有解析逻辑增加 11 个原生 Go fuzz 目标，覆盖终端输入、ICMP/TCP/UDP、
+MPLS、DN42 GeoFeed、nali、DNS endpoint、deploy WebSocket init JSON 和 NextTrace
+API v3 WebSocket 响应。
+
+生产代码只提取两个纯解析 seam：deploy WebSocket init 继续调用同一个
+`encoding/json.Unmarshal`；v3 响应继续调用同一个 gjson 字段映射函数。没有 fuzz
+目标访问 raw socket、真实网络或全局连接池。
+
+CLI flags、退出码、stdout/stderr、JSON schema、MTR 统计、TTY/ANSI、协议布局、导出
+API 和三 flavor 依赖边界均不变。
+
+## 精确版本与环境
+
+| 项目 | 值 |
+| --- | --- |
+| parent | `70ddd4040a990bb83ff0005727bfe290d59cbc5e` |
+| exact measured code head | `f19276ae33ee9a943ba9107ed0d701739f9b8c5d` |
+| 主机 | Apple M5，10 核，32 GB，AC 供电 |
+| 系统 | macOS 26.6.2，darwin/arm64 |
+| 工具链 | Go 1.27.1，`GOEXPERIMENT=nojsonv2` |
+| benchmark | `GOMAXPROCS=10`，每项 1 秒；完整 harness 10 次，越线项交替 20 次 |
+| profile | `GOMAXPROCS=10`，`BenchmarkFindIPSpans` 30 秒 |
+| 统计工具 | `benchstat v0.0.0-20260825160852-19be9d8e6c70` |
+
+证据提交只加入本文档，不改变被测 Go 行为或 workflow。原始 benchmark、profile、
+二进制和 fuzz cache 位于本地忽略目录；CI 失败时只上传最小 crash corpus。
+
+## 解析入口
+
+| 目标 | 输入上限 | 主要不变量 |
+| --- | ---: | --- |
+| `FuzzMTRInputParser` | 4 KiB | ANSI/CSI/SS3/OSC 状态和 action 范围 |
+| `FuzzParseSocketICMPMessage` | 4 KiB | 明确失败、响应类型范围、marshal round-trip |
+| `FuzzExtractEmbeddedICMPSeq` | 4 KiB | echo ID 匹配、sequence 范围、IPv4/IPv6 round-trip |
+| `FuzzDecodeTCPProbePacket` | 4 KiB | port/seq/ack 范围、peer IP family |
+| `FuzzParseEmbeddedUDPPacket` | 4 KiB | port/IP family、IPv4/IPv6 round-trip |
+| `FuzzExtractMPLS` | 4 KiB | label 数量、格式、Lbl/TC/S/TTL 范围 |
+| `FuzzParseGeoFeedRecord` | 64 KiB | 记录宽度、masked prefix、索引查询、CSV round-trip |
+| `FuzzFindIPSpans` | 16 KiB | span 有序不重叠、边界、源文本和 IP family |
+| `FuzzParseServer` | 4 KiB | endpoint 完整性、port 有效性、确定性 |
+| `FuzzDecodeWSInitRequest` | 64 KiB | JSON 明确失败、请求结构 round-trip |
+| `FuzzDecodeNextTraceAPIV3Message` | 64 KiB | JSON 明确失败、字段映射确定性 |
+
+每个 callback 先按协议上限截断输入；有效输入检查字段、索引和数值范围，无效输入必须
+显式返回失败。具备编码路径的格式执行 round-trip。
+
+## 调用链变化
+
+deploy WebSocket init 从：
+
+`ReadMessage -> inline json.Unmarshal -> prepareTrace`
+
+变为：
+
+`ReadMessage -> decodeWSInitRequest -> json.Unmarshal -> prepareTrace`
+
+NextTrace API v3 从：
+
+`dispatch -> gjson.Parse -> field mapping`
+
+变为：
+
+`dispatch -> gjson.Parse -> shared field mapping`
+
+fuzz 专用严格入口先用 `gjson.Valid` 拒绝畸形 JSON，再进入相同字段映射。生产 dispatch
+仍保留原有宽松解析行为，避免改变错误语义。
+
+## Fuzz 与 CI
+
+本地先运行所有 seed corpus，再对 11 个目标分别执行 2–3 秒短时 fuzz；全部通过，未生成
+crash corpus。该短跑只验证目标可执行和基本不变量，不替代 nightly。
+
+`.github/workflows/fuzz.yml` 只由每日 schedule 或手动触发，不在 PR 中执行随机 fuzz。
+nightly 使用 Go 1.27.1，把每个 package/target 作为独立 matrix job，单目标 fuzz 30 秒、
+minimize 10 秒、`parallel=1`。普通 PR 的既有 Test workflow 会把 fuzz seed corpus 当作普通
+测试执行。失败 job 只上传对应 `testdata/fuzz/<target>`，保留 14 天；不上传 Go fuzz cache。
+
+## Benchmark
+
+parent/head 的完整 Go 1.27.1 `nojsonv2` harness 各顺序运行 10 次。`util` 的 HTTP
+benchmark 因本地端口受沙箱限制，随后在允许 loopback 的相同主机上独立补齐 10 次。
+首轮超过 1% 的候选使用预编译 parent/head test binary，按奇偶轮交换先后顺序交替采样
+20 次。
+
+本 PR 直接相关且首轮未越线的结果：
+
+| Benchmark | parent | head | benchstat | B/op | allocs/op |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| WS JSON marshal | 493.4 ns | 492.2 ns | 不显著，`p=0.393` | 416 -> 416 | 2 -> 2 |
+| WS JSON unmarshal | 2.508 us | 2.471 us | 不显著，`p=0.190` | 656 -> 656 | 15 -> 15 |
+| nali spans | 4.591 us | 4.461 us | 不显著，`p=0.190` | 6,400 -> 6,400 | 61 -> 61 |
+
+20 轮校准结果：
+
+| 组 | parent geomean | head geomean | 结论 |
+| --- | ---: | ---: | --- |
+| Geo cache + MTR Snapshot/preview | 297.2 ns | 297.2 ns | `+0.01%`，8 项均不显著 |
+| ICMP/UDP decoder | 86.25 ns | 85.89 ns | `-0.42%`，4 项均不显著 |
+| Geo HTTP multi-client | 46.29 us | 46.12 us | `-0.37%`，4 项均不显著 |
+
+decoder 校准中 IPv4/IPv6 ICMP 和 UDP 的 `p` 值为 `0.733..0.836`；trace 组为
+`0.090..0.963`；HTTP 组为 `0.512..0.779`。全部 B/op/allocs/op 保持一致。
+首轮的 cache/MTR、ICMPv4/UDPv4 和 HTTP 并发回退未在交替采样中复现，不构成合并阻断。
+
+## Profile
+
+parent/head 对 `BenchmarkFindIPSpans` 各采集 30 秒 CPU 与 heap profile。两侧 CPU top
+均由 `FindIPSpans`、`parseCandidate`、`strings.IndexAny` 和 `net/netip` 解析构成；heap
+alloc-space 均由 `FindIPSpans`、IPv4/IPv6 parse 和错误构造主导，没有新增业务热点。
+
+profile 单次结果为 4.524 us 与 4.778 us，B/op 都是 6,400，allocs/op 都是 61；单次
+profile 吞吐只用于热点核验，不代替 10/20 次 benchstat。
+
+## 产物大小
+
+Darwin arm64 使用 `-buildvcs=false -trimpath -ldflags '-s -w -buildid= -macos=13.0'`
+构建，并以相同 UPX 5.2.1 `--force-macos -9` 压缩：
+
+| Flavor | parent 未压缩 | head 未压缩 | parent UPX | head UPX |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 30,143,154 B | 30,143,154 B | 10,141,712 B | 10,158,096 B |
+| nexttrace-tiny | 11,066,466 B | 11,066,466 B | 4,276,240 B | 4,276,240 B |
+| ntr | 11,066,466 B | 11,066,466 B | 4,276,240 B | 4,276,240 B |
+
+未压缩大小全部不变；tiny/ntr 的 UPX 大小不变，full 的 UPX 大小增加 16,384 B。
+六个 parent/head Darwin arm64 产物的 `LC_BUILD_VERSION` 均为 `minos 13.0`。
+
+## 门禁
+
+| 验证 | 结果 |
+| --- | --- |
+| `go test -count=1 ./...` | 通过，约 16.6 秒 |
+| `GOEXPERIMENT=nojsonv2 go test -count=1 ./...` | 通过，约 19.2 秒 |
+| `go test -race -count=1 ./...` | 通过，约 21.9 秒 |
+| `go build ./...` / `go vet ./...` | 通过 |
+| tiny/ntr 测试与构建 | 通过 |
+| Web 前端 Node 测试 | 15/15 通过 |
+| `go mod verify` / `go mod tidy -diff` | 通过，无 diff |
+| actionlint | 通过 |
+| golangci-lint CI 等价增量检查 | `0 issues` |
+| full/tiny/ntr 跨平台脚本 | 60 个产物，脚本退出 0 |
+| Darwin amd64/arm64 `LC_BUILD_VERSION` | 6/6 为 `minos 13.0` |
+
+仓库的完整 `golangci-lint run` 仍报告 75 个既有 baseline issue；CI 配置使用
+`only-new-issues: true`，本 PR 对应的 `--new-from-rev=main` 为 `0 issues`。未在本 PR
+清理无关历史问题。
+
+## 风险与回退
+
+主要风险是 fuzz invariant 过严造成误报、nightly 成本，以及纯 seam 意外改变解析错误
+语义。短时 fuzz、两套 JSON 测试、race、字段 round-trip 和保持生产 v3 宽松入口覆盖这些
+边界。nightly 不执行网络或 raw socket，不会向外部系统发送请求。
+
+如需回退，可撤销两个纯解析 seam、fuzz 文件、nightly workflow 和本文档。没有配置、协议、
+JSON、持久数据或导出 API 迁移；回退不需要数据处理。

--- a/internal/dnsclient/server_fuzz_test.go
+++ b/internal/dnsclient/server_fuzz_test.go
@@ -1,0 +1,39 @@
+//go:build !flavor_tiny && !flavor_ntr
+
+package dnsclient
+
+import (
+	"net"
+	"testing"
+)
+
+const fuzzDNSServerMaxBytes = 4096
+
+func FuzzParseServer(f *testing.F) {
+	f.Add("1.1.1.1")
+	f.Add("https://[2001:db8::1]/dns-query")
+	f.Add("tls://dns.example:853")
+	f.Add("sdns://invalid")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > fuzzDNSServerMaxBytes {
+			input = input[:fuzzDNSServerMaxBytes]
+		}
+		parsed, err := ParseServer(input)
+		if err != nil {
+			return
+		}
+		if parsed.Original != input || parsed.Address == "" || parsed.Host == "" || parsed.TransportType == "" {
+			t.Fatalf("successful DNS parse returned incomplete result: %+v", parsed)
+		}
+		if parsed.Port != "" {
+			if _, err := net.LookupPort("tcp", parsed.Port); err != nil {
+				t.Fatalf("successful DNS parse returned invalid port %q: %v", parsed.Port, err)
+			}
+		}
+		again, err := ParseServer(input)
+		if err != nil || again != parsed {
+			t.Fatalf("DNS parse is not deterministic: first=%+v second=(%+v, %v)", parsed, again, err)
+		}
+	})
+}

--- a/internal/nali/nali_fuzz_test.go
+++ b/internal/nali/nali_fuzz_test.go
@@ -1,0 +1,43 @@
+package nali
+
+import (
+	"net/netip"
+	"testing"
+)
+
+const fuzzNaliLineMaxBytes = 16 << 10
+
+func FuzzFindIPSpans(f *testing.F) {
+	f.Add([]byte("IP:1.1.1.1 [2001:db8::1]:443"))
+	f.Add([]byte("dead:8.8.8.8 fe80::1%en0 invalid:::"))
+	f.Add([]byte{0xff, '1', '.', '1', '.', '1', '.', '1'})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > fuzzNaliLineMaxBytes {
+			data = data[:fuzzNaliLineMaxBytes]
+		}
+		line := string(data)
+		spans := FindIPSpans(line)
+		previousEnd := 0
+		for i, span := range spans {
+			if span.Start < previousEnd || span.Start < 0 || span.Start > span.End || span.End > span.InsertEnd || span.InsertEnd > len(line) {
+				t.Fatalf("span[%d] has invalid or overlapping bounds: %+v after %d", i, span, previousEnd)
+			}
+			if line[span.Start:span.End] != span.Text {
+				t.Fatalf("span[%d] text = %q, source = %q", i, span.Text, line[span.Start:span.End])
+			}
+			addr, err := netip.ParseAddr(span.LookupIP)
+			if err != nil || !addr.IsValid() || addr.Zone() != "" {
+				t.Fatalf("span[%d] lookup IP = %q: %v", i, span.LookupIP, err)
+			}
+			wantFamily := Family6
+			if addr.Is4() {
+				wantFamily = Family4
+			}
+			if span.Family != wantFamily {
+				t.Fatalf("span[%d] family = %d, want %d", i, span.Family, wantFamily)
+			}
+			previousEnd = span.InsertEnd
+		}
+	})
+}

--- a/ipgeo/nexttrace_api_v3.go
+++ b/ipgeo/nexttrace_api_v3.go
@@ -102,8 +102,18 @@ func dispatchNextTraceAPIV3Message(data string) {
 }
 
 func parseNextTraceAPIV3Message(data string) (string, IPGeoData) {
-	// json解析 -> data
-	res := gjson.Parse(data)
+	return parseNextTraceAPIV3Result(gjson.Parse(data))
+}
+
+func decodeNextTraceAPIV3Message(data string) (string, IPGeoData, error) {
+	if !gjson.Valid(data) {
+		return "", IPGeoData{}, errors.New("invalid NextTrace API v3 response")
+	}
+	ip, geo := parseNextTraceAPIV3Result(gjson.Parse(data))
+	return ip, geo, nil
+}
+
+func parseNextTraceAPIV3Result(res gjson.Result) (string, IPGeoData) {
 	// 根据返回的IP信息，发送给对应等待回复的IP通道上
 	var domain = res.Get("domain").String()
 

--- a/ipgeo/nexttrace_api_v3_fuzz_test.go
+++ b/ipgeo/nexttrace_api_v3_fuzz_test.go
@@ -1,0 +1,35 @@
+package ipgeo
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+const fuzzNextTraceAPIV3MaxBytes = 64 << 10
+
+func FuzzDecodeNextTraceAPIV3Message(f *testing.F) {
+	f.Add(`{"ip":"192.0.2.1","asnumber":"AS64500","domain":"edge.example","lat":"1.25","lng":"2.5","router":{"r":["a","b"]}}`)
+	f.Add(`{"ip":"2001:db8::1","owner":"Example","router":"{\"r\":[\"x\"]}"}`)
+	f.Add(`{"ip":`)
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > fuzzNextTraceAPIV3MaxBytes {
+			data = data[:fuzzNextTraceAPIV3MaxBytes]
+		}
+		ip, geo, err := decodeNextTraceAPIV3Message(data)
+		if err != nil {
+			if json.Valid([]byte(data)) {
+				t.Fatalf("valid JSON returned decoder error: %v", err)
+			}
+			return
+		}
+		if !json.Valid([]byte(data)) {
+			t.Fatal("successful v3 response decode accepted invalid JSON")
+		}
+		againIP, againGeo, err := decodeNextTraceAPIV3Message(data)
+		if err != nil || againIP != ip || !reflect.DeepEqual(againGeo, geo) {
+			t.Fatalf("v3 response decode is not deterministic: first=(%q, %+v) second=(%q, %+v, %v)", ip, geo, againIP, againGeo, err)
+		}
+	})
+}

--- a/server/ws_handler.go
+++ b/server/ws_handler.go
@@ -350,8 +350,8 @@ func serveTraceWebsocket(parent context.Context, conn traceWSConn) {
 	session := newWSTraceSession(parent, conn, "", wsSendQueueSize)
 	defer session.finish()
 
-	var req traceRequest
-	if err := json.Unmarshal(message, &req); err != nil {
+	req, err := decodeWSInitRequest(message)
+	if err != nil {
 		_ = session.send(wsEnvelope{Type: "error", Error: "invalid request payload", Status: 400})
 		return
 	}
@@ -399,6 +399,12 @@ func serveTraceWebsocket(parent context.Context, conn traceWSConn) {
 			runSingleTrace(sessionCtx, session, setup)
 		}
 	})
+}
+
+func decodeWSInitRequest(message []byte) (traceRequest, error) {
+	var req traceRequest
+	err := json.Unmarshal(message, &req)
+	return req, err
 }
 
 func runSingleTrace(ctx context.Context, session *wsTraceSession, setup *traceExecution) {

--- a/server/ws_handler_fuzz_test.go
+++ b/server/ws_handler_fuzz_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func FuzzDecodeWSInitRequest(f *testing.F) {
+	f.Add([]byte(`{"target":"example.com","protocol":"icmp","queries":3}`))
+	f.Add([]byte(`{"target":"2001:db8::1","packet_size":64,"tos":0,"mode":"mtr"}`))
+	f.Add([]byte(`{"target":`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > maxWSInitMessageBytes {
+			data = data[:maxWSInitMessageBytes]
+		}
+		request, err := decodeWSInitRequest(data)
+		if err != nil {
+			return
+		}
+		if !json.Valid(data) {
+			t.Fatal("successful WebSocket init decode accepted invalid JSON")
+		}
+		encoded, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("marshal decoded WebSocket init request: %v", err)
+		}
+		roundTrip, err := decodeWSInitRequest(encoded)
+		if err != nil || !reflect.DeepEqual(roundTrip, request) {
+			t.Fatalf("WebSocket init round-trip = (%+v, %v), want %+v", roundTrip, err, request)
+		}
+	})
+}

--- a/trace/internal/decoder_fuzz_test.go
+++ b/trace/internal/decoder_fuzz_test.go
@@ -1,0 +1,162 @@
+package internal
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+const fuzzPacketMaxBytes = 4096
+
+func FuzzParseSocketICMPMessage(f *testing.F) {
+	f.Add(uint8(4), fuzzICMPTimeExceededSeed(f, 4))
+	f.Add(uint8(6), fuzzICMPTimeExceededSeed(f, 6))
+	f.Add(uint8(4), []byte{0, 0, 0, 0})
+
+	f.Fuzz(func(t *testing.T, version uint8, raw []byte) {
+		raw = capFuzzPacket(raw)
+		ipVersion := fuzzIPVersion(version)
+		message, ok := parseSocketICMPMessage(ipVersion, raw)
+		if !ok {
+			if message != nil {
+				t.Fatal("failed ICMP parse returned a message")
+			}
+			return
+		}
+		if message == nil {
+			t.Fatal("successful ICMP parse returned nil")
+		}
+		response := classifySocketICMPResponse(ipVersion, message, raw)
+		if response.Kind > ICMPResponseUnreachable {
+			t.Fatalf("response kind = %d, outside known range", response.Kind)
+		}
+
+		encoded, err := message.Marshal(nil)
+		if err != nil {
+			return
+		}
+		if roundTrip, valid := parseSocketICMPMessage(ipVersion, encoded); !valid || roundTrip == nil {
+			t.Fatal("marshaled ICMP message did not parse")
+		}
+	})
+}
+
+func FuzzExtractEmbeddedICMPSeq(f *testing.F) {
+	f.Add(uint16(13), buildIPv4InnerPacket(net.ParseIP("192.0.2.9"), 13, 99))
+	f.Add(uint16(17), buildIPv6InnerPacket(net.ParseIP("2001:db8::9"), 17, 123))
+	f.Add(uint16(1), []byte{0x45})
+
+	f.Fuzz(func(t *testing.T, echoID uint16, data []byte) {
+		data = capFuzzPacket(data)
+		seq, ok := extractEmbeddedICMPSeq(data, int(echoID))
+		if !ok {
+			return
+		}
+		if seq < 0 || seq > 65535 {
+			t.Fatalf("embedded ICMP sequence = %d, outside 0..65535", seq)
+		}
+
+		var encoded []byte
+		switch {
+		case len(data) >= 20 && data[0]>>4 == 4:
+			encoded = buildIPv4InnerPacket(net.IP(data[16:20]), int(echoID), seq)
+		case len(data) >= 40 && data[0]>>4 == 6:
+			encoded = buildIPv6InnerPacket(net.IP(data[24:40]), int(echoID), seq)
+		default:
+			return
+		}
+		if roundTrip, valid := extractEmbeddedICMPSeq(encoded, int(echoID)); !valid || roundTrip != seq {
+			t.Fatalf("embedded ICMP round-trip = (%d, %v), want (%d, true)", roundTrip, valid, seq)
+		}
+	})
+}
+
+func FuzzDecodeTCPProbePacket(f *testing.F) {
+	f.Add(uint8(4), uint16(443), fuzzIPv4TCPSeed())
+	f.Add(uint8(6), uint16(8443), fuzzIPv6TCPSeed())
+	f.Add(uint8(4), uint16(80), []byte{0x45})
+
+	f.Fuzz(func(t *testing.T, version uint8, dstPort uint16, raw []byte) {
+		raw = capFuzzPacket(raw)
+		ipVersion := fuzzIPVersion(version)
+		layerType := layers.LayerTypeIPv4
+		if ipVersion == 6 {
+			layerType = layers.LayerTypeIPv6
+		}
+		packet := gopacket.NewPacket(raw, layerType, gopacket.NoCopy)
+		srcPort, seq, ack, peer, ok := decodeTCPProbePacket(ipVersion, int(dstPort), packet)
+		if !ok {
+			return
+		}
+		if srcPort < 0 || srcPort > 65535 {
+			t.Fatalf("source port = %d, outside 0..65535", srcPort)
+		}
+		if seq != 0 && ack != 0 {
+			t.Fatalf("decoder returned both sequence %d and ack %d", seq, ack)
+		}
+		peerIP, valid := peer.(*net.IPAddr)
+		if !valid || peerIP == nil || peerIP.IP == nil {
+			t.Fatalf("peer = %#v, want non-nil IP address", peer)
+		}
+		if ipVersion == 4 && peerIP.IP.To4() == nil {
+			t.Fatalf("IPv4 decoder returned peer %v", peerIP.IP)
+		}
+		if ipVersion == 6 && (peerIP.IP.To16() == nil || peerIP.IP.To4() != nil) {
+			t.Fatalf("IPv6 decoder returned peer %v", peerIP.IP)
+		}
+	})
+}
+
+func capFuzzPacket(raw []byte) []byte {
+	if len(raw) > fuzzPacketMaxBytes {
+		return raw[:fuzzPacketMaxBytes]
+	}
+	return raw
+}
+
+func fuzzIPVersion(version uint8) int {
+	if version == 6 || version%2 == 1 {
+		return 6
+	}
+	return 4
+}
+
+func fuzzICMPTimeExceededSeed(f *testing.F, ipVersion int) []byte {
+	inner := make([]byte, 48)
+	inner[0] = 0x60
+	messageType := icmp.Type(ipv6.ICMPTypeTimeExceeded)
+	if ipVersion == 4 {
+		inner = make([]byte, 28)
+		inner[0] = 0x45
+		messageType = ipv4.ICMPTypeTimeExceeded
+	}
+	raw, err := (&icmp.Message{Type: messageType, Body: &icmp.TimeExceeded{Data: inner}}).Marshal(nil)
+	if err != nil {
+		f.Fatalf("marshal ICMP seed: %v", err)
+	}
+	return raw
+}
+
+func fuzzIPv4TCPSeed() []byte {
+	return []byte{
+		0x45, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00, 0x40, 0x06, 0x00, 0x00,
+		0xc6, 0x33, 0x64, 0x01, 0xc0, 0x00, 0x02, 0x09,
+		0x01, 0xbb, 0x7d, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc8,
+		0x50, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+}
+
+func fuzzIPv6TCPSeed() []byte {
+	return []byte{
+		0x60, 0x00, 0x00, 0x00, 0x00, 0x14, 0x06, 0x40,
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09,
+		0x20, 0xfb, 0xb2, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5b,
+		0x50, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+}

--- a/trace/mpls_fuzz_test.go
+++ b/trace/mpls_fuzz_test.go
@@ -1,0 +1,43 @@
+package trace
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	traceinternal "github.com/nxtrace/NTrace-core/trace/internal"
+)
+
+const fuzzMPLSMaxBytes = 4096
+
+func FuzzExtractMPLS(f *testing.F) {
+	f.Add([]byte{
+		0x20, 0x00, 0x00, 0x00,
+		0x00, 0x0c, 0x01, 0x01,
+		0x03, 0xe8, 0x01, 0x3f,
+		0x07, 0xd0, 0x00, 0x40,
+	})
+	f.Add([]byte("not an ICMP extension"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > fuzzMPLSMaxBytes {
+			data = data[:fuzzMPLSMaxBytes]
+		}
+		labels := extractMPLS(traceinternal.ReceivedMessage{Msg: data}, false)
+		if len(labels) > len(data)/4 {
+			t.Fatalf("decoded %d labels from %d bytes", len(labels), len(data))
+		}
+		for _, label := range labels {
+			if !strings.HasPrefix(label, "[MPLS: ") || !strings.HasSuffix(label, "]") {
+				t.Fatalf("invalid MPLS label format %q", label)
+			}
+			var lbl, tc, bottom, ttl int
+			if n, err := fmt.Sscanf(label, "[MPLS: Lbl %d, TC %d, S %d, TTL %d]", &lbl, &tc, &bottom, &ttl); err != nil || n != 4 {
+				t.Fatalf("parse MPLS label %q: matched=%d error=%v", label, n, err)
+			}
+			if lbl < 0 || lbl > 0xfffff || tc < 0 || tc > 7 || bottom < 0 || bottom > 1 || ttl < 0 || ttl > 255 {
+				t.Fatalf("MPLS label fields outside protocol range: %q", label)
+			}
+		}
+	})
+}

--- a/trace/mtu/decode_fuzz_test.go
+++ b/trace/mtu/decode_fuzz_test.go
@@ -1,0 +1,76 @@
+package mtu
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+const fuzzEmbeddedUDPMaxBytes = 4096
+
+func FuzzParseEmbeddedUDPPacket(f *testing.F) {
+	f.Add(uint8(4), fuzzEmbeddedUDPSeed(4))
+	f.Add(uint8(6), fuzzEmbeddedUDPSeed(6))
+	f.Add(uint8(6), []byte{0x60, 0, 0, 0})
+
+	f.Fuzz(func(t *testing.T, version uint8, data []byte) {
+		if len(data) > fuzzEmbeddedUDPMaxBytes {
+			data = data[:fuzzEmbeddedUDPMaxBytes]
+		}
+		ipVersion := 4
+		if version == 6 || version%2 == 1 {
+			ipVersion = 6
+		}
+		packet, ok := parseEmbeddedUDPPacket(data, ipVersion)
+		if !ok {
+			return
+		}
+		if packet.dstIP == nil || packet.dstIP.To16() == nil {
+			t.Fatalf("parsed destination IP = %v", packet.dstIP)
+		}
+		if ipVersion == 4 && packet.dstIP.To4() == nil {
+			t.Fatalf("IPv4 parser returned destination %v", packet.dstIP)
+		}
+		if ipVersion == 6 && packet.dstIP.To4() != nil {
+			t.Fatalf("IPv6 parser returned destination %v", packet.dstIP)
+		}
+		if packet.srcPort < 0 || packet.srcPort > 65535 || packet.dstPort < 0 || packet.dstPort > 65535 {
+			t.Fatalf("ports outside 0..65535: source=%d destination=%d", packet.srcPort, packet.dstPort)
+		}
+
+		encoded := encodeFuzzEmbeddedUDP(ipVersion, packet)
+		roundTrip, valid := parseEmbeddedUDPPacket(encoded, ipVersion)
+		if !valid || !roundTrip.dstIP.Equal(packet.dstIP) || roundTrip.srcPort != packet.srcPort || roundTrip.dstPort != packet.dstPort {
+			t.Fatalf("embedded UDP round-trip = (%+v, %v), want %+v", roundTrip, valid, packet)
+		}
+	})
+}
+
+func fuzzEmbeddedUDPSeed(ipVersion int) []byte {
+	packet := embeddedUDPPacket{srcPort: 40000, dstPort: 33494}
+	if ipVersion == 4 {
+		packet.dstIP = []byte{192, 0, 2, 9}
+	} else {
+		packet.dstIP = []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9}
+	}
+	return encodeFuzzEmbeddedUDP(ipVersion, packet)
+}
+
+func encodeFuzzEmbeddedUDP(ipVersion int, packet embeddedUDPPacket) []byte {
+	if ipVersion == 4 {
+		encoded := make([]byte, 28)
+		encoded[0] = 0x45
+		encoded[9] = 17
+		copy(encoded[16:20], packet.dstIP.To4())
+		binary.BigEndian.PutUint16(encoded[20:22], uint16(packet.srcPort))
+		binary.BigEndian.PutUint16(encoded[22:24], uint16(packet.dstPort))
+		return encoded
+	}
+
+	encoded := make([]byte, 48)
+	encoded[0] = 0x60
+	encoded[6] = 17
+	copy(encoded[24:40], packet.dstIP.To16())
+	binary.BigEndian.PutUint16(encoded[40:42], uint16(packet.srcPort))
+	binary.BigEndian.PutUint16(encoded[42:44], uint16(packet.dstPort))
+	return encoded
+}


### PR DESCRIPTION
### Summary

- 为终端输入、ICMP/TCP/UDP、MPLS、DN42 GeoFeed、nali、DNS、deploy WebSocket init JSON 与 v3 WebSocket 响应增加 11 个原生 Go fuzz 目标。
- 提取两个最小纯解析 seam，保持生产解析行为不变。
- 增加 Go 1.27.1 nightly matrix：每个目标独立 fuzz 30 秒，失败时只上传最小 crash corpus。

### Problem

核心解析器此前只有示例单测和 benchmark，缺少面向任意输入的 panic、越界、span 重叠和数值范围验证。WebSocket init JSON 与 v3 响应解析嵌在生产调用链中，也无法在不启动连接的情况下独立 fuzz。

### Call chains

Before:

- `ReadMessage -> inline json.Unmarshal -> prepareTrace`
- `dispatch -> gjson.Parse -> field mapping`

After:

- `ReadMessage -> decodeWSInitRequest -> json.Unmarshal -> prepareTrace`
- `dispatch -> gjson.Parse -> shared field mapping`
- fuzz 专用 v3 严格入口先校验 JSON，再复用相同字段映射；生产 dispatch 保留原有宽松行为。

### Compatibility

- 不改变 CLI flags、退出码、stdout/stderr、JSON schema、消息顺序、MTR 统计、TTY/ANSI、协议包布局或导出 API。
- fuzz callback 在测试入口按协议上限截断输入，不访问 raw socket、真实网络或全局连接池。
- nightly 仅由 schedule/workflow_dispatch 触发；PR CI 只运行确定性 seed corpus。

### Testing

- `go test -count=1 ./...`：通过。
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`：通过。
- `go test -race -count=1 ./...`：通过。
- `go build ./...`、`go vet ./...`：通过。
- tiny/ntr 专项测试与构建：通过。
- `node --test server/web/assets/*.test.cjs`：15/15 通过。
- `go mod verify`、`go mod tidy -diff`：通过，无 diff。
- actionlint：通过。
- golangci-lint CI 等价增量检查：`0 issues`。完整 lint 的 75 个既有 baseline issue 未在本 PR 清理。
- 11 个 fuzz 目标 seed corpus 和逐目标 2–3 秒短时 fuzz：全部通过，无 crash corpus。
- `.cross_compile.sh all`：full/tiny/ntr 共 60 个产物，脚本退出 0；Darwin amd64/arm64 6/6 为 `LC_BUILD_VERSION minos 13.0`。

### Performance

环境：Apple M5、Go 1.27.1、`GOEXPERIMENT=nojsonv2`、`GOMAXPROCS=10`。完整 harness parent/head 各 10 次；首轮越线候选使用预编译二进制交替 20 次。

- WS JSON marshal/unmarshal 与 nali spans：10 次均无显著差异，分配不变。
- Geo cache + MTR Snapshot/preview：20 次 geomean `+0.01%`，8 项均不显著。
- ICMP/UDP decoder：20 次 geomean `-0.42%`，4 项均不显著。
- Geo HTTP multi-client：20 次 geomean `-0.37%`，4 项均不显著。

### Profiles and size

- parent/head 对 `BenchmarkFindIPSpans` 各采集 30 秒 CPU/heap profile；热点结构一致，无新增业务热点。
- 三 flavor Darwin arm64 未压缩大小全部不变；tiny/ntr UPX 大小不变；full UPX 增加 16,384 B。
- 详细 benchstat、profile、大小和测试证据见 `docs/performance/go127-parser-fuzzing.md`；原始文件由本地忽略目录和 CI artifact 保存。

### Platform risk

主要风险是 fuzz invariant 过严、nightly 成本和纯 seam 改变错误语义。短时 fuzz、两套 JSON 测试、race、round-trip、20 次性能校准和保持生产 v3 宽松入口覆盖这些边界。Darwin 最低版本保持 macOS 13.0。

### Rollback

可直接撤销纯解析 seam、fuzz 文件、nightly workflow 和证据文档。没有配置、协议、JSON、持久数据或导出 API 迁移，不需要数据处理。

### Commits

- `825ca99 test(fuzz): 覆盖核心协议与输入解析器`
- `f19276a ci(fuzz): 增加 Go 1.27.1 nightly 解析器模糊测试`
- `bb06a0f docs(perf): 记录解析器 fuzz 验证证据`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增覆盖网络协议、DNS、地理信息、WebSocket、终端解析及数据包处理的模糊测试。
  * 增加输入边界、解析结果有效性、确定性及编码往返一致性校验。

* **持续集成**
  * 新增每日及手动触发的自动化模糊测试流程，并在失败时保存崩溃样本。

* **文档**
  * 补充 Go 解析器模糊测试范围、运行方式、验证标准及失败处理说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->