### PR TITLE
perf(build): 评估 Go 1.27 默认 PGO 并记录 NO-GO 结论

### DIFF
--- a/docs/adr/0002-go127-default-pgo.md
+++ b/docs/adr/0002-go127-default-pgo.md
@@ -1,0 +1,43 @@
+# ADR 0002：Go 1.27 默认 PGO
+
+- 状态：接受
+- 日期：2026-09-05
+- 工具链：Go 1.27.1
+- 决策：不提交 `default.pgo`
+
+## 背景
+
+Go 可以自动使用主包目录中的 `default.pgo`，也可以通过 `-pgo=off` 显式禁用。
+profile 应来自有代表性的稳定 workload，并同时验证没有关键路径回退。
+
+- [Profile-guided optimization](https://go.dev/doc/pgo)
+
+本轮门槛为：三个综合 workload 的等权 CPU 表现显著改善至少 3%，且任一关键
+benchmark 均不得显著回退超过 1%。
+
+## 决策
+
+1. 不向仓库加入 `default.pgo`，发布构建继续不启用 PGO。
+2. 保留固定 fake prober/provider、协议 decoder、MTR/Geo JSON 与 WebSocket JSON
+   组成的复合 workload，以及 profile、benchmark、大小和启动测量脚本。
+3. 候选 CPU profile、原始 benchmark 和二进制只作为测量产物保存，不进入 Git。
+
+## 证据
+
+Apple M5、Go 1.27.1、`GOMAXPROCS=10`、`nojsonv2` 下，PGO 让三个 workload
+等权几何均值改善 6.58%，达到综合门槛；但同时产生以下显著回退：
+
+- TCP decoder IPv4 +6.40%，IPv6 +6.59%。
+- Geo cache hit +2.72%，miss +3.18%，cached lookup hit +5.03%。
+- MTR snapshot +3.36%。
+
+任一项均足以否决默认 PGO。完整 benchstat、产物大小、启动和 RSS 数据见
+[Go 1.27.1 默认 PGO 评估](../performance/go127-default-pgo.md)。
+
+## 影响与复评
+
+- CLI、协议、JSON 与构建 flavor 合同均不变。
+- 仓库没有 `default.pgo` 时，Go 的自动 PGO 不会改变正式产物；紧急排除 PGO 时仍可
+  显式传 `-pgo=off`。
+- Go 补丁版本、热点分布或 profile workload 变化后，可按保留脚本重新采样；只有
+  同时满足综合收益和全部 guardrail，才重新评估提交 `default.pgo`。

--- a/docs/adr/0002-go127-default-pgo.md
+++ b/docs/adr/0002-go127-default-pgo.md
@@ -25,11 +25,11 @@ benchmark 均不得显著回退超过 1%。
 ## 证据
 
 Apple M5、Go 1.27.1、`GOMAXPROCS=10`、`nojsonv2` 下，PGO 让三个 workload
-等权几何均值改善 6.58%，达到综合门槛；但同时产生以下显著回退：
+等权几何均值改善 5.59%，达到综合门槛；但同时产生以下显著回退：
 
-- TCP decoder IPv4 +6.40%，IPv6 +6.59%。
-- Geo cache hit +2.72%，miss +3.18%，cached lookup hit +5.03%。
-- MTR snapshot +3.36%。
+- TCP decoder IPv4 +5.07%，IPv6 +4.77%。
+- Geo cache hit +3.21%，miss +3.96%，eviction +5.21%，cached lookup hit +1.48%。
+- MTR snapshot +3.41%，preview +2.30%。
 
 任一项均足以否决默认 PGO。完整 benchstat、产物大小、启动和 RSS 数据见
 [Go 1.27.1 默认 PGO 评估](../performance/go127-default-pgo.md)。

--- a/docs/adr/0002-go127-default-pgo.md
+++ b/docs/adr/0002-go127-default-pgo.md
@@ -18,8 +18,8 @@ benchmark 均不得显著回退超过 1%。
 ## 决策
 
 1. 不向仓库加入 `default.pgo`，发布构建继续不启用 PGO。
-2. 保留固定 fake prober/provider、协议 decoder、MTR/Geo JSON 与 WebSocket JSON
-   组成的复合 workload，以及 profile、benchmark、大小和启动测量脚本。
+2. 保留固定 fake prober/provider（含直接和缓存路径）、协议 decoder、MTR/Geo JSON
+   与 WebSocket JSON 组成的复合 workload，以及 profile、benchmark、大小和启动测量脚本。
 3. 候选 CPU profile、原始 benchmark 和二进制只作为测量产物保存，不进入 Git。
 
 ## 证据

--- a/docs/performance/go127-default-pgo.md
+++ b/docs/performance/go127-default-pgo.md
@@ -1,0 +1,108 @@
+# Go 1.27.1 默认 PGO 评估
+
+## 结论
+
+不提交 `default.pgo`。候选 profile 让三个综合 workload 的等权几何均值改善
+6.58%，但 TCP decoder、Geo cache 和 MTR snapshot 均出现统计显著且超过 1%
+的回退，违反合并门槛。
+
+保留 workload、profile 生成脚本和对照脚本，便于 Go 工具链或热点分布变化后复测。
+
+## 环境与 workload
+
+- 基线提交：`edfc38cdf6b2baf9928ae2c5f72f8142648aeb9e`
+- 主机：Apple M5，10 核，32 GB；macOS 26.6.2；AC 供电
+- 工具：Go 1.27.1，`GOEXPERIMENT=nojsonv2`，`GOMAXPROCS=10`
+- benchstat：`golang.org/x/perf` `19be9d8e6c70`
+- UPX：5.2.1，`--force-macos -9`
+- 固定种子：`20260905`
+
+单一复合 workload 由三个等长阶段组成，每段采集 10 秒 CPU profile：
+
+1. IPv4/IPv6 ICMP、TCP、UDP 纯 decoder。
+2. fake prober 生成 64 TTL × 4 path，经过 MTR 聚合、fake Geo provider 与
+   `encoding/json` 输出。
+3. WebSocket envelope 编码和请求解码。
+
+三段 profile 使用 `go tool pprof -proto` 合并。候选 profile SHA-256 为
+`6ac6a4c7c72beeaf0662240514a4a6badc882ff887474a8f45dd74396e4fdd1a`。
+
+## Benchmark
+
+PGO off/on 各执行 10 次、每次至少 1 秒。等权综合值使用三个 workload
+`ns/op` 中位数比值的几何均值。
+
+| 综合 workload | PGO off | PGO on | 变化 |
+| --- | ---: | ---: | ---: |
+| Protocol decoder | 369.5 ns/op | 367.2 ns/op | -0.62%，p=0.011 |
+| MTR + Geo JSON | 260.3 µs/op | 237.6 µs/op | -8.73%，p=0.000 |
+| WebSocket JSON | 2.918 µs/op | 2.623 µs/op | -10.11%，p=0.000 |
+| 等权几何均值 | — | — | **-6.58%** |
+
+复合 MTR + Geo JSON 的 B/op 增加 0.54%（p=0.000）；其 allocs/op 与另外两个
+workload 的内存指标未变化。
+
+关键 guardrail：
+
+| 路径 | PGO 变化 | 判定 |
+| --- | ---: | --- |
+| ICMP decoder IPv4 / IPv6 | -1.46% / -1.32% | 改善，均显著 |
+| TCP decoder IPv4 / IPv6 | +6.40% / +6.59% | **回退，均 p=0.000** |
+| UDP decoder IPv4 / IPv6 | +0.40% / 无显著变化 | 通过 |
+| Geo cache hit / miss | +2.72% / +3.18% | **回退，p≤0.001** |
+| Geo cache eviction / parallel | 无显著变化 | 通过 |
+| Geo cached lookup hit | +5.03% | **回退，p=0.000** |
+| Geo parallel lookup hit | 无显著变化 | 通过 |
+| MTR Update | -1.68% | 改善，p=0.002 |
+| MTR Snapshot | +3.36% | **回退，p=0.002** |
+| MTR preview | -0.32% | 通过 |
+| WebSocket marshal / unmarshal | -11.51% / -6.16% | 改善，均 p=0.000 |
+
+所有 guardrail 的 B/op 与 allocs/op 均未变化。回退已经统计明确，不需要增加到
+20 次。
+
+## Darwin 产物
+
+两侧使用相同 macOS 13.0 deployment target、
+`-buildvcs=false -trimpath -ldflags '-s -w -buildid= -macos=13.0'` 和 UPX 参数。
+六个产物的 `LC_BUILD_VERSION` 均为 `minos 13.0`。
+
+| Flavor | PGO off 未压缩 / UPX | PGO on 未压缩 / UPX | 未压缩变化 | UPX 变化 |
+| --- | ---: | ---: | ---: | ---: |
+| nexttrace | 30,143,154 / 10,158,096 B | 30,192,658 / 10,174,480 B | +0.16% | +0.16% |
+| nexttrace-tiny | 11,066,466 / 4,276,240 B | 11,132,498 / 4,309,008 B | +0.60% | +0.77% |
+| ntr | 11,066,466 / 4,276,240 B | 11,132,498 / 4,309,008 B | +0.60% | +0.77% |
+
+## `--help` 启动与峰值 RSS
+
+每个新构建产物无预热运行 10 次。“首次启动”记录新产物第一次执行；“后续中位数”
+取其余 9 次的中位数；RSS 为 10 次 `/usr/bin/time -l` 的最大观测值。首次执行受
+macOS 首次验证影响，只作记录。
+
+| Flavor | PGO off 首次 / 后续中位数 | PGO on 首次 / 后续中位数 | PGO off / on 最大 RSS |
+| --- | ---: | ---: | ---: |
+| nexttrace | 644.691 / 16.910 ms | 519.728 / 16.976 ms | 30,031,872 / 30,031,872 B |
+| nexttrace-tiny | 438.096 / 15.803 ms | 438.289 / 15.558 ms | 23,511,040 / 23,478,272 B |
+| ntr | 455.425 / 15.459 ms | 449.588 / 15.908 ms | 23,166,976 / 23,658,496 B |
+
+启动和 RSS 没有改变 NO-GO 结论；ntr 后续启动中位数与最大 RSS 还分别增加
+2.91% 和 2.12%。
+
+## 复现
+
+profile 与 benchmark：
+
+```sh
+scripts/perf/generate_pgo_profile.sh pr8b-edfc38c
+scripts/perf/run_pgo_benchmarks.sh pr8b-pgo-off off
+scripts/perf/run_pgo_benchmarks.sh pr8b-pgo-on .cache/perf/pr8b-edfc38c.candidate.pgo
+go tool benchstat .cache/perf/pr8b-pgo-off.workload.bench.txt .cache/perf/pr8b-pgo-on.workload.bench.txt
+go tool benchstat .cache/perf/pr8b-pgo-off.guardrail.bench.txt .cache/perf/pr8b-pgo-on.guardrail.bench.txt
+```
+
+Darwin 产物需同时设置 `MACOSX_DEPLOYMENT_TARGET=13.0`、SDK 对应的
+`CGO_CFLAGS` / `CGO_LDFLAGS`、上述 linker 参数和 `PERF_BINARY_DIR`，然后运行
+`measure_binaries.sh`。启动/RSS 使用 `measure_help_startup.sh`。
+
+原始 benchmark、profile 和二进制位于忽略的 `.cache/perf`，不提交候选
+`default.pgo`。未来复测必须先提交 workload，再生成与精确提交对应的新 profile。

--- a/docs/performance/go127-default-pgo.md
+++ b/docs/performance/go127-default-pgo.md
@@ -3,14 +3,14 @@
 ## 结论
 
 不提交 `default.pgo`。候选 profile 让三个综合 workload 的等权几何均值改善
-6.58%，但 TCP decoder、Geo cache 和 MTR snapshot 均出现统计显著且超过 1%
-的回退，违反合并门槛。
+5.59%，但 TCP decoder、Geo cache、MTR snapshot 和 preview 均出现统计显著且
+超过 1% 的回退，违反合并门槛。
 
 保留 workload、profile 生成脚本和对照脚本，便于 Go 工具链或热点分布变化后复测。
 
 ## 环境与 workload
 
-- 基线提交：`edfc38cdf6b2baf9928ae2c5f72f8142648aeb9e`
+- 基线提交：`954267663dc9daeb70b80f2d3da7907af2bf9ff7`
 - 主机：Apple M5，10 核，32 GB；macOS 26.6.2；AC 供电
 - 工具：Go 1.27.1，`GOEXPERIMENT=nojsonv2`，`GOMAXPROCS=10`
 - benchstat：`golang.org/x/perf` `19be9d8e6c70`
@@ -25,7 +25,7 @@
 3. WebSocket envelope 编码和请求解码。
 
 三段 profile 使用 `go tool pprof -proto` 合并。候选 profile SHA-256 为
-`6ac6a4c7c72beeaf0662240514a4a6badc882ff887474a8f45dd74396e4fdd1a`。
+`4d3d8582e063dc3d893f9f398ec601d55966c5ac6c00666695475e03527fb3a5`。
 
 ## Benchmark
 
@@ -34,29 +34,28 @@ PGO off/on 各执行 10 次、每次至少 1 秒。等权综合值使用三个 w
 
 | 综合 workload | PGO off | PGO on | 变化 |
 | --- | ---: | ---: | ---: |
-| Protocol decoder | 369.5 ns/op | 367.2 ns/op | -0.62%，p=0.011 |
-| MTR + Geo JSON | 260.3 µs/op | 237.6 µs/op | -8.73%，p=0.000 |
-| WebSocket JSON | 2.918 µs/op | 2.623 µs/op | -10.11%，p=0.000 |
-| 等权几何均值 | — | — | **-6.58%** |
+| Protocol decoder | 371.8 ns/op | 363.6 ns/op | -2.22%，p=0.000 |
+| MTR + Geo JSON | 259.9 µs/op | 242.9 µs/op | -6.54%，p=0.000 |
+| WebSocket JSON | 2.879 µs/op | 2.651 µs/op | -7.90%，p=0.004 |
+| 等权几何均值 | — | — | **-5.59%** |
 
-复合 MTR + Geo JSON 的 B/op 增加 0.54%（p=0.000）；其 allocs/op 与另外两个
-workload 的内存指标未变化。
+三个 workload 的 B/op 与 allocs/op 均无显著变化。
 
 关键 guardrail：
 
 | 路径 | PGO 变化 | 判定 |
 | --- | ---: | --- |
-| ICMP decoder IPv4 / IPv6 | -1.46% / -1.32% | 改善，均显著 |
-| TCP decoder IPv4 / IPv6 | +6.40% / +6.59% | **回退，均 p=0.000** |
-| UDP decoder IPv4 / IPv6 | +0.40% / 无显著变化 | 通过 |
-| Geo cache hit / miss | +2.72% / +3.18% | **回退，p≤0.001** |
-| Geo cache eviction / parallel | 无显著变化 | 通过 |
-| Geo cached lookup hit | +5.03% | **回退，p=0.000** |
-| Geo parallel lookup hit | 无显著变化 | 通过 |
-| MTR Update | -1.68% | 改善，p=0.002 |
-| MTR Snapshot | +3.36% | **回退，p=0.002** |
-| MTR preview | -0.32% | 通过 |
-| WebSocket marshal / unmarshal | -11.51% / -6.16% | 改善，均 p=0.000 |
+| ICMP decoder IPv4 / IPv6 | -3.39% / -1.72% | 改善，p≤0.006 |
+| TCP decoder IPv4 / IPv6 | +5.07% / +4.77% | **回退，均 p=0.000** |
+| UDP decoder IPv4 / IPv6 | 无显著变化 / -0.30% | 通过 |
+| Geo cache hit / miss | +3.21% / +3.96% | **回退，均 p=0.000** |
+| Geo cache eviction / parallel | +5.21% / 无显著变化 | **eviction 回退，p=0.000** |
+| Geo cached lookup hit | +1.48% | **回退，p=0.000** |
+| Geo parallel lookup hit | -1.45% | 改善，p=0.018 |
+| MTR Update | 无显著变化 | 通过 |
+| MTR Snapshot | +3.41% | **回退，p=0.000** |
+| MTR preview | +2.30% | **回退，p=0.000** |
+| WebSocket marshal / unmarshal | -10.42% / -5.72% | 改善，均 p=0.000 |
 
 所有 guardrail 的 B/op 与 allocs/op 均未变化。回退已经统计明确，不需要增加到
 20 次。
@@ -69,9 +68,9 @@ workload 的内存指标未变化。
 
 | Flavor | PGO off 未压缩 / UPX | PGO on 未压缩 / UPX | 未压缩变化 | UPX 变化 |
 | --- | ---: | ---: | ---: | ---: |
-| nexttrace | 30,143,154 / 10,158,096 B | 30,192,658 / 10,174,480 B | +0.16% | +0.16% |
-| nexttrace-tiny | 11,066,466 / 4,276,240 B | 11,132,498 / 4,309,008 B | +0.60% | +0.77% |
-| ntr | 11,066,466 / 4,276,240 B | 11,132,498 / 4,309,008 B | +0.60% | +0.77% |
+| nexttrace | 30,143,154 / 10,158,096 B | 30,192,674 / 10,174,480 B | +0.16% | +0.16% |
+| nexttrace-tiny | 11,066,466 / 4,276,240 B | 11,149,026 / 4,309,008 B | +0.75% | +0.77% |
+| ntr | 11,066,466 / 4,276,240 B | 11,149,026 / 4,309,008 B | +0.75% | +0.77% |
 
 ## `--help` 启动与峰值 RSS
 
@@ -81,23 +80,23 @@ macOS 首次验证影响，只作记录。
 
 | Flavor | PGO off 首次 / 后续中位数 | PGO on 首次 / 后续中位数 | PGO off / on 最大 RSS |
 | --- | ---: | ---: | ---: |
-| nexttrace | 644.691 / 16.910 ms | 519.728 / 16.976 ms | 30,031,872 / 30,031,872 B |
-| nexttrace-tiny | 438.096 / 15.803 ms | 438.289 / 15.558 ms | 23,511,040 / 23,478,272 B |
-| ntr | 455.425 / 15.459 ms | 449.588 / 15.908 ms | 23,166,976 / 23,658,496 B |
+| nexttrace | 878.807 / 17.003 ms | 733.432 / 16.880 ms | 29,818,880 / 30,130,176 B |
+| nexttrace-tiny | 391.338 / 15.721 ms | 396.602 / 15.705 ms | 23,625,728 / 23,412,736 B |
+| ntr | 391.187 / 15.553 ms | 425.306 / 15.792 ms | 23,543,808 / 23,314,432 B |
 
-启动和 RSS 没有改变 NO-GO 结论；ntr 后续启动中位数与最大 RSS 还分别增加
-2.91% 和 2.12%。
+启动和 RSS 波动没有改变 NO-GO 结论；后续启动中位数的最大变化为 ntr +1.54%，
+最大 RSS 的最大变化为 nexttrace +1.04%。
 
 ## 复现
 
 profile 与 benchmark：
 
 ```sh
-scripts/perf/generate_pgo_profile.sh pr8b-edfc38c
-scripts/perf/run_pgo_benchmarks.sh pr8b-pgo-off off
-scripts/perf/run_pgo_benchmarks.sh pr8b-pgo-on .cache/perf/pr8b-edfc38c.candidate.pgo
-go tool benchstat .cache/perf/pr8b-pgo-off.workload.bench.txt .cache/perf/pr8b-pgo-on.workload.bench.txt
-go tool benchstat .cache/perf/pr8b-pgo-off.guardrail.bench.txt .cache/perf/pr8b-pgo-on.guardrail.bench.txt
+scripts/perf/generate_pgo_profile.sh pr8b-9542676
+scripts/perf/run_pgo_benchmarks.sh pr8b-9542676-pgo-off off
+scripts/perf/run_pgo_benchmarks.sh pr8b-9542676-pgo-on .cache/perf/pr8b-9542676.candidate.pgo
+go tool benchstat .cache/perf/pr8b-9542676-pgo-off.workload.bench.txt .cache/perf/pr8b-9542676-pgo-on.workload.bench.txt
+go tool benchstat .cache/perf/pr8b-9542676-pgo-off.guardrail.bench.txt .cache/perf/pr8b-9542676-pgo-on.guardrail.bench.txt
 ```
 
 Darwin 产物需同时设置 `MACOSX_DEPLOYMENT_TARGET=13.0`、SDK 对应的

--- a/docs/performance/go127-default-pgo.md
+++ b/docs/performance/go127-default-pgo.md
@@ -20,8 +20,8 @@
 单一复合 workload 由三个等长阶段组成，每段采集 10 秒 CPU profile：
 
 1. IPv4/IPv6 ICMP、TCP、UDP 纯 decoder。
-2. fake prober 生成 64 TTL × 4 path，经过 MTR 聚合、fake Geo provider 与
-   `encoding/json` 输出。
+2. fake prober 生成 64 TTL × 4 path，经过 MTR 聚合、fake Geo provider
+   直接/缓存路径与 `encoding/json` 输出。
 3. WebSocket envelope 编码和请求解码。
 
 三段 profile 使用 `go tool pprof -proto` 合并。候选 profile SHA-256 为

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -50,3 +50,37 @@ scripts/perf/measure_help_startup.sh go127 \
   nexttrace-tiny /path/to/nexttrace-tiny \
   ntr /path/to/ntr
 ```
+
+## Default PGO evaluation
+
+Generate a 30-second candidate profile from three equally timed deterministic
+workloads. They cover the protocol decoders, fake-prober MTR aggregation with a
+fake Geo provider and JSON output, and WebSocket JSON encode/decode:
+
+```sh
+scripts/perf/generate_pgo_profile.sh candidate
+```
+
+Compare `-pgo=off` with the candidate using ten one-second samples. The
+`workload` files contain only the three equally weighted profile workloads; the
+`guardrail` files contain the individual critical paths:
+
+```sh
+scripts/perf/run_pgo_benchmarks.sh pgo-off off
+scripts/perf/run_pgo_benchmarks.sh pgo-on .cache/perf/candidate.candidate.pgo
+go tool benchstat .cache/perf/pgo-off.workload.bench.txt .cache/perf/pgo-on.workload.bench.txt
+go tool benchstat .cache/perf/pgo-off.guardrail.bench.txt .cache/perf/pgo-on.guardrail.bench.txt
+```
+
+The scripts fix `GOEXPERIMENT=nojsonv2`, `GOMAXPROCS=10`, and seed `20260905`
+by default. If a threshold is crossed without statistical confidence, rerun
+both sides with `BENCH_COUNT=20`.
+
+Set `PERF_BINARY_DIR` to keep the exact binaries built by
+`measure_binaries.sh` for startup and RSS comparison:
+
+```sh
+GOFLAGS=-pgo=off PERF_BINARY_DIR=.cache/perf/pgo-off-bin scripts/perf/measure_binaries.sh pgo-off
+GOFLAGS=-pgo=$PWD/.cache/perf/candidate.candidate.pgo \
+  PERF_BINARY_DIR=.cache/perf/pgo-on-bin scripts/perf/measure_binaries.sh pgo-on
+```

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -53,9 +53,10 @@ scripts/perf/measure_help_startup.sh go127 \
 
 ## Default PGO evaluation
 
-Generate a 30-second candidate profile from three equally timed deterministic
-workloads. They cover the protocol decoders, fake-prober MTR aggregation with a
-fake Geo provider and JSON output, and WebSocket JSON encode/decode:
+Generate a 30-second candidate profile from one deterministic composite
+workload with three equally timed phases. It covers the protocol decoders,
+fake-prober MTR aggregation with a fake Geo provider and JSON output, and
+WebSocket JSON encode/decode:
 
 ```sh
 scripts/perf/generate_pgo_profile.sh candidate

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -55,8 +55,8 @@ scripts/perf/measure_help_startup.sh go127 \
 
 Generate a 30-second candidate profile from one deterministic composite
 workload with three equally timed phases. It covers the protocol decoders,
-fake-prober MTR aggregation with a fake Geo provider and JSON output, and
-WebSocket JSON encode/decode:
+fake-prober MTR aggregation with direct and cached fake Geo provider paths and
+JSON output, and WebSocket JSON encode/decode:
 
 ```sh
 scripts/perf/generate_pgo_profile.sh candidate

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -81,7 +81,8 @@ Set `PERF_BINARY_DIR` to keep the exact binaries built by
 `measure_binaries.sh` for startup and RSS comparison:
 
 ```sh
-GOFLAGS=-pgo=off PERF_BINARY_DIR=.cache/perf/pgo-off-bin scripts/perf/measure_binaries.sh pgo-off
-GOFLAGS=-pgo=$PWD/.cache/perf/candidate.candidate.pgo \
+GOEXPERIMENT=nojsonv2 GOFLAGS=-pgo=off \
+  PERF_BINARY_DIR=.cache/perf/pgo-off-bin scripts/perf/measure_binaries.sh pgo-off
+GOEXPERIMENT=nojsonv2 GOFLAGS=-pgo=$PWD/.cache/perf/candidate.candidate.pgo \
   PERF_BINARY_DIR=.cache/perf/pgo-on-bin scripts/perf/measure_binaries.sh pgo-on
 ```

--- a/scripts/perf/generate_pgo_profile.sh
+++ b/scripts/perf/generate_pgo_profile.sh
@@ -84,6 +84,11 @@ profile_component ./server BenchmarkPGOWebSocketJSONWorkload websocket-json
 candidate="${RESULT_DIR}/${RESULT_NAME}.candidate.pgo"
 go tool pprof -proto -output "${candidate}" "${profiles[@]}"
 
+candidate_sha256="$(sha256_file "${candidate}")" || {
+  echo "error: failed to calculate SHA-256 for ${candidate}" >&2
+  exit 1
+}
+
 manifest="${RESULT_DIR}/${RESULT_NAME}.profile.txt"
 {
   printf 'commit=%s\n' "$(git -C "${ROOT_DIR}" rev-parse HEAD)"
@@ -97,7 +102,7 @@ manifest="${RESULT_DIR}/${RESULT_NAME}.profile.txt"
   printf 'profile_2=./trace:BenchmarkPGOTraceWorkload\n'
   printf 'profile_3=./server:BenchmarkPGOWebSocketJSONWorkload\n'
   printf 'candidate=%s\n' "${candidate}"
-  printf 'candidate_sha256=%s\n' "$(sha256_file "${candidate}")"
+  printf 'candidate_sha256=%s\n' "${candidate_sha256}"
 } >"${manifest}"
 
 cat "${manifest}"

--- a/scripts/perf/generate_pgo_profile.sh
+++ b/scripts/perf/generate_pgo_profile.sh
@@ -10,6 +10,9 @@ PROFILE_COMPONENT_TIME="${PROFILE_COMPONENT_TIME:-10s}"
 BENCH_GOMAXPROCS="${BENCH_GOMAXPROCS:-10}"
 PGO_SEED=20260905
 PGO_GOEXPERIMENT="${PGO_GOEXPERIMENT:-nojsonv2}"
+REQUIRED_GO_VERSION=go1.27.1
+
+export GOTOOLCHAIN="${REQUIRED_GO_VERSION}"
 
 if [[ "${RESULT_DIR}" != /* ]]; then
   RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
@@ -19,12 +22,31 @@ mkdir -p "${RESULT_DIR}"
 export GOMAXPROCS="${BENCH_GOMAXPROCS}"
 export GOEXPERIMENT="${PGO_GOEXPERIMENT}"
 
+actual_go_version="$(go env GOVERSION)"
+if [[ "${actual_go_version}" != "${REQUIRED_GO_VERSION}" ]]; then
+  echo "error: ${REQUIRED_GO_VERSION} required, got ${actual_go_version}" >&2
+  exit 1
+fi
+
 if [[ -n "$(git -C "${ROOT_DIR}" status --porcelain)" ]]; then
   echo "error: commit the workload before generating its PGO profile" >&2
   exit 1
 fi
 
 profiles=()
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+    return
+  fi
+  echo "error: no SHA-256 utility found" >&2
+  return 1
+}
+
 profile_component() {
   local package="$1"
   local benchmark="$2"
@@ -75,7 +97,7 @@ manifest="${RESULT_DIR}/${RESULT_NAME}.profile.txt"
   printf 'profile_2=./trace:BenchmarkPGOTraceWorkload\n'
   printf 'profile_3=./server:BenchmarkPGOWebSocketJSONWorkload\n'
   printf 'candidate=%s\n' "${candidate}"
-  printf 'candidate_sha256=%s\n' "$(shasum -a 256 "${candidate}" | awk '{print $1}')"
+  printf 'candidate_sha256=%s\n' "$(sha256_file "${candidate}")"
 } >"${manifest}"
 
 cat "${manifest}"

--- a/scripts/perf/generate_pgo_profile.sh
+++ b/scripts/perf/generate_pgo_profile.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CALLER_DIR="${PWD}"
+RESULT_NAME="${1:-$(git -C "${ROOT_DIR}" rev-parse --short HEAD)-pgo}"
+RESULT_DIR="${PERF_RESULT_DIR:-${ROOT_DIR}/.cache/perf}"
+PROFILE_COMPONENT_TIME="${PROFILE_COMPONENT_TIME:-10s}"
+BENCH_GOMAXPROCS="${BENCH_GOMAXPROCS:-10}"
+PGO_SEED=20260905
+PGO_GOEXPERIMENT="${PGO_GOEXPERIMENT:-nojsonv2}"
+
+if [[ "${RESULT_DIR}" != /* ]]; then
+  RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
+fi
+
+mkdir -p "${RESULT_DIR}"
+export GOMAXPROCS="${BENCH_GOMAXPROCS}"
+export GOEXPERIMENT="${PGO_GOEXPERIMENT}"
+
+if [[ -n "$(git -C "${ROOT_DIR}" status --porcelain)" ]]; then
+  echo "error: commit the workload before generating its PGO profile" >&2
+  exit 1
+fi
+
+profiles=()
+profile_component() {
+  local package="$1"
+  local benchmark="$2"
+  local label="$3"
+  local profile="${RESULT_DIR}/${RESULT_NAME}.${label}.cpu.pprof"
+  local benchmark_list
+
+  benchmark_list="$(
+    cd "${ROOT_DIR}"
+    go test -pgo=off -run '^$' -list "^${benchmark}$" "${package}"
+  )"
+  if ! grep -qx "${benchmark}" <<<"${benchmark_list}"; then
+    echo "benchmark not found in ${package}: ${benchmark}" >&2
+    exit 1
+  fi
+
+  (
+    cd "${ROOT_DIR}"
+    go test \
+      -pgo=off \
+      -run '^$' \
+      -bench "^${benchmark}$" \
+      -benchtime "${PROFILE_COMPONENT_TIME}" \
+      -count 1 \
+      -cpuprofile "${profile}" \
+      "${package}"
+  )
+  profiles+=("${profile}")
+}
+
+profile_component ./trace/internal BenchmarkPGOProtocolDecodeWorkload protocol-decode
+profile_component ./trace BenchmarkPGOTraceWorkload trace-mtr-geo-json
+profile_component ./server BenchmarkPGOWebSocketJSONWorkload websocket-json
+
+candidate="${RESULT_DIR}/${RESULT_NAME}.candidate.pgo"
+go tool pprof -proto -output "${candidate}" "${profiles[@]}"
+
+manifest="${RESULT_DIR}/${RESULT_NAME}.profile.txt"
+{
+  printf 'commit=%s\n' "$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+  printf 'go_version=%s\n' "$(go version)"
+  printf 'goexperiment=%s\n' "${GOEXPERIMENT}"
+  printf 'gomaxprocs=%s\n' "${GOMAXPROCS}"
+  printf 'seed=%s\n' "${PGO_SEED}"
+  printf 'component_time=%s\n' "${PROFILE_COMPONENT_TIME}"
+  printf 'components=3\n'
+  printf 'profile_1=./trace/internal:BenchmarkPGOProtocolDecodeWorkload\n'
+  printf 'profile_2=./trace:BenchmarkPGOTraceWorkload\n'
+  printf 'profile_3=./server:BenchmarkPGOWebSocketJSONWorkload\n'
+  printf 'candidate=%s\n' "${candidate}"
+  printf 'candidate_sha256=%s\n' "$(shasum -a 256 "${candidate}" | awk '{print $1}')"
+} >"${manifest}"
+
+cat "${manifest}"
+echo "Candidate PGO profile: ${candidate}"

--- a/scripts/perf/measure_binaries.sh
+++ b/scripts/perf/measure_binaries.sh
@@ -6,15 +6,28 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CALLER_DIR="${PWD}"
 RESULT_NAME="${1:-$(git -C "${ROOT_DIR}" rev-parse --short HEAD)}"
 RESULT_DIR="${PERF_RESULT_DIR:-${ROOT_DIR}/.cache/perf}"
-BUILD_DIR="$(mktemp -d)"
 PERF_LDFLAGS="${PERF_LDFLAGS:--s -w -buildid=}"
+REMOVE_BUILD_DIR=true
+
+if [[ -n "${PERF_BINARY_DIR:-}" ]]; then
+  BUILD_DIR="${PERF_BINARY_DIR}"
+  if [[ "${BUILD_DIR}" != /* ]]; then
+    BUILD_DIR="${CALLER_DIR}/${BUILD_DIR}"
+  fi
+  mkdir -p "${BUILD_DIR}"
+  REMOVE_BUILD_DIR=false
+else
+  BUILD_DIR="$(mktemp -d)"
+fi
 
 if [[ "${RESULT_DIR}" != /* ]]; then
   RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
 fi
 
 cleanup() {
-  rm -rf -- "${BUILD_DIR}"
+  if [[ "${REMOVE_BUILD_DIR}" == true ]]; then
+    rm -rf -- "${BUILD_DIR}"
+  fi
 }
 trap cleanup EXIT
 

--- a/scripts/perf/run_pgo_benchmarks.sh
+++ b/scripts/perf/run_pgo_benchmarks.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 RESULT_NAME PGO_PROFILE|off" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CALLER_DIR="${PWD}"
+RESULT_NAME="$1"
+PGO_PROFILE="$2"
+RESULT_DIR="${PERF_RESULT_DIR:-${ROOT_DIR}/.cache/perf}"
+BENCH_COUNT="${BENCH_COUNT:-10}"
+BENCH_TIME="${BENCH_TIME:-1s}"
+BENCH_GOMAXPROCS="${BENCH_GOMAXPROCS:-10}"
+PGO_GOEXPERIMENT="${PGO_GOEXPERIMENT:-nojsonv2}"
+
+if [[ "${RESULT_DIR}" != /* ]]; then
+  RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
+fi
+if [[ "${PGO_PROFILE}" != "off" && "${PGO_PROFILE}" != /* ]]; then
+  PGO_PROFILE="${CALLER_DIR}/${PGO_PROFILE}"
+fi
+if [[ "${PGO_PROFILE}" != "off" && ! -f "${PGO_PROFILE}" ]]; then
+  echo "PGO profile not found: ${PGO_PROFILE}" >&2
+  exit 1
+fi
+
+mkdir -p "${RESULT_DIR}"
+export GOMAXPROCS="${BENCH_GOMAXPROCS}"
+export GOEXPERIMENT="${PGO_GOEXPERIMENT}"
+
+run_group() {
+  local group="$1"
+  local benchmark_pattern="$2"
+  shift 2
+  local output="${RESULT_DIR}/${RESULT_NAME}.${group}.bench.txt"
+
+  (
+    cd "${ROOT_DIR}"
+    go version
+    echo "GOEXPERIMENT=${GOEXPERIMENT}"
+    echo "GOMAXPROCS=${GOMAXPROCS}"
+    echo "PGO_PROFILE=${PGO_PROFILE}"
+    go test \
+      -pgo="${PGO_PROFILE}" \
+      -run '^$' \
+      -bench "${benchmark_pattern}" \
+      -benchmem \
+      -benchtime "${BENCH_TIME}" \
+      -count "${BENCH_COUNT}" \
+      "$@"
+  ) | tee "${output}"
+  echo "${group} benchmark results: ${output}"
+}
+
+run_group workload \
+  '^(BenchmarkPGOProtocolDecodeWorkload|BenchmarkPGOTraceWorkload|BenchmarkPGOWebSocketJSONWorkload)$' \
+  ./trace/internal ./trace ./server
+
+run_group guardrail \
+  '^(BenchmarkDecodeICMPSocketMessage|BenchmarkDecodeTCPProbePacket|BenchmarkDecodeUDPSocketMessage|BenchmarkMTRAggregatorUpdate64TTL4Paths|BenchmarkMTRAggregatorSnapshot64TTL4Paths|BenchmarkMTRAggregatorPreviewCloneUpdate64TTL4Paths|BenchmarkGeoCacheAccess|BenchmarkWebSocketJSONMarshalEnvelope|BenchmarkWebSocketJSONUnmarshalRequest)$' \
+  ./trace/internal ./trace ./server

--- a/scripts/perf/run_pgo_benchmarks.sh
+++ b/scripts/perf/run_pgo_benchmarks.sh
@@ -16,6 +16,9 @@ BENCH_COUNT="${BENCH_COUNT:-10}"
 BENCH_TIME="${BENCH_TIME:-1s}"
 BENCH_GOMAXPROCS="${BENCH_GOMAXPROCS:-10}"
 PGO_GOEXPERIMENT="${PGO_GOEXPERIMENT:-nojsonv2}"
+REQUIRED_GO_VERSION=go1.27.1
+
+export GOTOOLCHAIN="${REQUIRED_GO_VERSION}"
 
 if [[ "${RESULT_DIR}" != /* ]]; then
   RESULT_DIR="${CALLER_DIR}/${RESULT_DIR}"
@@ -31,6 +34,12 @@ fi
 mkdir -p "${RESULT_DIR}"
 export GOMAXPROCS="${BENCH_GOMAXPROCS}"
 export GOEXPERIMENT="${PGO_GOEXPERIMENT}"
+
+actual_go_version="$(go env GOVERSION)"
+if [[ "${actual_go_version}" != "${REQUIRED_GO_VERSION}" ]]; then
+  echo "error: ${REQUIRED_GO_VERSION} required, got ${actual_go_version}" >&2
+  exit 1
+fi
 
 run_group() {
   local group="$1"

--- a/server/ws_json_benchmark_test.go
+++ b/server/ws_json_benchmark_test.go
@@ -104,14 +104,15 @@ func benchmarkWebSocketRequestPayload() []byte {
 func BenchmarkPGOWebSocketJSONWorkload(b *testing.B) {
 	envelope := benchmarkWebSocketEnvelope()
 	payload := benchmarkWebSocketRequestPayload()
-	if _, err := json.Marshal(envelope); err != nil {
+	encodedSample, err := json.Marshal(envelope)
+	if err != nil {
 		b.Fatalf("marshal sample envelope: %v", err)
 	}
 	var sample traceRequest
 	if err := json.Unmarshal(payload, &sample); err != nil {
 		b.Fatalf("unmarshal sample request: %v", err)
 	}
-	b.SetBytes(int64(len(payload)))
+	b.SetBytes(int64(len(payload) + len(encodedSample)))
 	b.ReportAllocs()
 
 	for b.Loop() {

--- a/server/ws_json_benchmark_test.go
+++ b/server/ws_json_benchmark_test.go
@@ -13,7 +13,25 @@ var (
 )
 
 func BenchmarkWebSocketJSONMarshalEnvelope(b *testing.B) {
-	envelope := wsEnvelope{
+	envelope := benchmarkWebSocketEnvelope()
+	sample, err := json.Marshal(envelope)
+	if err != nil {
+		b.Fatalf("marshal sample envelope: %v", err)
+	}
+	b.SetBytes(int64(len(sample)))
+	b.ReportAllocs()
+
+	for b.Loop() {
+		encoded, err := json.Marshal(envelope)
+		if err != nil {
+			b.Fatalf("marshal websocket envelope: %v", err)
+		}
+		wsJSONBytesSink = encoded
+	}
+}
+
+func benchmarkWebSocketEnvelope() wsEnvelope {
+	return wsEnvelope{
 		Type: "mtr_raw",
 		Data: trace.MTRRawRecord{
 			Iteration: 8,
@@ -35,24 +53,10 @@ func BenchmarkWebSocketJSONMarshalEnvelope(b *testing.B) {
 			},
 		},
 	}
-	sample, err := json.Marshal(envelope)
-	if err != nil {
-		b.Fatalf("marshal sample envelope: %v", err)
-	}
-	b.SetBytes(int64(len(sample)))
-	b.ReportAllocs()
-
-	for b.Loop() {
-		encoded, err := json.Marshal(envelope)
-		if err != nil {
-			b.Fatalf("marshal websocket envelope: %v", err)
-		}
-		wsJSONBytesSink = encoded
-	}
 }
 
 func BenchmarkWebSocketJSONUnmarshalRequest(b *testing.B) {
-	payload := []byte(`{"target":"example.test","protocol":"udp","port":33494,"queries":3,"max_hops":64,"timeout_ms":2000,"packet_size":84,"tos":32,"parallel_requests":16,"begin_hop":1,"ipv6_only":true,"data_provider":"NextTrace-API","dot_server":"dns.example:853","always_rdns":true,"disable_maptrace":true,"language":"en","source_address":"2001:db8::10","source_device":"en0","packet_interval":50,"ttl_interval":300,"mode":"mtr","hop_interval_ms":1000,"max_rounds":10}`)
+	payload := benchmarkWebSocketRequestPayload()
 	var sample traceRequest
 	if err := json.Unmarshal(payload, &sample); err != nil {
 		b.Fatalf("unmarshal sample websocket request: %v", err)
@@ -89,6 +93,37 @@ func BenchmarkWebSocketJSONUnmarshalRequest(b *testing.B) {
 		if err := json.Unmarshal(payload, &request); err != nil {
 			b.Fatalf("unmarshal websocket request: %v", err)
 		}
+		wsJSONRequestSink = request
+	}
+}
+
+func benchmarkWebSocketRequestPayload() []byte {
+	return []byte(`{"target":"example.test","protocol":"udp","port":33494,"queries":3,"max_hops":64,"timeout_ms":2000,"packet_size":84,"tos":32,"parallel_requests":16,"begin_hop":1,"ipv6_only":true,"data_provider":"NextTrace-API","dot_server":"dns.example:853","always_rdns":true,"disable_maptrace":true,"language":"en","source_address":"2001:db8::10","source_device":"en0","packet_interval":50,"ttl_interval":300,"mode":"mtr","hop_interval_ms":1000,"max_rounds":10}`)
+}
+
+func BenchmarkPGOWebSocketJSONWorkload(b *testing.B) {
+	envelope := benchmarkWebSocketEnvelope()
+	payload := benchmarkWebSocketRequestPayload()
+	if _, err := json.Marshal(envelope); err != nil {
+		b.Fatalf("marshal sample envelope: %v", err)
+	}
+	var sample traceRequest
+	if err := json.Unmarshal(payload, &sample); err != nil {
+		b.Fatalf("unmarshal sample request: %v", err)
+	}
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+
+	for b.Loop() {
+		encoded, err := json.Marshal(envelope)
+		if err != nil {
+			b.Fatalf("marshal websocket envelope: %v", err)
+		}
+		var request traceRequest
+		if err := json.Unmarshal(payload, &request); err != nil {
+			b.Fatalf("unmarshal websocket request: %v", err)
+		}
+		wsJSONBytesSink = encoded
 		wsJSONRequestSink = request
 	}
 }

--- a/trace/internal/decode_benchmark_test.go
+++ b/trace/internal/decode_benchmark_test.go
@@ -215,7 +215,10 @@ func BenchmarkPGOProtocolDecodeWorkload(b *testing.B) {
 		b.Fatal("IPv6 TCP workload fixture did not decode")
 	}
 
-	b.SetBytes(int64(len(icmp4Raw) + len(icmp6Raw) + len(udp4Raw) + len(udp6Raw)))
+	b.SetBytes(int64(
+		len(icmp4Raw) + len(icmp6Raw) + len(udp4Raw) + len(udp6Raw) +
+			len(tcp4Packet.Data()) + len(tcp6Packet.Data()),
+	))
 	b.ReportAllocs()
 	for b.Loop() {
 		decodeBenchmarkFinishSink, decodeBenchmarkSeqSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = icmp4Spec.decodeICMPSocketMessage(icmp4Msg)

--- a/trace/internal/decode_benchmark_test.go
+++ b/trace/internal/decode_benchmark_test.go
@@ -167,6 +167,66 @@ func BenchmarkDecodeUDPSocketMessage(b *testing.B) {
 	}
 }
 
+func BenchmarkPGOProtocolDecodeWorkload(b *testing.B) {
+	ipv4Dst := net.ParseIP("192.0.2.9")
+	ipv6Dst := net.ParseIP("2001:db8::9")
+	ipv4Peer := &net.IPAddr{IP: net.ParseIP("198.51.100.1")}
+	ipv6Peer := &net.IPAddr{IP: net.ParseIP("2001:db8::1")}
+
+	icmp4Raw := benchmarkICMPTimeExceeded(b, 4, benchmarkEmbeddedICMPPacket(4, ipv4Dst, 401, 1234))
+	icmp6Raw := benchmarkICMPTimeExceeded(b, 6, benchmarkEmbeddedICMPPacket(6, ipv6Dst, 402, 2345))
+	icmp4Spec := &ICMPSpec{IPVersion: 4, EchoID: 401, DstIP: ipv4Dst}
+	icmp6Spec := &ICMPSpec{IPVersion: 6, EchoID: 402, DstIP: ipv6Dst}
+	icmp4Msg := ReceivedMessage{Peer: ipv4Peer, Msg: icmp4Raw}
+	icmp6Msg := ReceivedMessage{Peer: ipv6Peer, Msg: icmp6Raw}
+
+	udp4Raw := benchmarkICMPTimeExceeded(b, 4, benchmarkEmbeddedUDPPacket(4, ipv4Dst, 40000, 33494))
+	udp6Raw := benchmarkICMPTimeExceeded(b, 6, benchmarkEmbeddedUDPPacket(6, ipv6Dst, 40001, 33494))
+	udp4Spec := &UDPSpec{IPVersion: 4, DstIP: ipv4Dst, DstPort: 33494}
+	udp6Spec := &UDPSpec{IPVersion: 6, DstIP: ipv6Dst, DstPort: 33494}
+	udp4Msg := ReceivedMessage{Peer: ipv4Peer, Msg: udp4Raw}
+	udp6Msg := ReceivedMessage{Peer: ipv6Peer, Msg: udp6Raw}
+
+	tcp4Packet := benchmarkSerializeTCPPacket(b, &layers.IPv4{
+		Version: 4, IHL: 5, Protocol: layers.IPProtocolTCP,
+		SrcIP: net.ParseIP("198.51.100.1").To4(), DstIP: ipv4Dst.To4(),
+	}, &layers.TCP{SrcPort: 443, DstPort: 32100, ACK: true, RST: true, Ack: 200})
+	tcp6Packet := benchmarkSerializeTCPPacket(b, &layers.IPv6{
+		Version: 6, NextHeader: layers.IPProtocolTCP,
+		SrcIP: net.ParseIP("2001:db8::1"), DstIP: ipv6Dst,
+	}, &layers.TCP{SrcPort: 8443, DstPort: 45678, ACK: true, SYN: true, Ack: 91})
+
+	if _, seq, _, ok := icmp4Spec.decodeICMPSocketMessage(icmp4Msg); !ok || seq != 1234 {
+		b.Fatal("IPv4 ICMP workload fixture did not decode")
+	}
+	if _, seq, _, ok := icmp6Spec.decodeICMPSocketMessage(icmp6Msg); !ok || seq != 2345 {
+		b.Fatal("IPv6 ICMP workload fixture did not decode")
+	}
+	if _, data, _, ok := udp4Spec.decodeICMPSocketMessage(udp4Msg); !ok || len(data) == 0 {
+		b.Fatal("IPv4 UDP workload fixture did not decode")
+	}
+	if _, data, _, ok := udp6Spec.decodeICMPSocketMessage(udp6Msg); !ok || len(data) == 0 {
+		b.Fatal("IPv6 UDP workload fixture did not decode")
+	}
+	if _, _, _, _, ok := decodeTCPProbePacket(4, 443, tcp4Packet); !ok {
+		b.Fatal("IPv4 TCP workload fixture did not decode")
+	}
+	if _, _, _, _, ok := decodeTCPProbePacket(6, 8443, tcp6Packet); !ok {
+		b.Fatal("IPv6 TCP workload fixture did not decode")
+	}
+
+	b.SetBytes(int64(len(icmp4Raw) + len(icmp6Raw) + len(udp4Raw) + len(udp6Raw)))
+	b.ReportAllocs()
+	for b.Loop() {
+		decodeBenchmarkFinishSink, decodeBenchmarkSeqSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = icmp4Spec.decodeICMPSocketMessage(icmp4Msg)
+		decodeBenchmarkFinishSink, decodeBenchmarkSeqSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = icmp6Spec.decodeICMPSocketMessage(icmp6Msg)
+		decodeBenchmarkFinishSink, decodeBenchmarkDataSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = udp4Spec.decodeICMPSocketMessage(udp4Msg)
+		decodeBenchmarkFinishSink, decodeBenchmarkDataSink, decodeBenchmarkResponseSink, decodeBenchmarkOKSink = udp6Spec.decodeICMPSocketMessage(udp6Msg)
+		decodeBenchmarkSrcPortSink, decodeBenchmarkSeqSink, decodeBenchmarkAckSink, decodeBenchmarkPeerSink, decodeBenchmarkOKSink = decodeTCPProbePacket(4, 443, tcp4Packet)
+		decodeBenchmarkSrcPortSink, decodeBenchmarkSeqSink, decodeBenchmarkAckSink, decodeBenchmarkPeerSink, decodeBenchmarkOKSink = decodeTCPProbePacket(6, 8443, tcp6Packet)
+	}
+}
+
 func benchmarkICMPTimeExceeded(b *testing.B, ipVersion int, inner []byte) []byte {
 	b.Helper()
 

--- a/trace/pgo_workload_benchmark_test.go
+++ b/trace/pgo_workload_benchmark_test.go
@@ -70,10 +70,8 @@ func BenchmarkPGOTraceWorkload(b *testing.B) {
 		Prov: "测试", ProvEn: "Test", City: "基准", CityEn: "Benchmark",
 		Owner: "Example Network", Lat: 31.25, Lng: 121.5, Source: "fake-pgo-provider",
 	}
-	provider := CachedGeoSource(ipgeo.SourceDescriptor{
-		Source: func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
-			return geo, nil
-		},
+	provider := ipgeo.Source(func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+		return geo, nil
 	})
 	prober := newPGOBenchmarkProber(geo)
 	agg := NewMTRAggregator()

--- a/trace/pgo_workload_benchmark_test.go
+++ b/trace/pgo_workload_benchmark_test.go
@@ -73,12 +73,31 @@ func BenchmarkPGOTraceWorkload(b *testing.B) {
 	provider := ipgeo.Source(func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
 		return geo, nil
 	})
+	cachedProviderCalls := 0
+	cachedProvider := CachedGeoSource(ipgeo.SourceDescriptor{
+		Source: func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			cachedProviderCalls++
+			return geo, nil
+		},
+		Namespace: ipgeo.SourceNamespaceIPSB,
+		Backend:   ipgeo.SourceNamespaceIPSB,
+	})
+	const hotQuery = "198.18.1.1"
+	coldQueries := make([]string, 4095)
+	for idx := range coldQueries {
+		coldQueries[idx] = fmt.Sprintf("198.19.%d.%d", idx>>8, idx&0xff)
+	}
+	ClearCaches()
+	b.Cleanup(ClearCaches)
 	prober := newPGOBenchmarkProber(geo)
 	agg := NewMTRAggregator()
 	result := &Result{Hops: make([][]Hop, mtrBenchmarkTTLCount)}
 
-	if got, err := provider("198.18.1.1", time.Second, "en", false); err != nil || got != geo {
+	if got, err := provider(hotQuery, time.Second, "en", false); err != nil || got != geo {
 		b.Fatalf("fake geo provider = (%+v, %v), want fixture", got, err)
+	}
+	if got, err := cachedProvider(hotQuery, time.Second, "en", false); err != nil || got == nil {
+		b.Fatalf("cached fake geo provider = (%+v, %v), want fixture", got, err)
 	}
 	if probe, err := prober.ProbeTTL(context.Background(), 1); err != nil || !probe.Success {
 		b.Fatalf("fake prober = (%+v, %v), want success", probe, err)
@@ -86,6 +105,8 @@ func BenchmarkPGOTraceWorkload(b *testing.B) {
 	_ = prober.Reset()
 
 	b.ReportAllocs()
+	b.ResetTimer()
+	iteration := 0
 	for b.Loop() {
 		agg.Reset()
 		if err := prober.Reset(); err != nil {
@@ -95,10 +116,20 @@ func BenchmarkPGOTraceWorkload(b *testing.B) {
 			result.Hops[idx] = result.Hops[idx][:0]
 		}
 
-		resolved, err := provider("198.18.1.1", time.Second, "en", false)
-		if err != nil {
+		if _, err := provider(hotQuery, time.Second, "en", false); err != nil {
 			b.Fatalf("fake geo provider: %v", err)
 		}
+		resolved, err := cachedProvider(hotQuery, time.Second, "en", false)
+		if err != nil {
+			b.Fatalf("cached fake geo provider: %v", err)
+		}
+		if iteration%64 == 0 {
+			coldQuery := coldQueries[(iteration/64)%len(coldQueries)]
+			if _, err := cachedProvider(coldQuery, time.Second, "en", false); err != nil {
+				b.Fatalf("cached fake geo provider miss: %v", err)
+			}
+		}
+		iteration++
 		for ttl := 1; ttl <= mtrBenchmarkTTLCount; ttl++ {
 			for range mtrBenchmarkPathCount {
 				probe, err := prober.ProbeTTL(context.Background(), ttl)
@@ -121,5 +152,8 @@ func BenchmarkPGOTraceWorkload(b *testing.B) {
 	}
 	if err := prober.Close(); err != nil {
 		b.Fatalf("close fake prober: %v", err)
+	}
+	if want := 1 + (iteration+63)/64; cachedProviderCalls != want {
+		b.Fatalf("cached fake geo provider calls = %d, want %d", cachedProviderCalls, want)
 	}
 }

--- a/trace/pgo_workload_benchmark_test.go
+++ b/trace/pgo_workload_benchmark_test.go
@@ -1,0 +1,127 @@
+package trace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+const pgoBenchmarkSeed = 20260905
+
+var (
+	pgoBenchmarkJSONSink    []byte
+	pgoBenchmarkGeoDataSink *ipgeo.IPGeoData
+)
+
+type pgoBenchmarkProber struct {
+	results [mtrBenchmarkTTLCount][mtrBenchmarkPathCount]mtrProbeResult
+	initial [mtrBenchmarkTTLCount]uint8
+	next    [mtrBenchmarkTTLCount]uint8
+}
+
+func newPGOBenchmarkProber(geo *ipgeo.IPGeoData) *pgoBenchmarkProber {
+	p := &pgoBenchmarkProber{}
+	for ttl := 1; ttl <= mtrBenchmarkTTLCount; ttl++ {
+		p.initial[ttl-1] = uint8((pgoBenchmarkSeed + ttl) % mtrBenchmarkPathCount)
+		for path := 1; path <= mtrBenchmarkPathCount; path++ {
+			p.results[ttl-1][path-1] = mtrProbeResult{
+				TTL:      ttl,
+				Success:  true,
+				Addr:     &net.IPAddr{IP: net.IPv4(198, 18, byte(ttl), byte(path))},
+				RTT:      time.Duration(ttl*path) * time.Millisecond,
+				Hostname: fmt.Sprintf("hop-%02d-path-%d.example", ttl, path),
+				Geo:      geo,
+				MPLS:     []string{fmt.Sprintf("[MPLS: Lbl %d, TC 0, S 1, TTL %d]", ttl*100+path, ttl)},
+			}
+		}
+	}
+	p.next = p.initial
+	return p
+}
+
+func (p *pgoBenchmarkProber) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, error) {
+	if err := ctx.Err(); err != nil {
+		return mtrProbeResult{}, err
+	}
+	if ttl < 1 || ttl > len(p.results) {
+		return mtrProbeResult{}, fmt.Errorf("TTL %d outside benchmark fixture", ttl)
+	}
+	idx := ttl - 1
+	path := int(p.next[idx] % mtrBenchmarkPathCount)
+	p.next[idx]++
+	return p.results[idx][path], nil
+}
+
+func (p *pgoBenchmarkProber) Reset() error {
+	p.next = p.initial
+	return nil
+}
+
+func (*pgoBenchmarkProber) Close() error { return nil }
+
+func BenchmarkPGOTraceWorkload(b *testing.B) {
+	geo := &ipgeo.IPGeoData{
+		IP: "198.18.1.1", Asnumber: "64512", Country: "示例", CountryEn: "Example",
+		Prov: "测试", ProvEn: "Test", City: "基准", CityEn: "Benchmark",
+		Owner: "Example Network", Lat: 31.25, Lng: 121.5, Source: "fake-pgo-provider",
+	}
+	provider := CachedGeoSource(ipgeo.SourceDescriptor{
+		Source: func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			return geo, nil
+		},
+	})
+	prober := newPGOBenchmarkProber(geo)
+	agg := NewMTRAggregator()
+	result := &Result{Hops: make([][]Hop, mtrBenchmarkTTLCount)}
+
+	if got, err := provider("198.18.1.1", time.Second, "en", false); err != nil || got != geo {
+		b.Fatalf("fake geo provider = (%+v, %v), want fixture", got, err)
+	}
+	if probe, err := prober.ProbeTTL(context.Background(), 1); err != nil || !probe.Success {
+		b.Fatalf("fake prober = (%+v, %v), want success", probe, err)
+	}
+	_ = prober.Reset()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		agg.Reset()
+		if err := prober.Reset(); err != nil {
+			b.Fatalf("reset fake prober: %v", err)
+		}
+		for idx := range result.Hops {
+			result.Hops[idx] = result.Hops[idx][:0]
+		}
+
+		resolved, err := provider("198.18.1.1", time.Second, "en", false)
+		if err != nil {
+			b.Fatalf("fake geo provider: %v", err)
+		}
+		for ttl := 1; ttl <= mtrBenchmarkTTLCount; ttl++ {
+			for range mtrBenchmarkPathCount {
+				probe, err := prober.ProbeTTL(context.Background(), ttl)
+				if err != nil {
+					b.Fatalf("fake probe TTL %d: %v", ttl, err)
+				}
+				result.Hops[ttl-1] = append(result.Hops[ttl-1], Hop{
+					Success: probe.Success, Address: probe.Addr, Hostname: probe.Hostname,
+					TTL: probe.TTL, RTT: probe.RTT, Geo: resolved, Lang: "en", MPLS: probe.MPLS,
+				})
+			}
+		}
+		stats := agg.Update(result, mtrBenchmarkPathCount)
+		encoded, err := json.Marshal(MTRSnapshot{Iteration: 10, Stats: stats})
+		if err != nil {
+			b.Fatalf("marshal MTR workload snapshot: %v", err)
+		}
+		pgoBenchmarkJSONSink = encoded
+		pgoBenchmarkGeoDataSink = resolved
+	}
+	if err := prober.Close(); err != nil {
+		b.Fatalf("close fake prober: %v", err)
+	}
+}


### PR DESCRIPTION
## 问题

Go 1.27.1 支持基于 `default.pgo` 的自动 PGO，但仓库此前没有可重复的代表性 workload，也没有以关键路径回退为否决条件的完整证据。直接提交 profile 可能让局部热点加速、同时拖慢协议 decoder、Geo cache 或 MTR。

## 前后调用链

- 调整前：发布 `go build` → 仓库无 `default.pgo` → 不启用 PGO。
- 评估链路：固定复合 workload → 三个等长 10 秒阶段 → 合并候选 CPU profile → PGO off/on 各 10 组 workload 与 guardrail → 三 flavor 大小、启动和 RSS。
- 调整后：证据触发 NO-GO → 不提交 `default.pgo` → 发布调用链保持不变；保留 workload 和测量脚本供后续复评。

## 变更

- 增加 IPv4/IPv6 ICMP、TCP、UDP decoder 的组合 workload。
- 使用固定 seed、fake prober/provider 构造 64 TTL × 4 path 的 MTR + Geo JSON workload，并覆盖 Geo 直接、缓存命中和受控未命中路径。
- 增加 WebSocket JSON 编解码组合 workload。
- 增加候选 profile 生成、PGO off/on workload/guardrail 对照脚本；严格校验 Go 1.27.1 和 profile SHA-256，`measure_binaries.sh` 可保留精确构建产物。
- 新增性能证据和 ADR，记录不提交 `default.pgo` 的结论与复评方式。

## 兼容性

- 不修改生产代码、CLI、JSON、协议布局或三 flavor 依赖边界。
- 不提交 `default.pgo`，正式发布仍不启用 PGO。
- 测量固定 Go 1.27.1、`GOEXPERIMENT=nojsonv2`、`GOMAXPROCS=10`。

## Benchmark 与 profile

- 主机：Apple M5 10 核、32 GB、AC 供电；macOS 26.6.2。
- CPU profile：三个等长 10 秒阶段，固定 seed `20260905`；候选 SHA-256 `4d3d8582e063dc3d893f9f398ec601d55966c5ac6c00666695475e03527fb3a5`。
- PGO off/on 各 10 次、每次至少 1 秒；三个综合 workload 的等权几何均值改善 5.59%。
- 否决项：TCP decoder IPv4 +5.07%、IPv6 +4.77%；Geo hit +3.21%、miss +3.96%、eviction +5.21%、cached lookup hit +1.48%；MTR snapshot +3.41%、preview +2.30%。以上均统计显著并超过 1% 回退门槛。
- WebSocket marshal/unmarshal 分别改善 10.42%/5.72%，但不能抵消关键 guardrail 回退。
- 回退已在 10 次样本明确，不需要增加到 20 次。

## 大小、启动与 RSS

- nexttrace 未压缩/UPX：+0.16% / +0.16%。
- nexttrace-tiny、ntr 未压缩/UPX：+0.75% / +0.77%。
- 六个 Darwin 产物均验证 `LC_BUILD_VERSION minos 13.0`。
- 后续 9 次 `--help` 中位数：nexttrace -0.72%，tiny -0.10%，ntr +1.54%；最大 RSS 的最大变化为 nexttrace +1.04%。

## 验证

- `go test -count=1 ./...`：通过。
- `GOEXPERIMENT=nojsonv2 go test -count=1 ./...`：通过。
- `go test -race -count=1 ./...`：通过。
- `go build ./...`、`go vet ./...`：通过。
- full/tiny/ntr 的默认和 `nojsonv2` 构建：通过。
- tiny/ntr 专项测试：通过。
- Linux amd64（CGO disabled）与 Windows amd64 交叉编译：通过。
- `node --test server/web/assets/*.test.cjs`：15/15 通过。
- `go mod verify`、`go mod tidy` diff：通过、无变化。
- golangci-lint v2.13.2 `--new-from-rev origin/main`：0 issues。

## 平台风险与回退

- 候选 profile 来自 Apple M5，不能代表所有 CPU；这也是 guardrail 失败时不启用默认 PGO 的原因。
- 本 PR 只增加测试、脚本和文档。回退只需撤销本 PR；未来即使加入 profile，也可用 `-pgo=off` 立即禁用。

## Commit 列表

- `edfc38c test(bench): 建立可复现的 PGO 综合工作负载`
- `6580ebc docs(performance): 记录默认 PGO 的 NO-GO 结论`
- `8cb5929 fix(bench): 校验 PGO 工具链并修正吞吐统计`
- `9542676 fix(bench): 覆盖 Geo 缓存并校验 profile 摘要`
- `8c3b936 docs(performance): 刷新缓存 workload 的 PGO 证据`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 新增 Go 1.27 默认 PGO 评估与决策说明，记录测试环境、性能门槛、结果及复现方法。
  - 明确当前发布构建不启用默认 PGO，CLI、协议、JSON 与构建行为保持不变。

- **性能与测试**
  - 新增 WebSocket JSON、协议解码及链路追踪等 PGO 工作负载基准测试。
  - 完善 PGO 配置文件生成、基准运行及二进制测量脚本，支持结果校验与可复现评估。
  - 优化性能测试文档，覆盖直接和缓存地理数据路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->