### PR TITLE
feat(mtr): 支持实时 NDJSON 和最终 JSON 报告

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,20 @@ nexttrace -r --raw 1.1.1.1
 nexttrace -t --tcp --max-hops 20 --first 3 --no-rdns 8.8.8.8
 ```
 
+MTR JSON is available in all three builds:
+
+```bash
+nexttrace --mtr --json 1.1.1.1        # continuous NDJSON events
+nexttrace --mtr --json -q 10 1.1.1.1  # finite NDJSON events
+nexttrace -r --json -q 10 1.1.1.1     # one final JSON report
+nexttrace -w --json -q 10 1.1.1.1     # identical to -r --json
+ntr --json 1.1.1.1                    # continuous NDJSON events
+```
+
+JSON always includes all available metadata (FULL), ignores `-y`, and honors Geo/PTR/provider/language settings. `-r/-w --json` use the same wide collection rules. Streams run indefinitely when `-q` is omitted or nonpositive; JSON reports default to 10 probes per hop and reject explicit nonpositive counts. `--raw` and MTR `--json` are mutually exclusive. Bare `--json` in full/tiny retains traditional traceroute JSON, including after a future default-mode switch.
+
+NDJSON emits `start`, `probe`, `path_end`, and `end` objects with consecutive `seq` values. Reports emit exactly one object, including partial statistics on interruption or failure. Diagnostics go to stderr. Exit codes: completion `0`, runtime/initialization error `1`, invalid arguments `2`, SIGINT `130`, SIGTERM `143`. Completion does not imply reachability; use `path_end`. See the [MTR JSON v1 contract and examples](docs/mtr-json.md).
+
 When running in a terminal (TTY), MTR mode uses an **interactive full-screen TUI**:
 
 - **`q` / `Q`** — quit (restores terminal, no output left behind)
@@ -701,7 +715,7 @@ In MTR mode (`--mtr`, `-r`, `-w`, including `--raw`), `-i/--ttl-time` sets the *
 
 > Note: `--show-ips` only takes effect in MTR mode (`--mtr`, `-r`, `-w`); otherwise it is ignored.
 >
-> Note: `--mtr` cannot be used together with `--traceroute`, `--table`, `--classic`, `--json`, `--output`, `--output-default`, `--route-path`, `--from`, `--fast-trace`, `--file`, or `--deploy`.
+> Note: `--mtr` cannot be used together with `--traceroute`, `--table`, `--classic`, `--output`, `--output-default`, `--route-path`, `--from`, `--fast-trace`, `--file`, or `--deploy`.
 
 #### `NextTrace` supports users to select their own IP API (currently supports: `NextTrace-API`, `IP.SB`, `IPInfo`, `IPInsight`, `IPAPI.com`, `IPInfoLocal`, `IPDB.One`, `CHUNZHEN`, `DN42`)
 
@@ -893,9 +907,10 @@ Arguments:
                                      default of 80 for "tcp", 33494 for "udp"
   -q  --queries                      Traceroute: latency samples per hop
                                      (default 3). MTR: max probes per hop. 0 =
-                                     unlimited in TUI/raw. When omitted: 10
-                                     with --report/--wide (including --raw),
-                                     otherwise unlimited
+                                     unlimited in TUI/raw/JSON streams. JSON
+                                     reports require a positive count. When
+                                     omitted: 10 with --report/--wide
+                                     (including --raw), otherwise unlimited
       --max-attempts                 Advanced: hard cap on probe packets per
                                      hop. Leave unset for auto sizing; raise on
                                      lossy links if --queries is not enough
@@ -930,7 +945,8 @@ Arguments:
                                      (/tmp/trace.log)
       --table                        Output trace results as a final summary
                                      table (traceroute report mode)
-  -j  --json                         Output trace results as JSON
+  -j  --json                         Output JSON; MTR streams NDJSON unless
+                                     --report/--wide is selected
   -c  --classic                      Classic Output trace results like
                                      BestTrace
       --dn42                         DN42 Mode
@@ -1006,7 +1022,7 @@ Arguments:
       --show-ips                     MTR only: display both PTR hostnames and
                                      numeric IPs (PTR first, IP in parentheses)
   -y  --ipinfo                       Set initial MTR TUI host info mode (0-4).
-                                     TUI only; ignored in --report/--raw.
+                                     TUI only; ignored in --report/--raw/--json.
                                      0:IP/PTR 1:ASN 2:City 3:Owner 4:Full.
                                      Default: 0
       --file                         Read IP Address or domain name from file

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -622,6 +622,20 @@ nexttrace -r --raw 1.1.1.1
 nexttrace -t --tcp --max-hops 20 --first 3 --no-rdns 8.8.8.8
 ```
 
+三个版本均支持 MTR JSON：
+
+```bash
+nexttrace --mtr --json 1.1.1.1        # 持续输出 NDJSON 事件
+nexttrace --mtr --json -q 10 1.1.1.1  # 限次输出 NDJSON 事件
+nexttrace -r --json -q 10 1.1.1.1     # 结束后输出一个汇总 JSON
+nexttrace -w --json -q 10 1.1.1.1     # 与 -r --json 完全等价
+ntr --json 1.1.1.1                    # 持续输出 NDJSON 事件
+```
+
+JSON 固定输出完整可用元数据（FULL），忽略 `-y`，仍遵守 Geo/PTR、数据源及语言设置。`-r/-w --json` 共用 wide 采集规则。实时模式省略 `-q` 或传非正值表示无限运行；JSON 报告默认每跳 10 次，显式非正值报错。MTR 中 `--raw` 与 `--json` 互斥。full/tiny 单独 `--json` 保持传统 traceroute JSON，未来默认模式切换后也保持此行为。
+
+NDJSON 输出 `start`、`probe`、`path_end`、`end` 事件，`seq` 连续递增。报告只输出一个对象，中断或失败时保留已有统计。诊断写入 stderr。退出码：完成 `0`，初始化/执行错误 `1`，参数错误 `2`，SIGINT `130`，SIGTERM `143`。完成不表示目的地可达，可达性读取 `path_end`。详见 [MTR JSON v1 契约及示例](docs/mtr-json.md)。
+
 在终端（TTY）中运行时，MTR 模式使用**交互式全屏 TUI**：
 
 - **`q` / `Q`** — 退出（恢复终端，不留下输出）
@@ -692,7 +706,7 @@ raw stdout 契约仍严格保持 12 列。无限运行的 MTR 中，unreachable 
 
 > 注意：`--show-ips` 仅在 MTR 模式（`--mtr`、`-r`、`-w`）生效，其他模式会忽略。
 >
-> 注意：`--mtr` 不可与 `--traceroute`、`--table`、`--classic`、`--json`、`--output`、`--output-default`、`--route-path`、`--from`、`--fast-trace`、`--file`、`--deploy` 同时使用。
+> 注意：`--mtr` 不可与 `--traceroute`、`--table`、`--classic`、`--output`、`--output-default`、`--route-path`、`--from`、`--fast-trace`、`--file`、`--deploy` 同时使用。
 
 #### `NextTrace`支持用户自主选择 IP 数据库（目前支持：`NextTrace-API`, `IP.SB`, `IPInfo`, `IPInsight`, `IPAPI.com`, `IPInfoLocal`, `IPDB.One`, `CHUNZHEN`, `DN42`）
 
@@ -868,9 +882,10 @@ Arguments:
                                      default of 80 for "tcp", 33494 for "udp"
   -q  --queries                      Traceroute: latency samples per hop
                                      (default 3). MTR: max probes per hop. 0 =
-                                     unlimited in TUI/raw. When omitted: 10
-                                     with --report/--wide (including --raw),
-                                     otherwise unlimited
+                                     unlimited in TUI/raw/JSON streams. JSON
+                                     reports require a positive count. When
+                                     omitted: 10 with --report/--wide
+                                     (including --raw), otherwise unlimited
       --max-attempts                 Advanced: hard cap on probe packets per
                                      hop. Leave unset for auto sizing; raise on
                                      lossy links if --queries is not enough
@@ -905,7 +920,8 @@ Arguments:
                                      (/tmp/trace.log)
       --table                        Output trace results as a final summary
                                      table (traceroute report mode)
-  -j  --json                         Output trace results as JSON
+  -j  --json                         Output JSON; MTR streams NDJSON unless
+                                     --report/--wide is selected
   -c  --classic                      Classic Output trace results like
                                      BestTrace
       --dn42                         DN42 Mode
@@ -981,7 +997,7 @@ Arguments:
       --show-ips                     MTR only: display both PTR hostnames and
                                      numeric IPs (PTR first, IP in parentheses)
   -y  --ipinfo                       Set initial MTR TUI host info mode (0-4).
-                                     TUI only; ignored in --report/--raw.
+                                     TUI only; ignored in --report/--raw/--json.
                                      0:IP/PTR 1:ASN 2:City 3:Owner 4:Full.
                                      Default: 0
       --file                         Read IP Address or domain name from file

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -408,7 +408,7 @@ func buildQueriesHelp() string {
 	if enableTraceroute {
 		help = "Traceroute: latency samples per hop (default 3). MTR: max probes per hop."
 	}
-	return help + " 0 = unlimited in TUI/raw. When omitted: 10 with --report/--wide (including --raw), otherwise unlimited"
+	return help + " 0 = unlimited in TUI/raw/JSON streams. JSON reports require a positive count. When omitted: 10 with --report/--wide (including --raw), otherwise unlimited"
 }
 
 func buildMaxAttemptsHelp() string {
@@ -444,13 +444,14 @@ func registerTracerouteOutputFlags(parser *argparse.Parser) tracerouteOutputFlag
 }
 
 func registerTracerouteOutputFlagsWithAvailability(parser *argparse.Parser, enabled bool) tracerouteOutputFlags {
+	jsonPrint := parser.Flag("j", "json", &argparse.Options{Help: "Output JSON; with MTR, stream NDJSON unless --report/--wide is selected"})
 	if enabled {
 		return tracerouteOutputFlags{
 			routePath:     parser.Flag("P", "route-path", &argparse.Options{Help: "Print traceroute hop path by ASN and location"}),
 			outputPath:    parser.String("o", "output", &argparse.Options{Help: "Write realtime trace output and final stop reason to FILE"}),
 			outputDefault: parser.Flag("O", "output-default", &argparse.Options{Help: "Write realtime trace output and final stop reason to the default log file (/tmp/trace.log)"}),
 			tablePrint:    parser.Flag("", "table", &argparse.Options{Help: "Output trace results as a final summary table (traceroute report mode)"}),
-			jsonPrint:     parser.Flag("j", "json", &argparse.Options{Help: "Output trace results as JSON"}),
+			jsonPrint:     jsonPrint,
 			classicPrint:  parser.Flag("c", "classic", &argparse.Options{Help: "Classic Output trace results like BestTrace"}),
 		}
 	}
@@ -459,7 +460,7 @@ func registerTracerouteOutputFlagsWithAvailability(parser *argparse.Parser, enab
 		outputPath:    ptrStr(""),
 		outputDefault: ptrBool(false),
 		tablePrint:    ptrBool(false),
-		jsonPrint:     ptrBool(false),
+		jsonPrint:     jsonPrint,
 		classicPrint:  ptrBool(false),
 	}
 }
@@ -569,7 +570,7 @@ func registerMTRFlags(parser *argparse.Parser) mtrCLIFlags {
 			reportMode: parser.Flag("r", "report", &argparse.Options{Help: "MTR report mode (non-interactive, implies --mtr); can trigger MTR without --mtr"}),
 			wideMode:   parser.Flag("w", "wide", &argparse.Options{Help: "MTR wide report mode (implies --mtr --report); alone equals --mtr --report --wide"}),
 			showIPs:    parser.Flag("", "show-ips", &argparse.Options{Help: "MTR only: display both PTR hostnames and numeric IPs (PTR first, IP in parentheses)"}),
-			ipInfoMode: parser.Int("y", "ipinfo", &argparse.Options{Default: 0, Help: "Set initial MTR TUI host info mode (0-4). TUI only; ignored in --report/--raw. 0:IP/PTR 1:ASN 2:City 3:Owner 4:Full"}),
+			ipInfoMode: parser.Int("y", "ipinfo", &argparse.Options{Default: 0, Help: "Set initial MTR TUI host info mode (0-4). TUI only; ignored in --report/--raw/--json. 0:IP/PTR 1:ASN 2:City 3:Owner 4:Full"}),
 		}
 	}
 	return mtrCLIFlags{
@@ -1368,13 +1369,15 @@ func supportsMapTrace(dataOrigin string) bool {
 }
 
 func Execute() {
-	if handled, exitCode := maybeRunDNSMode(os.Args[1:], os.Stdout, os.Stderr); handled {
-		os.Exit(exitCode)
+	mtrJSONRequested := requestsMTRJSON(os.Args[1:])
+	if !mtrJSONRequested {
+		if handled, exitCode := maybeRunDNSMode(os.Args[1:], os.Stdout, os.Stderr); handled {
+			os.Exit(exitCode)
+		}
+		if handled, exitCode := maybeRunSpeedMode(os.Args[1:], os.Stdout, os.Stderr); handled {
+			os.Exit(exitCode)
+		}
 	}
-	if handled, exitCode := maybeRunSpeedMode(os.Args[1:], os.Stdout, os.Stderr); handled {
-		os.Exit(exitCode)
-	}
-
 	parser := argparse.NewParser(appBinName, "An open source visual route tracking CLI tool")
 	// Override HelpFunc so positional arg names are sanitized in --help output
 	parser.HelpFunc = func(c *argparse.Command, msg interface{}) string {
@@ -1458,8 +1461,16 @@ func Execute() {
 	if err != nil {
 		// In case of error print error and print usage
 		// This can also be done by passing -h or --help flags
+		if mtrJSONRequested {
+			fmt.Fprint(os.Stderr, sanitizeUsagePositionalArgs(parser.Usage(err)))
+			os.Exit(2)
+		}
 		fmt.Print(sanitizeUsagePositionalArgs(parser.Usage(err)))
 		return
+	}
+	if mtrJSONRequested && (*setupNextTraceAPIV4Token || *dnsMode || *speedMode) {
+		fmt.Fprintln(os.Stderr, "MTR JSON cannot be combined with a standalone mode")
+		os.Exit(2)
 	}
 	if *dnsMode {
 		fmt.Fprintln(os.Stderr, "-l/--dns must be the first argument")
@@ -1467,6 +1478,9 @@ func Execute() {
 	}
 	if err := validateGlobalpingAvailability(*from, enableGlobalping); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		if mtrJSONRequested {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 	if *setupNextTraceAPIV4Token {
@@ -1498,13 +1512,49 @@ func Execute() {
 		report:     *reportMode,
 		wide:       *wideMode,
 		raw:        *rawPrint,
-		traditional: *jsonPrint || *tablePrint || *classicPrint || *outputPath != "" ||
+		traditional: (*jsonPrint && enableTraceroute) || *tablePrint || *classicPrint || *outputPath != "" ||
 			*outputDefault || *routePath || *fastTraceFlag || *file != "" || *from != "",
 		standalone: standalone,
 	}, defaultMTR)
 	if modeErr != nil {
 		fmt.Fprintln(os.Stderr, modeErr)
+		if mtrJSONRequested {
+			os.Exit(2)
+		}
 		os.Exit(1)
+	}
+	if mtrModes.mtr && *jsonPrint {
+		if maybePrintVersion(*ver) {
+			return
+		}
+		conflicts := map[string]bool{
+			"table": *tablePrint, "classic": *classicPrint, "output": *outputPath != "", "outputDefault": *outputDefault,
+			"routePath": *routePath, "from": *from != "", "fastTrace": *fastTraceFlag, "file": *file != "", "deploy": *deploy,
+		}
+		conflict, ok := checkMTRConflicts(conflicts)
+		if !ok || *rawPrint || *mtuMode || *naliMode || *init || *deployMCP {
+			if ok {
+				conflict = "--raw or a standalone mode"
+			}
+			fmt.Fprintf(os.Stderr, "MTR JSON cannot be combined with %s\n", conflict)
+			os.Exit(2)
+		}
+		queriesSet, intervalSet, packetSet, _ := detectExplicitProbeFlags(parser)
+		count, interval := deriveMTRProbeParams(mtrModes.report, queriesSet, *numMeasurements, intervalSet, *ttlInterval)
+		code := runMTRJSONCLI(mtrJSONOptions{
+			Target: *str, Method: resolveTraceMethod(*tcp, *udp), Report: mtrModes.report,
+			MaxPerHop: count, HopIntervalMs: interval, PacketSize: *packetSize, PacketSizeExplicit: packetSet,
+			IPv4Only: *ipv4Only, IPv6Only: *ipv6Only, DataProvider: *dataOrigin, PowProvider: *powProvider, DotServer: *dot,
+			Config: trace.Config{
+				OSType: resolveOSType(), ICMPMode: *icmpMode, DN42: *dn42,
+				SrcAddr: *srcAddr, SourceDevice: *srcDev, SrcPort: *srcPort, DstPort: *port,
+				BeginHop: *beginHop, MaxHops: *maxHops, ParallelRequests: *parallelRequests,
+				Timeout: time.Duration(*timeout) * time.Millisecond, TOS: *tos, Lang: *lang,
+				RDNS: !*norDNS, AlwaysWaitRDNS: *alwaysrDNS, DisableMPLS: *disableMPLS,
+			},
+		})
+		stop()
+		os.Exit(code)
 	}
 	if *naliMode {
 		applyColorMode(*noColor)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1128,18 +1128,21 @@ func maybeRunMTRMode(
 		ttlInterval,
 	)
 
+	var err error
 	switch chooseMTRRunMode(modes.raw, modes.report) {
 	case mtrRunRaw:
-		runMTRRaw(method, conf, mtrHopIntervalMs, mtrMaxPerHop, dataOrigin)
+		err = runMTRRaw(method, conf, mtrHopIntervalMs, mtrMaxPerHop, dataOrigin)
 	case mtrRunReport:
-		runMTRReport(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, modes.wide, showIPs)
+		err = runMTRReport(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, modes.wide, showIPs)
 	default:
 		if ipInfoMode < 0 || ipInfoMode > 4 {
 			fmt.Fprintf(os.Stderr, "--ipinfo/-y 必须在 0-4 范围内，当前值: %d\n", ipInfoMode)
 			os.Exit(1)
 		}
-		runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode)
+		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode)
 	}
+	// Mode-local defers restore the terminal and close listeners before exit.
+	exitOnTraceRunError(err)
 	return true
 }
 
@@ -1292,7 +1295,10 @@ func maybeRunUninterruptedRaw(rawPrint bool, method trace.Method, conf trace.Con
 			if errors.Is(err, context.Canceled) {
 				return true
 			}
-			fmt.Println(err)
+			if trace.IsInitializationError(err) {
+				exitOnTraceRunError(err)
+			}
+			_, _ = fmt.Fprintln(os.Stderr, err)
 		}
 	}
 }
@@ -1300,12 +1306,18 @@ func maybeRunUninterruptedRaw(rawPrint bool, method trace.Method, conf trace.Con
 func runTraceOnce(method trace.Method, conf trace.Config) (*trace.Result, bool) {
 	res, err := trace.Traceroute(method, conf)
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			fmt.Println(err)
-		}
+		exitOnTraceRunError(err)
 		return nil, false
 	}
 	return res, true
+}
+
+func exitOnTraceRunError(err error) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	_, _ = fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
 }
 
 // traceMapPayload preserves the historical external tracemap request shape.

--- a/cmd/mtr_json.go
+++ b/cmd/mtr_json.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/config"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+const mtrJSONSchemaVersion = 1
+
+type mtrJSONParameters struct {
+	MaxPerHop        int    `json:"max_per_hop"`
+	HopIntervalMs    int    `json:"hop_interval_ms"`
+	TimeoutMs        int64  `json:"timeout_ms"`
+	BeginHop         int    `json:"begin_hop"`
+	MaxHops          int    `json:"max_hops"`
+	ParallelRequests int    `json:"parallel_requests"`
+	SourceAddress    string `json:"source_address"`
+	SourceDevice     string `json:"source_device,omitempty"`
+	SourcePort       *int   `json:"source_port,omitempty"`
+	Port             *int   `json:"port,omitempty"`
+	PacketSize       int    `json:"packet_size"`
+	RandomPacketSize bool   `json:"random_packet_size"`
+	TOS              int    `json:"tos"`
+	ICMPMode         *int   `json:"icmp_mode,omitempty"`
+	DataProvider     string `json:"data_provider"`
+	Language         string `json:"language"`
+	DotServer        string `json:"dot_server,omitempty"`
+	RDNS             bool   `json:"rdns"`
+	AlwaysWaitRDNS   bool   `json:"always_wait_rdns"`
+	DisableMPLS      bool   `json:"disable_mpls"`
+	DN42             bool   `json:"dn42"`
+}
+
+type mtrJSONSession struct {
+	Version             string             `json:"version"`
+	Target              string             `json:"target"`
+	ResolvedIP          *string            `json:"resolved_ip"`
+	Protocol            string             `json:"protocol"`
+	StartedAt           time.Time          `json:"started_at"`
+	EffectiveParameters *mtrJSONParameters `json:"effective_parameters"`
+}
+
+type mtrJSONError struct {
+	Stage   string `json:"stage"`
+	Message string `json:"message"`
+}
+
+type mtrJSONEnd struct {
+	EndedAt    time.Time         `json:"ended_at"`
+	DurationMs int64             `json:"duration_ms"`
+	EndReason  string            `json:"end_reason"`
+	PathEnd    *trace.StopReason `json:"path_end"`
+	Error      *mtrJSONError     `json:"error,omitempty"`
+	Signal     string            `json:"signal,omitempty"`
+}
+
+type mtrJSONReport struct {
+	SchemaVersion int `json:"schema_version"`
+	mtrJSONSession
+	mtrJSONEnd
+	Stats []trace.MTRHopStat `json:"stats"`
+}
+
+type mtrJSONEvent struct {
+	SchemaVersion int    `json:"schema_version"`
+	Type          string `json:"type"`
+	Seq           uint64 `json:"seq"`
+	*mtrJSONSession
+	*mtrJSONEnd
+	Record *trace.MTRRawRecord `json:"record,omitempty"`
+}
+
+// One writer owns event ordering and remembers the first write failure.
+type mtrJSONOutput struct {
+	mu      sync.Mutex
+	writer  io.Writer
+	cancel  context.CancelCauseFunc
+	stream  bool
+	started bool
+	seq     uint64
+	err     error
+	start   time.Time
+	report  mtrJSONReport
+}
+
+func newMTRJSONOutput(w io.Writer, stream bool, target string, method trace.Method, cancel context.CancelCauseFunc) *mtrJSONOutput {
+	start := time.Now()
+	return &mtrJSONOutput{
+		writer: w, stream: stream, cancel: cancel, start: start,
+		report: mtrJSONReport{
+			SchemaVersion:  mtrJSONSchemaVersion,
+			mtrJSONSession: mtrJSONSession{Version: config.Version, Target: target, Protocol: string(method), StartedAt: start.UTC()},
+			Stats:          make([]trace.MTRHopStat, 0),
+		},
+	}
+}
+
+func (o *mtrJSONOutput) writeLocked(value any) {
+	if o.err != nil {
+		return
+	}
+	data, err := json.Marshal(value)
+	if err == nil {
+		data = append(data, '\n')
+		var n int
+		n, err = o.writer.Write(data)
+		if err == nil && n != len(data) {
+			err = io.ErrShortWrite
+		}
+	}
+	if err != nil {
+		o.err = err
+		o.cancel(err)
+	}
+}
+
+func (o *mtrJSONOutput) eventLocked(event mtrJSONEvent) {
+	o.seq++
+	event.SchemaVersion, event.Seq = mtrJSONSchemaVersion, o.seq
+	o.writeLocked(event)
+}
+
+func (o *mtrJSONOutput) startLocked() {
+	if !o.stream || o.started {
+		return
+	}
+	o.started = true
+	o.eventLocked(mtrJSONEvent{Type: "start", mtrJSONSession: &o.report.mtrJSONSession})
+}
+
+func (o *mtrJSONOutput) startStream() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.startLocked()
+}
+
+func (o *mtrJSONOutput) probe(rec trace.MTRRawRecord) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.eventLocked(mtrJSONEvent{Type: "probe", Record: &rec})
+}
+
+func (o *mtrJSONOutput) pathEnd(reason *trace.StopReason) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.report.PathEnd = copyMTRPathEnd(reason)
+	// A separate payload makes an explicit null distinct from an absent field.
+	o.seq++
+	o.writeLocked(struct {
+		SchemaVersion int               `json:"schema_version"`
+		Type          string            `json:"type"`
+		Seq           uint64            `json:"seq"`
+		PathEnd       *trace.StopReason `json:"path_end"`
+	}{mtrJSONSchemaVersion, "path_end", o.seq, o.report.PathEnd})
+}
+
+func copyMTRPathEnd(reason *trace.StopReason) *trace.StopReason {
+	if reason == nil {
+		return nil
+	}
+	result := *reason
+	result.Responses = append([]string(nil), reason.Responses...)
+	result.Markers = append([]string(nil), reason.Markers...)
+	return &result
+}
+
+type mtrJSONSignal struct{ signal os.Signal }
+
+func (e *mtrJSONSignal) Error() string { return e.signal.String() }
+
+func (o *mtrJSONOutput) finish(err error, stage string, stderr io.Writer) int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	code := 0
+	o.report.EndedAt = time.Now().UTC()
+	o.report.DurationMs = time.Since(o.start).Milliseconds()
+	o.report.EndReason = "completed"
+	var interrupted *mtrJSONSignal
+	switch {
+	case errors.As(err, &interrupted):
+		o.report.EndReason, o.report.Signal, code = "interrupted", "SIGINT", 130
+		if interrupted.signal == syscall.SIGTERM {
+			o.report.Signal, code = "SIGTERM", 143
+		}
+	case err != nil:
+		o.report.EndReason = "error"
+		o.report.Error = &mtrJSONError{Stage: stage, Message: err.Error()}
+		code = 1
+		if stage == "validation" {
+			code = 2
+		}
+		_, _ = fmt.Fprintln(stderr, err)
+	}
+	if o.stream {
+		o.startLocked()
+		o.eventLocked(mtrJSONEvent{Type: "end", mtrJSONEnd: &o.report.mtrJSONEnd})
+	} else {
+		o.writeLocked(o.report)
+	}
+	if o.err != nil {
+		_, _ = fmt.Fprintf(stderr, "write MTR JSON: %v\n", o.err)
+		return 1
+	}
+	return code
+}
+
+var runMTRReportFn = trace.RunMTR
+
+// Both human and JSON reports consume the same final snapshot.
+func collectMTRReport(ctx context.Context, method trace.Method, conf trace.Config, opts trace.MTROptions) ([]trace.MTRHopStat, *trace.StopReason, error) {
+	stats := make([]trace.MTRHopStat, 0)
+	var pathEnd *trace.StopReason
+	opts.OnPathEnd = func(reason *trace.StopReason) { pathEnd = copyMTRPathEnd(reason) }
+	err := runMTRReportFn(ctx, method, conf, opts, func(_ int, snapshot []trace.MTRHopStat) {
+		stats = append(stats[:0], snapshot...)
+	})
+	return stats, pathEnd, err
+}

--- a/cmd/mtr_json_run.go
+++ b/cmd/mtr_json_run.go
@@ -1,0 +1,268 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/config"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+type mtrJSONOptions struct {
+	Target             string
+	Method             trace.Method
+	Config             trace.Config
+	Report             bool
+	MaxPerHop          int
+	HopIntervalMs      int
+	PacketSize         int
+	PacketSizeExplicit bool
+	IPv4Only           bool
+	IPv6Only           bool
+	DataProvider       string
+	PowProvider        string
+	DotServer          string
+}
+
+var runMTRJSONRawFn = trace.RunMTRRaw
+
+// Only used to route pre-parser diagnostics/standalone dispatch. Parsed flags
+// remain the authority for selecting an output mode.
+func requestsMTRJSON(args []string) bool {
+	jsonOutput, mtr := false, !enableTraceroute && defaultMTR
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		name, _, _ := strings.Cut(arg, "=")
+		switch name {
+		case "-j", "--json":
+			jsonOutput = true
+		case "-t", "--mtr", "-r", "--report", "-w", "--wide":
+			mtr = true
+		}
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			jsonOutput = jsonOutput || strings.Contains(arg[1:], "j")
+			mtr = mtr || strings.ContainsAny(arg[1:], "trw")
+		}
+	}
+	return jsonOutput && mtr
+}
+
+func runMTRJSONCLI(opts mtrJSONOptions) int {
+	// Let a closed stdout pipe return EPIPE to the writer so the runner can
+	// cancel and join its workers instead of the runtime exiting on SIGPIPE.
+	pipeSignals := make(chan os.Signal, 1)
+	signal.Notify(pipeSignals, syscall.SIGPIPE)
+	defer signal.Stop(pipeSignals)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case sig := <-signals:
+			cancel(&mtrJSONSignal{signal: sig})
+		case <-ctx.Done():
+		}
+	}()
+	defer func() {
+		signal.Stop(signals)
+		cancel(nil)
+		<-done
+	}()
+	return runMTRJSON(ctx, opts, os.Stdout, os.Stderr)
+}
+
+func runMTRJSON(parent context.Context, opts mtrJSONOptions, stdout, stderr io.Writer) int {
+	ctx, cancel := context.WithCancelCause(parent)
+	defer cancel(nil)
+	out := newMTRJSONOutput(stdout, !opts.Report, opts.Target, opts.Method, cancel)
+	stage := "validation"
+	var cleanup func()
+	err := normalizeMTRJSONOptions(&opts, stderr)
+	if err == nil {
+		stage = "resolve"
+		cleanup, err = prepareMTRJSON(ctx, &opts, out, &stage, stderr)
+	}
+	if err == nil {
+		out.startStream()
+		stage = "probe"
+		if ctx.Err() != nil {
+			err = context.Cause(ctx)
+		} else if opts.Report {
+			out.report.Stats, out.report.PathEnd, err = collectMTRReport(ctx, opts.Method, opts.Config, trace.MTROptions{
+				HopInterval: time.Duration(opts.HopIntervalMs) * time.Millisecond,
+				MaxPerHop:   opts.MaxPerHop,
+			})
+		} else {
+			err = runMTRJSONRawFn(ctx, opts.Method, opts.Config, trace.MTRRawOptions{
+				HopInterval: time.Duration(opts.HopIntervalMs) * time.Millisecond,
+				MaxPerHop:   opts.MaxPerHop, OnPathEnd: out.pathEnd,
+			}, out.probe)
+		}
+	}
+	if cause := context.Cause(ctx); cause != nil && (err == nil || errors.Is(err, context.Canceled)) {
+		err = cause
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	return out.finish(err, stage, stderr)
+}
+
+func normalizeMTRJSONOptions(opts *mtrJSONOptions, stderr io.Writer) error {
+	if strings.TrimSpace(normalizeCLITarget(opts.Target)) == "" {
+		return errors.New("MTR JSON requires a target")
+	}
+	if opts.IPv4Only && opts.IPv6Only {
+		return errors.New("--ipv4 cannot be combined with --ipv6")
+	}
+	if opts.Report && opts.MaxPerHop <= 0 {
+		return errors.New("MTR JSON report requires --queries greater than zero")
+	}
+	if opts.MaxPerHop < 0 {
+		opts.MaxPerHop = 0
+	}
+	if opts.Method != trace.TCPTrace && opts.MaxPerHop > 255 {
+		_, _ = fmt.Fprintln(stderr, "Query 最大值为 255，已自动调整为 255")
+		opts.MaxPerHop = 255
+	}
+	if opts.HopIntervalMs <= 0 {
+		opts.HopIntervalMs = 1000
+	}
+	cfg := &opts.Config
+	if cfg.TOS < 0 || cfg.TOS > 255 {
+		return errors.New("--tos must be between 0 and 255")
+	}
+	if cfg.Timeout <= 0 {
+		return errors.New("--timeout must be greater than zero")
+	}
+	if cfg.BeginHop <= 0 {
+		cfg.BeginHop = 1
+	}
+	if cfg.MaxHops <= 0 {
+		cfg.MaxHops = 30
+	}
+	if cfg.MaxHops > 255 {
+		cfg.MaxHops = 255
+	}
+	if cfg.BeginHop > cfg.MaxHops {
+		return errors.New("--first must not exceed --max-hops")
+	}
+	if cfg.ParallelRequests <= 0 {
+		cfg.ParallelRequests = 1
+	}
+	applyDefaultPort(&cfg.DstPort, opts.Method == trace.UDPTrace)
+	if opts.Method != trace.ICMPTrace && (cfg.SrcPort < 0 || cfg.SrcPort > 65535 || cfg.DstPort < 1 || cfg.DstPort > 65535) {
+		return errors.New("probe ports must be between 1 and 65535 (source port 0 selects automatically)")
+	}
+	if cfg.ICMPMode <= 0 && util.EnvICMPMode > 0 {
+		cfg.ICMPMode = util.EnvICMPMode
+	}
+	if cfg.ICMPMode < 0 || cfg.ICMPMode > 2 {
+		cfg.ICMPMode = 0
+	}
+	cfg.NumMeasurements, cfg.MaxAttempts, cfg.TTLInterval = 1, 1, 0
+	cfg.RealtimePrinter, cfg.AsyncPrinter = nil, nil
+	return nil
+}
+
+func prepareMTRJSON(ctx context.Context, opts *mtrJSONOptions, out *mtrJSONOutput, stage *string, stderr io.Writer) (func(), error) {
+	restoreOutput := setFastIPOutputSuppression(true)
+	cleanup := restoreOutput
+	configureGeoDNS(opts.DotServer)
+	if err := ctx.Err(); err != nil {
+		return cleanup, context.Cause(ctx)
+	}
+	ip, err := lookupTargetIP(ctx, normalizeCLITarget(opts.Target), opts.IPv4Only, opts.IPv6Only, opts.DotServer, true)
+	if err != nil {
+		return cleanup, err
+	}
+	if ip == nil {
+		return cleanup, errors.New("target resolution returned no address")
+	}
+	out.report.ResolvedIP = ptrStr(ip.String())
+	*stage = "initialize"
+	cfg := &opts.Config
+	cfg.DstIP, cfg.Context = ip, ctx
+	src, _, err := trace.ResolveConfiguredSrcAddr(ip, cfg.SrcAddr, cfg.SourceDevice)
+	if err != nil {
+		return cleanup, err
+	}
+	normalized, err := trace.NormalizeExplicitSourceConfig(opts.Method, *cfg)
+	if err != nil {
+		return cleanup, err
+	}
+	if normalized.SrcAddr != "" {
+		src = normalized.SrcAddr
+	}
+	cfg.SrcAddr, cfg.SourceDevice = src, normalized.SourceDevice
+	if src != "" {
+		sourceIP := net.ParseIP(src)
+		if sourceIP == nil || (sourceIP.To4() == nil) != (ip.To4() == nil) {
+			*stage = "validation"
+			return cleanup, errors.New("--source must be an IP address matching the target IP family")
+		}
+	}
+	packetSize := resolvePacketSizeArg(opts.PacketSize, opts.PacketSizeExplicit, opts.Method, ip)
+	packet, err := trace.NormalizePacketSize(opts.Method, ip, packetSize)
+	if err != nil {
+		*stage = "validation"
+		return cleanup, err
+	}
+	cfg.PktSize, cfg.RandomPacketSize = packet.PayloadSize, packet.Random
+	status := util.TracePrivilegeStatus(appBinName, false)
+	if status.Message != "" {
+		_, _ = fmt.Fprintln(stderr, status.Message)
+	}
+	if status.Fatal {
+		return cleanup, errors.New(status.Message)
+	}
+	if cfg.DN42 || isDN42Provider(opts.DataProvider) {
+		if err := config.InitConfigWithWriter(stderr); err != nil {
+			return cleanup, err
+		}
+		opts.DataProvider, cfg.DN42 = "DN42", true
+	}
+	conn := initNextTraceAPIV3WebSocket(ctx, &opts.DataProvider, &opts.PowProvider, false)
+	cleanup = func() { closeNextTraceAPIV3WebSocket(conn); restoreOutput() }
+	// Runtime provider fallback can select DN42 as well.
+	if !cfg.DN42 && isDN42Provider(opts.DataProvider) {
+		if err := config.InitConfigWithWriter(stderr); err != nil {
+			return cleanup, err
+		}
+		cfg.DN42 = true
+	}
+	descriptor := ipgeo.GetSourceDescriptorSession(opts.DataProvider)
+	session := trace.CachedGeoSourceSession(descriptor)
+	cfg.IPGeoSource, cfg.IPGeoDescriptor, cfg.RefreshIPGeoSource = session.Source, descriptor.Current, session.Refresh
+	*cfg = normalizeMTRReportConfig(*cfg, true)
+	util.SrcPort, util.DstIP = cfg.SrcPort, ip.String()
+	params := &mtrJSONParameters{
+		MaxPerHop: opts.MaxPerHop, HopIntervalMs: opts.HopIntervalMs, TimeoutMs: cfg.Timeout.Milliseconds(),
+		BeginHop: cfg.BeginHop, MaxHops: cfg.MaxHops, ParallelRequests: cfg.ParallelRequests,
+		SourceAddress: cfg.SrcAddr, SourceDevice: cfg.SourceDevice, PacketSize: packetSize, RandomPacketSize: packet.Random,
+		TOS: cfg.TOS, DataProvider: opts.DataProvider, Language: cfg.Lang, DotServer: opts.DotServer,
+		RDNS: cfg.RDNS, AlwaysWaitRDNS: cfg.RDNS && cfg.AlwaysWaitRDNS, DisableMPLS: cfg.DisableMPLS, DN42: cfg.DN42,
+	}
+	if opts.Method != trace.ICMPTrace {
+		params.Port, params.SourcePort = ptrInt(cfg.DstPort), ptrInt(cfg.SrcPort)
+	}
+	if cfg.OSType == 2 {
+		params.ICMPMode = ptrInt(cfg.ICMPMode)
+	}
+	out.report.EffectiveParameters = params
+	return cleanup, nil
+}

--- a/cmd/mtr_json_run.go
+++ b/cmd/mtr_json_run.go
@@ -107,19 +107,45 @@ func runMTRJSON(parent context.Context, opts mtrJSONOptions, stdout, stderr io.W
 				MaxPerHop:   opts.MaxPerHop,
 			})
 		} else {
-			err = runMTRJSONRawFn(ctx, opts.Method, opts.Config, trace.MTRRawOptions{
-				HopInterval: time.Duration(opts.HopIntervalMs) * time.Millisecond,
-				MaxPerHop:   opts.MaxPerHop, OnPathEnd: out.pathEnd,
-			}, out.probe)
+			err = runMTRJSONStream(ctx, opts, out)
 		}
 	}
 	if cause := context.Cause(ctx); cause != nil && (err == nil || errors.Is(err, context.Canceled)) {
 		err = cause
 	}
+	if trace.IsInitializationError(err) {
+		stage = "initialize"
+	}
 	if cleanup != nil {
 		cleanup()
 	}
 	return out.finish(err, stage, stderr)
+}
+
+func runMTRJSONStream(ctx context.Context, opts mtrJSONOptions, out *mtrJSONOutput) error {
+	// The per-hop scheduler announces a path change before the associated RAW
+	// callback. Hold only that change so the JSON probe precedes its conclusion.
+	var pending *trace.StopReason
+	pathChanged := false
+	flushPath := func() {
+		if pathChanged {
+			out.pathEnd(pending)
+			pathChanged = false
+		}
+	}
+	err := runMTRJSONRawFn(ctx, opts.Method, opts.Config, trace.MTRRawOptions{
+		HopInterval: time.Duration(opts.HopIntervalMs) * time.Millisecond,
+		MaxPerHop:   opts.MaxPerHop, OnPathEnd: func(reason *trace.StopReason) {
+			flushPath()
+			pending, pathChanged = copyMTRPathEnd(reason), true
+		},
+	}, func(record trace.MTRRawRecord) {
+		out.probe(record)
+		flushPath()
+	})
+	// A max-hops conclusion can be emitted after the last probe callback.
+	flushPath()
+	return err
 }
 
 func normalizeMTRJSONOptions(opts *mtrJSONOptions, stderr io.Writer) error {

--- a/cmd/mtr_json_signal_test.go
+++ b/cmd/mtr_json_signal_test.go
@@ -1,0 +1,80 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestMTRJSONProcessSignals(t *testing.T) {
+	for _, report := range []bool{false, true} {
+		for _, data := range []string{"zero", "partial"} {
+			for _, sig := range []os.Signal{os.Interrupt, syscall.SIGTERM} {
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				args := []string{"-test.run=^TestMTRJSONCLIProcess$", "--", "--json", "--data-provider", "disable-geoip", "-s", "127.0.0.1", "127.0.0.1"}
+				if enableTraceroute {
+					args = append(args, "--mtr")
+				}
+				if report {
+					args = append(args, "-r")
+				}
+				process := exec.CommandContext(ctx, os.Args[0], args...)
+				process.Env = append(os.Environ(), "NTRACE_TEST_MTR_JSON_PROCESS=1", "NTRACE_TEST_MTR_JSON_BLOCK="+data)
+				var stdout bytes.Buffer
+				process.Stdout = &stdout
+				stderr, err := process.StderrPipe()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err = process.Start(); err != nil {
+					t.Fatal(err)
+				}
+				scanner := bufio.NewScanner(stderr)
+				ready := false
+				for scanner.Scan() {
+					if scanner.Text() == "ready" {
+						ready = true
+						break
+					}
+				}
+				if !ready {
+					cancel()
+					_ = process.Wait()
+					t.Fatal("session never became ready")
+				}
+				if err = process.Process.Signal(sig); err != nil {
+					t.Fatal(err)
+				}
+				err = process.Wait()
+				cancel()
+				wantCode, wantSignal := 130, `"SIGINT"`
+				if sig == syscall.SIGTERM {
+					wantCode, wantSignal = 143, `"SIGTERM"`
+				}
+				var exit *exec.ExitError
+				if !errors.As(err, &exit) || exit.ExitCode() != wantCode {
+					t.Fatalf("report=%v data=%s signal=%v: exit=%v stdout=%s", report, data, sig, err, stdout.String())
+				}
+				values := decodeMTRJSON(t, stdout.Bytes())
+				end := values[len(values)-1]
+				if string(end["end_reason"]) != `"interrupted"` || string(end["signal"]) != wantSignal {
+					t.Fatalf("incorrect signal outcome: %s", stdout.String())
+				}
+				if report && (len(values) != 1 || (string(end["stats"]) == "[]") != (data == "zero")) {
+					t.Fatalf("partial report: %s", stdout.String())
+				}
+				if !report && len(values) != map[string]int{"zero": 2, "partial": 3}[data] {
+					t.Fatalf("partial stream: %s", stdout.String())
+				}
+			}
+		}
+	}
+}

--- a/cmd/mtr_json_test.go
+++ b/cmd/mtr_json_test.go
@@ -225,6 +225,51 @@ func testMTRJSONOptions() mtrJSONOptions {
 	}
 }
 
+func TestMTRJSONStreamOrdersProbeBeforePathChange(t *testing.T) {
+	oldRaw := runMTRJSONRawFn
+	t.Cleanup(func() { runMTRJSONRawFn = oldRaw })
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	var stdout bytes.Buffer
+	out := newMTRJSONOutput(&stdout, true, "target", trace.ICMPTrace, cancel)
+	out.startStream()
+	records := []trace.MTRRawRecord{{TTL: 1, IP: "192.0.2.1"}, {TTL: 2, IP: "192.0.2.2"}}
+	runMTRJSONRawFn = func(_ context.Context, _ trace.Method, _ trace.Config, opts trace.MTRRawOptions, cb trace.MTRRawOnRecord) error {
+		for i, reason := range []*trace.StopReason{{Hop: 1, Reason: trace.StopReasonUnreachable}, nil} {
+			opts.OnPathEnd(reason)
+			cb(records[i])
+			if got := len(decodeMTRJSON(t, stdout.Bytes())); got != 3+2*i {
+				t.Fatalf("probe/path change were not flushed immediately: %s", stdout.String())
+			}
+		}
+		opts.OnPathEnd(&trace.StopReason{Hop: 3, Reason: trace.StopReasonMaxHops})
+		return nil
+	}
+	err := runMTRJSONStream(ctx, testMTRJSONOptions(), out)
+	if code := out.finish(err, "probe", io.Discard); code != 0 {
+		t.Fatalf("exit=%d", code)
+	}
+	events := decodeMTRJSON(t, stdout.Bytes())
+	wantTypes := []string{"start", "probe", "path_end", "probe", "path_end", "path_end", "end"}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("unexpected events: %s", stdout.String())
+	}
+	for i, want := range wantTypes {
+		if string(events[i]["type"]) != `"`+want+`"` || string(events[i]["seq"]) != fmt.Sprint(i+1) {
+			t.Fatalf("event %d: %s", i, stdout.String())
+		}
+	}
+	for i, event := range []map[string]json.RawMessage{events[1], events[3]} {
+		var got trace.MTRRawRecord
+		if err := json.Unmarshal(event["record"], &got); err != nil || !reflect.DeepEqual(got, records[i]) {
+			t.Fatalf("RAW record changed: %+v, %v", got, err)
+		}
+	}
+	if string(events[4]["path_end"]) != "null" || !bytes.Equal(events[5]["path_end"], events[6]["path_end"]) {
+		t.Fatalf("lost reopening or final max-hops conclusion: %s", stdout.String())
+	}
+}
+
 func TestMTRJSONRunnerUsesFullConfigAndPreservesSnapshot(t *testing.T) {
 	oldPort, oldDst := util.SrcPort, util.DstIP
 	t.Cleanup(func() { util.SrcPort, util.DstIP = oldPort, oldDst })

--- a/cmd/mtr_json_test.go
+++ b/cmd/mtr_json_test.go
@@ -51,6 +51,29 @@ func TestRequestsMTRJSONRoutesSyntaxErrors(t *testing.T) {
 	}
 }
 
+func TestMTRJSONHelpAndVersion(t *testing.T) {
+	for _, flag := range []string{"--help", "-h", "--version", "-V"} {
+		t.Run(flag, func(t *testing.T) {
+			args := []string{"-test.run=^TestMTRJSONCLIProcess$", "--", "--json", flag}
+			if enableTraceroute {
+				args = append(args, "--mtr")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			process := exec.CommandContext(ctx, os.Args[0], args...)
+			process.Env = append(os.Environ(), "NTRACE_TEST_MTR_JSON_PROCESS=1")
+			var stdout, stderr bytes.Buffer
+			process.Stdout, process.Stderr = &stdout, &stderr
+			if err := process.Run(); err != nil || stdout.Len() == 0 || stderr.Len() != 0 {
+				t.Fatalf("%s: error=%v stdout=%s stderr=%s", flag, err, stdout.String(), stderr.String())
+			}
+			if (flag == "--help" || flag == "-h") && !strings.Contains(stdout.String(), "usage:") {
+				t.Fatalf("missing help output: %s", stdout.String())
+			}
+		})
+	}
+}
+
 func TestMTRJSONStreamRecordsAndPathChanges(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(t.Context())
 	defer cancel(nil)

--- a/cmd/mtr_json_test.go
+++ b/cmd/mtr_json_test.go
@@ -70,6 +70,9 @@ func TestMTRJSONHelpAndVersion(t *testing.T) {
 			if (flag == "--help" || flag == "-h") && !strings.Contains(stdout.String(), "usage:") {
 				t.Fatalf("missing help output: %s", stdout.String())
 			}
+			if (flag == "--version" || flag == "-V") && !strings.Contains(stdout.String(), "NextTrace CopyRight") {
+				t.Fatalf("missing version command output: %s", stdout.String())
+			}
 		})
 	}
 }

--- a/cmd/mtr_json_test.go
+++ b/cmd/mtr_json_test.go
@@ -1,0 +1,424 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+func decodeMTRJSON(t *testing.T, data []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var result []map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for {
+		var value map[string]json.RawMessage
+		err := dec.Decode(&value)
+		if err == io.EOF {
+			return result
+		}
+		if err != nil {
+			t.Fatalf("invalid JSON: %v\n%s", err, data)
+		}
+		result = append(result, value)
+	}
+}
+
+func TestRequestsMTRJSONRoutesSyntaxErrors(t *testing.T) {
+	for _, args := range [][]string{
+		{"--mtr", "--json=invalid"}, {"-rj"}, {"-twj", "--unknown"},
+	} {
+		if !requestsMTRJSON(args) {
+			t.Fatalf("MTR JSON diagnostics not selected: %v", args)
+		}
+	}
+	if requestsMTRJSON([]string{"--", "--mtr", "--json"}) {
+		t.Fatal("positional flags selected MTR JSON")
+	}
+}
+
+func TestMTRJSONStreamRecordsAndPathChanges(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	var stdout, stderr bytes.Buffer
+	out := newMTRJSONOutput(&stdout, true, "example.com", trace.ICMPTrace, cancel)
+	out.startStream()
+	records := []trace.MTRRawRecord{
+		{TTL: 1, Success: true, IP: "192.0.2.1", Host: "中文\n\"host\"", RTTMs: 0, ASN: "64500", City: "测试", MPLS: []string{"label=16"}},
+		{TTL: 2, Success: false},
+	}
+	for _, rec := range records {
+		out.probe(rec)
+	}
+	out.pathEnd(&trace.StopReason{Hop: 2, Reason: trace.StopReasonUnreachable})
+	out.pathEnd(nil)
+	out.pathEnd(&trace.StopReason{Hop: 3, Reason: trace.StopReasonDestination})
+	if code := out.finish(nil, "probe", &stderr); code != 0 || ctx.Err() != nil {
+		t.Fatalf("exit=%d, err=%v, stderr=%s", code, ctx.Err(), stderr.String())
+	}
+	lines := bytes.Split(bytes.TrimSpace(stdout.Bytes()), []byte{'\n'})
+	wantTypes := []string{"start", "probe", "probe", "path_end", "path_end", "path_end", "end"}
+	if len(lines) != len(wantTypes) {
+		t.Fatalf("line count=%d, output=%s", len(lines), stdout.String())
+	}
+	values := decodeMTRJSON(t, stdout.Bytes())
+	for i, value := range values {
+		var typ string
+		var seq, version int
+		_ = json.Unmarshal(value["type"], &typ)
+		_ = json.Unmarshal(value["seq"], &seq)
+		_ = json.Unmarshal(value["schema_version"], &version)
+		if typ != wantTypes[i] || seq != i+1 || version != 1 {
+			t.Fatalf("event %d: %s", i, lines[i])
+		}
+		if i == 1 || i == 2 {
+			var rec trace.MTRRawRecord
+			if err := json.Unmarshal(value["record"], &rec); err != nil || !reflect.DeepEqual(rec, records[i-1]) {
+				t.Fatalf("record %d changed: %#v, %v", i, rec, err)
+			}
+		}
+	}
+	if string(values[4]["path_end"]) != "null" || string(values[6]["end_reason"]) != `"completed"` {
+		t.Fatalf("path reopening/completion lost: %s", stdout.String())
+	}
+	if _, present := values[6]["stats"]; present {
+		t.Fatal("stream end must not recompute a report")
+	}
+}
+
+func TestMTRJSONEmptyAndPartialOutcomes(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, tc := range []struct {
+			name, stage, reason, signal string
+			err                         error
+			code                        int
+		}{
+			{name: "complete", stage: "probe", reason: "completed"},
+			{name: "validation", stage: "validation", reason: "error", err: errors.New("bad queries"), code: 2},
+			{name: "dns", stage: "resolve", reason: "error", err: errors.New("no address"), code: 1},
+			{name: "setup", stage: "initialize", reason: "error", err: errors.New("socket denied"), code: 1},
+			{name: "runtime", stage: "probe", reason: "error", err: errors.New("rotation failed"), code: 1},
+			{name: "internal cancellation", stage: "probe", reason: "error", err: context.Canceled, code: 1},
+			{name: "interrupt", reason: "interrupted", signal: "SIGINT", err: &mtrJSONSignal{os.Interrupt}, code: 130},
+			{name: "terminate", reason: "interrupted", signal: "SIGTERM", err: &mtrJSONSignal{syscall.SIGTERM}, code: 143},
+		} {
+			t.Run(tc.name+map[bool]string{true: "/stream", false: "/report"}[stream], func(t *testing.T) {
+				_, cancel := context.WithCancelCause(t.Context())
+				defer cancel(nil)
+				var stdout, stderr bytes.Buffer
+				out := newMTRJSONOutput(&stdout, stream, "target", trace.UDPTrace, cancel)
+				if tc.name == "runtime" {
+					out.report.Stats = []trace.MTRHopStat{{TTL: 1, Snt: 2, Received: 1, Loss: 50, Avg: 1.5}}
+				}
+				if code := out.finish(tc.err, tc.stage, &stderr); code != tc.code {
+					t.Fatalf("exit=%d want=%d", code, tc.code)
+				}
+				values := decodeMTRJSON(t, stdout.Bytes())
+				count := 1
+				if stream {
+					count = 2
+				}
+				if len(values) != count {
+					t.Fatalf("got %d documents", len(values))
+				}
+				last := values[len(values)-1]
+				if string(last["end_reason"]) != `"`+tc.reason+`"` {
+					t.Fatalf("outcome: %s", stdout.String())
+				}
+				if tc.signal != "" && string(last["signal"]) != `"`+tc.signal+`"` {
+					t.Fatal("missing signal")
+				}
+				if !stream {
+					if tc.name == "runtime" && !bytes.Contains(last["stats"], []byte(`"snt":2`)) {
+						t.Fatal("lost partial stats")
+					}
+					if tc.name != "runtime" && string(last["stats"]) != "[]" {
+						t.Fatal("empty stats must be []")
+					}
+				}
+			})
+		}
+	}
+}
+
+type failingMTRWriter struct {
+	calls int
+	short bool
+}
+
+func (w *failingMTRWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.short {
+		return len(p) - 1, nil
+	}
+	return 0, io.ErrClosedPipe
+}
+
+func TestMTRJSONWriteFailureCancelsWithoutRetry(t *testing.T) {
+	for _, short := range []bool{false, true} {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		w := &failingMTRWriter{short: short}
+		out := newMTRJSONOutput(w, true, "target", trace.ICMPTrace, cancel)
+		out.startStream()
+		out.probe(trace.MTRRawRecord{TTL: 1})
+		if out.finish(nil, "probe", io.Discard) != 1 || ctx.Err() == nil || w.calls != 1 {
+			t.Fatalf("write failure retried or not canceled: calls=%d cause=%v", w.calls, context.Cause(ctx))
+		}
+		cancel(nil)
+	}
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	var data bytes.Buffer
+	out := newMTRJSONOutput(&data, true, "target", trace.ICMPTrace, cancel)
+	out.startStream()
+	out.probe(trace.MTRRawRecord{RTTMs: math.NaN()})
+	if out.finish(nil, "probe", io.Discard) != 1 || ctx.Err() == nil || len(decodeMTRJSON(t, data.Bytes())) != 1 {
+		t.Fatal("encoding failure must leave only previously completed events")
+	}
+}
+
+func testMTRJSONOptions() mtrJSONOptions {
+	return mtrJSONOptions{
+		Target: "example.com", Method: trace.ICMPTrace, MaxPerHop: 2, HopIntervalMs: 10,
+		DataProvider: "disable-geoip", PowProvider: "api.nxtrace.org",
+		Config: trace.Config{SrcAddr: "127.0.0.1", MaxHops: 3, Timeout: time.Second, Lang: "cn"},
+	}
+}
+
+func TestMTRJSONRunnerUsesFullConfigAndPreservesSnapshot(t *testing.T) {
+	oldPort, oldDst := util.SrcPort, util.DstIP
+	t.Cleanup(func() { util.SrcPort, util.DstIP = oldPort, oldDst })
+	oldLookup, oldReport, oldRaw := domainLookupFn, runMTRReportFn, runMTRJSONRawFn
+	t.Cleanup(func() { domainLookupFn, runMTRReportFn, runMTRJSONRawFn = oldLookup, oldReport, oldRaw })
+	domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		return net.ParseIP("127.0.0.1"), nil
+	}
+	want := []trace.MTRHopStat{
+		{TTL: 1, IP: "192.0.2.1", Snt: 1, Received: 1},
+		{TTL: 1, IP: "192.0.2.2", Snt: 1, Received: 1, Avg: 2.5},
+		{TTL: 2, Snt: 2, Loss: 100},
+	}
+	runMTRReportFn = func(_ context.Context, _ trace.Method, cfg trace.Config, opts trace.MTROptions, snapshot trace.MTROnSnapshot) error {
+		if cfg.AlwaysWaitRDNS || cfg.TTLInterval != 0 || opts.MaxPerHop != 2 {
+			t.Fatalf("unexpected report config: %+v", cfg)
+		}
+		opts.OnPathEnd(&trace.StopReason{Hop: 3, Reason: trace.StopReasonDestination})
+		snapshot(1, want)
+		return errors.New("rotation failed")
+	}
+	var stdout, stderr bytes.Buffer
+	opts := testMTRJSONOptions()
+	opts.Report, opts.PacketSizeExplicit, opts.PacketSize = true, true, -84
+	if code := runMTRJSON(t.Context(), opts, &stdout, &stderr); code != 1 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	var report mtrJSONReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(report.Stats, want) || report.PathEnd.Reason != trace.StopReasonDestination {
+		t.Fatalf("lost snapshot: %s", stdout.String())
+	}
+	if p := report.EffectiveParameters; p.PacketSize != -84 || !p.RandomPacketSize || p.MaxPerHop != 2 || p.Port != nil {
+		t.Fatalf("effective parameters: %+v", p)
+	}
+
+	runMTRJSONRawFn = func(ctx context.Context, _ trace.Method, _ trace.Config, opts trace.MTRRawOptions, callback trace.MTRRawOnRecord) error {
+		callback(trace.MTRRawRecord{TTL: 1, Success: true, IP: "192.0.2.1"})
+		opts.OnPathEnd(nil)
+		return &mtrJSONSignal{syscall.SIGTERM}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	opts.Report = false
+	if code := runMTRJSON(t.Context(), opts, &stdout, &stderr); code != 143 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	if values := decodeMTRJSON(t, stdout.Bytes()); len(values) != 4 {
+		t.Fatalf("events=%d", len(values))
+	}
+}
+
+func TestMTRJSONPreparationFailures(t *testing.T) {
+	oldLookup := domainLookupFn
+	t.Cleanup(func() { domainLookupFn = oldLookup })
+	for _, tc := range []struct {
+		name      string
+		source    string
+		lookupErr error
+		code      int
+	}{
+		{"DNS failure", "127.0.0.1", errors.New("DNS unavailable"), 1},
+		{"interrupted resolution", "127.0.0.1", &mtrJSONSignal{os.Interrupt}, 130},
+		{"invalid source", "bad-source", nil, 2},
+		{"wrong source family", "::1", nil, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+				return net.IPv4(127, 0, 0, 1), tc.lookupErr
+			}
+			opts := testMTRJSONOptions()
+			opts.Config.SrcAddr = tc.source
+			var stdout, stderr bytes.Buffer
+			if code := runMTRJSON(t.Context(), opts, &stdout, &stderr); code != tc.code {
+				t.Fatalf("code=%d: %s", code, stderr.String())
+			}
+			values := decodeMTRJSON(t, stdout.Bytes())
+			if len(values) != 2 || string(values[0]["effective_parameters"]) != "null" {
+				t.Fatalf("invalid failed lifecycle: %s", stdout.String())
+			}
+			if tc.lookupErr != nil && string(values[0]["resolved_ip"]) != "null" {
+				t.Fatal("failed DNS must not claim a resolved address")
+			}
+		})
+	}
+}
+
+func TestMTRJSONUsesEveryRawFixtureRecord(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	var stdout, stderr bytes.Buffer
+	out := newMTRJSONOutput(&stdout, true, "fixture", trace.ICMPTrace, cancel)
+	out.startStream()
+	var records []trace.MTRRawRecord
+	err := trace.RunMTRRaw(ctx, trace.ICMPTrace, trace.Config{MaxHops: 2}, trace.MTRRawOptions{
+		MaxRounds: 1,
+		RunRound: func(_ trace.Method, cfg trace.Config) (*trace.Result, error) {
+			res := &trace.Result{Hops: [][]trace.Hop{
+				{{TTL: 1, Success: true, Address: &net.IPAddr{IP: net.IPv4(192, 0, 2, 1)}, RTT: 0, MPLS: []string{"label=16"}}, {TTL: 1, Success: true, Address: &net.IPAddr{IP: net.IPv4(192, 0, 2, 2)}}},
+				{{TTL: 2, Success: false}},
+			}}
+			cfg.RealtimePrinter(res, 0)
+			cfg.RealtimePrinter(res, 1)
+			return res, nil
+		}, OnPathEnd: out.pathEnd,
+	}, func(rec trace.MTRRawRecord) { records = append(records, rec); out.probe(rec) })
+	if code := out.finish(err, "probe", &stderr); code != 0 {
+		t.Fatalf("code=%d: %s", code, stderr.String())
+	}
+	values := decodeMTRJSON(t, stdout.Bytes())
+	var got []trace.MTRRawRecord
+	for _, value := range values {
+		if string(value["type"]) == `"probe"` {
+			var rec trace.MTRRawRecord
+			if err := json.Unmarshal(value["record"], &rec); err != nil {
+				t.Fatal(err)
+			}
+			got = append(got, rec)
+		}
+	}
+	if len(records) != 3 || !reflect.DeepEqual(got, records) {
+		t.Fatalf("RAW/JSON records differ: %+v / %+v", records, got)
+	}
+}
+
+func TestMTRJSONCLIProcess(t *testing.T) {
+	if os.Getenv("NTRACE_TEST_MTR_JSON_PROCESS") == "1" {
+		domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+			return net.ParseIP("127.0.0.1"), nil
+		}
+		runMTRJSONRawFn = func(ctx context.Context, _ trace.Method, _ trace.Config, _ trace.MTRRawOptions, cb trace.MTRRawOnRecord) error {
+			if os.Getenv("NTRACE_TEST_MTR_JSON_BLOCK") != "zero" {
+				cb(trace.MTRRawRecord{TTL: 1, Success: true, ASN: "64500", City: "测试", RTTMs: 0})
+			}
+			if os.Getenv("NTRACE_TEST_MTR_JSON_BLOCK") != "" {
+				fmt.Fprintln(os.Stderr, "ready")
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			return nil
+		}
+		runMTRReportFn = func(ctx context.Context, _ trace.Method, cfg trace.Config, _ trace.MTROptions, cb trace.MTROnSnapshot) error {
+			if cfg.AlwaysWaitRDNS {
+				panic("report must use wide rules")
+			}
+			if os.Getenv("NTRACE_TEST_MTR_JSON_BLOCK") != "zero" {
+				cb(1, []trace.MTRHopStat{{TTL: 1, Snt: 1, Received: 1}})
+			}
+			if os.Getenv("NTRACE_TEST_MTR_JSON_BLOCK") != "" {
+				fmt.Fprintln(os.Stderr, "ready")
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			return nil
+		}
+		for i, arg := range os.Args {
+			if arg == "--" {
+				os.Args = append([]string{appBinName}, os.Args[i+1:]...)
+				break
+			}
+		}
+		Execute()
+		os.Exit(0)
+	}
+	base := []string{"--json", "--data-provider", "disable-geoip", "-s", "127.0.0.1", "127.0.0.1"}
+	if enableTraceroute {
+		base = append([]string{"--mtr"}, base...)
+	}
+	for _, tc := range []struct {
+		name            string
+		extra           []string
+		code, documents int
+	}{
+		{"stream", nil, 0, 3},
+		{"finite stream", []string{"-q", "10"}, 0, 3},
+		{"unlimited zero", []string{"-q", "0"}, 0, 3},
+		{"unlimited negative", []string{"-q", "-1"}, 0, 3},
+		{"ignored y", []string{"-y", "99"}, 0, 3},
+		{"report", []string{"-r"}, 0, 1},
+		{"wide", []string{"-w"}, 0, 1},
+		{"report ignored y", []string{"-r", "-y", "99"}, 0, 1},
+		{"invalid report count", []string{"-r", "-q", "0"}, 2, 1},
+		{"invalid tos", []string{"-Q", "256"}, 2, 2},
+		{"duplicate source syntax", []string{"-s", "bad-source"}, 2, 0},
+		{"raw conflict", []string{"--raw"}, 2, 0},
+		{"unknown argument", []string{"--unknown-mtr-option"}, 2, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"-test.run=^TestMTRJSONCLIProcess$", "--"}, base...)
+			args = append(args, tc.extra...)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, os.Args[0], args...)
+			cmd.Env = append(os.Environ(), "NTRACE_TEST_MTR_JSON_PROCESS=1")
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			err := cmd.Run()
+			code := 0
+			if err != nil {
+				var exit *exec.ExitError
+				if !errors.As(err, &exit) {
+					t.Fatal(err)
+				}
+				code = exit.ExitCode()
+			}
+			if code != tc.code {
+				t.Fatalf("exit=%d want=%d stdout=%s stderr=%s", code, tc.code, stdout.String(), stderr.String())
+			}
+			values := decodeMTRJSON(t, stdout.Bytes())
+			if len(values) != tc.documents {
+				t.Fatalf("documents=%d output=%s stderr=%s", len(values), stdout.String(), stderr.String())
+			}
+			if strings.Contains(stdout.String(), "\x1b") {
+				t.Fatal("ANSI in JSON")
+			}
+			if code == 0 && tc.documents == 3 && !bytes.Contains(values[1]["record"], []byte(`"asn":"64500"`)) {
+				t.Fatal("FULL fields missing")
+			}
+		})
+	}
+}

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -48,7 +48,7 @@ func checkMTRConflicts(flags map[string]bool) (conflict string, ok bool) {
 // runMTRTUI 执行 MTR 交互式 TUI 模式。
 // 当 stdin 为 TTY 时启用全屏 TUI（备用屏幕、按键控制）；
 // 非 TTY 时降级为简单表格刷新。
-func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int) {
+func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -102,11 +102,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		}
 	}
 
-	err := trace.RunMTR(ctx, method, roundConf, opts, onSnapshot)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		// 离开备用屏幕后再打印错误
-		fmt.Println(err)
-	}
+	return trace.RunMTR(ctx, method, roundConf, opts, onSnapshot)
 }
 
 func buildMTRInteractiveOptions(ui *mtrUI, hopIntervalMs int, maxPerHop int) trace.MTROptions {
@@ -143,7 +139,7 @@ func attachMTRHistoryIfTTY(ui *mtrUI, opts *trace.MTROptions) *printer.MTRHistor
 
 // runMTRReport 执行 MTR 非全屏报告模式（对齐 mtr -rzw 风格）。
 // 探测完 maxPerHop 后一次性输出最终统计到 stdout，不进入 alternate screen。
-func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, wide bool, showIPs bool) {
+func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, wide bool, showIPs bool) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -174,13 +170,12 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 	roundConf := normalizeMTRReportConfig(conf, wide)
 	finalStats, _, err := collectMTRReport(ctx, method, roundConf, opts)
 	if err != nil && !errors.Is(err, context.Canceled) {
-		fmt.Println(err)
-		return
+		return err
 	}
 
 	if len(finalStats) == 0 {
 		fmt.Println("No data collected.")
-		return
+		return nil
 	}
 
 	printer.MTRReportPrint(finalStats, printer.MTRReportOptions{
@@ -190,6 +185,7 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 		ShowIPs:   showIPs,
 		Lang:      lang,
 	})
+	return nil
 }
 
 // runMTRRaw 执行 MTR 原始流式模式（逐事件输出，'|' 分隔）。
@@ -202,7 +198,7 @@ func writeMTRRawPathEnd(w io.Writer, reason *trace.StopReason) error {
 	return printer.WriteTraceStopReason(w, reason)
 }
 
-func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, dataOrigin string) {
+func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, dataOrigin string) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -225,12 +221,9 @@ func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		fmt.Println(apiLine)
 	}
 
-	err := trace.RunMTRRaw(ctx, method, roundConf, opts, func(rec trace.MTRRawRecord) {
+	return trace.RunMTRRaw(ctx, method, roundConf, opts, func(rec trace.MTRRawRecord) {
 		fmt.Println(printer.FormatMTRRawLine(rec))
 	})
-	if err != nil && !errors.Is(err, context.Canceled) {
-		writeMTRRawRuntimeError(os.Stderr, err)
-	}
 }
 
 func normalizeMTRTraceConfig(conf trace.Config) trace.Config {

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -29,7 +29,6 @@ func checkMTRConflicts(flags map[string]bool) (conflict string, ok bool) {
 	}{
 		{"--table", flags["table"]},
 		{"--classic", flags["classic"]},
-		{"--json", flags["json"]},
 		{"--output", flags["output"]},
 		{"--output-default", flags["outputDefault"]},
 		{"--route-path", flags["routePath"]},
@@ -167,19 +166,13 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 		lang = "cn"
 	}
 
-	// 最终快照
-	var finalStats []trace.MTRHopStat
-	onSnapshot := func(iteration int, stats []trace.MTRHopStat) {
-		finalStats = stats
-	}
-
 	opts := trace.MTROptions{
 		HopInterval: time.Duration(hopIntervalMs) * time.Millisecond,
 		MaxPerHop:   maxPerHop,
 	}
 
 	roundConf := normalizeMTRReportConfig(conf, wide)
-	err := trace.RunMTR(ctx, method, roundConf, opts, onSnapshot)
+	finalStats, _, err := collectMTRReport(ctx, method, roundConf, opts)
 	if err != nil && !errors.Is(err, context.Canceled) {
 		fmt.Println(err)
 		return

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -75,19 +75,9 @@ func TestCheckMTRConflicts_Table(t *testing.T) {
 	}
 }
 
-func TestCheckMTRConflicts_JSON(t *testing.T) {
-	flags := map[string]bool{
-		"table": false, "raw": false, "classic": false,
-		"json": true, "output": false, "outputDefault": false,
-		"routePath": false, "from": false, "fastTrace": false,
-		"file": false, "deploy": false,
-	}
-	conflict, ok := checkMTRConflicts(flags)
-	if ok {
-		t.Fatal("expected conflict with --json")
-	}
-	if conflict != "--json" {
-		t.Errorf("conflict = %q, want --json", conflict)
+func TestCheckMTRConflicts_JSONAllowed(t *testing.T) {
+	if conflict, ok := checkMTRConflicts(map[string]bool{"json": true}); !ok {
+		t.Fatalf("JSON should be accepted, got conflict %q", conflict)
 	}
 }
 

--- a/cmd/trace_exit_test.go
+++ b/cmd/trace_exit_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestTraceRunErrorExitStatus(t *testing.T) {
+	for _, mode := range []string{"failure", "report", "canceled", "success"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			process := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestTraceRunErrorProcess$")
+			process.Env = append(os.Environ(), "NTRACE_TEST_TRACE_ERROR="+mode)
+			var stdout, stderr bytes.Buffer
+			process.Stdout, process.Stderr = &stdout, &stderr
+			err := process.Run()
+			if mode == "failure" || mode == "report" {
+				var exit *exec.ExitError
+				if !errors.As(err, &exit) || exit.ExitCode() != 1 || stdout.Len() != 0 || !bytes.Contains(stderr.Bytes(), []byte("probe setup failed")) {
+					t.Fatalf("error=%v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+				}
+			} else if err != nil || stderr.Len() != 0 {
+				t.Fatalf("error=%v stderr=%s", err, stderr.String())
+			}
+		})
+	}
+}
+
+func TestTraceRunErrorProcess(t *testing.T) {
+	switch os.Getenv("NTRACE_TEST_TRACE_ERROR") {
+	case "failure":
+		exitOnTraceRunError(errors.New("probe setup failed"))
+	case "report":
+		runMTRReportFn = func(context.Context, trace.Method, trace.Config, trace.MTROptions, trace.MTROnSnapshot) error {
+			return errors.New("probe setup failed")
+		}
+		maybeRunMTRMode(effectiveMTRModes{mtr: true, report: true}, trace.ICMPTrace,
+			trace.Config{SrcAddr: "127.0.0.1", DstIP: net.IPv4(127, 0, 0, 1)}, true, 1, false, 0,
+			"127.0.0.1", "disable-geoip", false, 0)
+	case "canceled":
+		exitOnTraceRunError(context.Canceled)
+	case "success":
+		exitOnTraceRunError(nil)
+	}
+}

--- a/cmd/trace_mode_test.go
+++ b/cmd/trace_mode_test.go
@@ -100,12 +100,12 @@ func TestModeFlagsMatchFlavorCapabilities(t *testing.T) {
 	registerPacketIntervalFlag(parser)
 	registerFileFlag(parser)
 	usage := parser.Usage(nil)
-	for _, flag := range []string{"--traceroute", "--json", "--classic", "--output", "--send-time", "--file"} {
+	for _, flag := range []string{"--traceroute", "--classic", "--output", "--send-time", "--file"} {
 		if strings.Contains(usage, flag) != enableTraceroute {
 			t.Errorf("%s availability incorrect in %s", flag, appBinName)
 		}
 	}
-	for _, flag := range []string{"--report", "--wide", "--show-ips", "--ipinfo"} {
+	for _, flag := range []string{"--json", "--report", "--wide", "--show-ips", "--ipinfo"} {
 		if !strings.Contains(usage, flag) {
 			t.Errorf("missing %s in %s", flag, appBinName)
 		}

--- a/config/viper.go
+++ b/config/viper.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +15,11 @@ import (
 var viperMu sync.RWMutex
 
 func InitConfig() {
+	_ = InitConfigWithWriter(os.Stdout)
+}
+
+// InitConfigWithWriter keeps machine-readable stdout separate from diagnostics.
+func InitConfigWithWriter(w io.Writer) error {
 	viperMu.Lock()
 	defer viperMu.Unlock()
 
@@ -72,20 +78,22 @@ func InitConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		var notFound viper.ConfigFileNotFoundError
 		if errors.As(err, &notFound) {
-			fmt.Println("未能找到配置文件，我们将在您的运行目录为您创建 nt_config.yaml 默认配置")
+			fmt.Fprintln(w, "未能找到配置文件，我们将在您的运行目录为您创建 nt_config.yaml 默认配置")
 			if err := viper.SafeWriteConfigAs("./nt_config.yaml"); err != nil {
-				fmt.Println("创建默认配置文件失败:", err)
-				return
+				fmt.Fprintln(w, "创建默认配置文件失败:", err)
+				return err
 			}
 			if err := viper.ReadInConfig(); err != nil {
-				fmt.Println("加载默认配置失败:", err)
+				fmt.Fprintln(w, "加载默认配置失败:", err)
+				return err
 			}
-			return
+			return nil
 		}
 
-		fmt.Println("加载配置文件失败:", err)
-		return
+		fmt.Fprintln(w, "加载配置文件失败:", err)
+		return err
 	}
+	return nil
 }
 
 func GeoFeedPath() string {

--- a/config/viper.go
+++ b/config/viper.go
@@ -78,19 +78,19 @@ func InitConfigWithWriter(w io.Writer) error {
 	if err := viper.ReadInConfig(); err != nil {
 		var notFound viper.ConfigFileNotFoundError
 		if errors.As(err, &notFound) {
-			fmt.Fprintln(w, "未能找到配置文件，我们将在您的运行目录为您创建 nt_config.yaml 默认配置")
+			_, _ = fmt.Fprintln(w, "未能找到配置文件，我们将在您的运行目录为您创建 nt_config.yaml 默认配置")
 			if err := viper.SafeWriteConfigAs("./nt_config.yaml"); err != nil {
-				fmt.Fprintln(w, "创建默认配置文件失败:", err)
+				_, _ = fmt.Fprintln(w, "创建默认配置文件失败:", err)
 				return err
 			}
 			if err := viper.ReadInConfig(); err != nil {
-				fmt.Fprintln(w, "加载默认配置失败:", err)
+				_, _ = fmt.Fprintln(w, "加载默认配置失败:", err)
 				return err
 			}
 			return nil
 		}
 
-		fmt.Fprintln(w, "加载配置文件失败:", err)
+		_, _ = fmt.Fprintln(w, "加载配置文件失败:", err)
 		return err
 	}
 	return nil

--- a/docs/mtr-json.md
+++ b/docs/mtr-json.md
@@ -1,0 +1,128 @@
+# MTR JSON v1
+
+`nexttrace` and `nexttrace-tiny` select this contract with `--mtr --json`,
+`-r --json`, or `-w --json`. `ntr --json` selects it by default.
+Bare full/tiny `--json` retains the traditional traceroute contract.
+
+## Modes
+
+| Options | Output | Default count per hop |
+| --- | --- | --- |
+| `--mtr --json` | NDJSON stream | Unlimited |
+| `--mtr --json -q 10` | NDJSON stream | 10 |
+| `-r --json` or `-w --json` | One final JSON document | 10 |
+
+`-q` never changes the output mode. Nonpositive counts mean unlimited for
+streams and are invalid for JSON reports. The existing non-TCP count cap of
+255 applies. The default per-hop interval is 1000ms.
+
+Both modes use FULL metadata and ignore `-y`, `--show-ips`, and presentation
+settings. FULL means all available information, not guaranteed Geo/PTR data.
+Provider selection, language, `--no-rdns`, `--always-rdns`, `--dot-server`, and
+`--disable-mpls` still apply. JSON reports use wide collection rules even with
+`-r`; `--raw` cannot be combined with MTR `--json`.
+
+## NDJSON events
+
+Each UTF-8 line is a complete JSON object written immediately, without ANSI,
+banners, or diagnostic lines. Every event has `schema_version: 1`, `type`, and
+`seq`, starting at 1 and incrementing by 1. Consumers should tolerate additional
+fields within schema version 1.
+
+| Type | Fields |
+| --- | --- |
+| `start` | `version`, `target`, `resolved_ip`, `protocol`, `started_at`, `effective_parameters` |
+| `probe` | `record`: the existing `MTRRawRecord` |
+| `path_end` | `path_end`: path conclusion or `null` when the path reopens |
+| `end` | `ended_at`, `duration_ms`, `end_reason`, `path_end`, optional `error` and `signal` |
+
+`start` occurs exactly once and first. `end` occurs exactly once and last on
+completion, handled interruption, or session failure, provided stdout remains
+writable. Initialization failure still produces `start` and `end`; undetermined
+session fields are `null`. Write/encoding failures cancel probing and stop
+output, with no retry of the final event/report.
+
+Each RAW callback maps to one `probe` in the same order. `iteration` keeps its
+RAW meaning and is not a unique event identifier. There are no separate Geo/PTR
+update events, no retained event history, and no final stream statistics.
+
+Example finite stream with metadata queries disabled (version/times illustrative):
+
+```jsonl
+{"schema_version":1,"type":"start","seq":1,"version":"v0.0.0.alpha","target":"127.0.0.1","resolved_ip":"127.0.0.1","protocol":"icmp","started_at":"2026-09-07T00:00:00Z","effective_parameters":{"max_per_hop":1,"hop_interval_ms":1000,"timeout_ms":1000,"begin_hop":1,"max_hops":1,"parallel_requests":18,"source_address":"127.0.0.1","packet_size":28,"random_packet_size":false,"tos":0,"data_provider":"disable-geoip","language":"cn","rdns":false,"always_wait_rdns":false,"disable_mpls":false,"dn42":false}}
+{"schema_version":1,"type":"probe","seq":2,"record":{"iteration":1,"ttl":1,"success":true,"ip":"127.0.0.1","rtt_ms":0,"lat":0,"lng":0}}
+{"schema_version":1,"type":"path_end","seq":3,"path_end":{"hop":1,"reason":"destination_reached"}}
+{"schema_version":1,"type":"end","seq":4,"ended_at":"2026-09-07T00:00:00.2Z","duration_ms":200,"end_reason":"completed","path_end":{"hop":1,"reason":"destination_reached"}}
+```
+
+`record` preserves the [MTRRawRecord fields](../trace/mtr_raw.go):
+`iteration`, `ttl`, `success`, `ip`, `host`, `rtt_ms`, `asn`, `country`, `prov`,
+`city`, `district`, `owner`, `lat`, `lng`, `mpls`, and `response`.
+Optional metadata fields can be absent. A successful zero RTT is valid;
+`success` distinguishes replies from timeouts.
+
+## Final report
+
+Stdout contains exactly one JSON object, followed by a newline. The first JSON
+decode succeeds and the second returns EOF. Fields:
+
+- `schema_version`, `version`, `target`, `resolved_ip`, `protocol`.
+- `started_at`, `ended_at`: UTC RFC3339Nano timestamps; `duration_ms` includes
+  target resolution, initialization, probing, and cleanup.
+- `effective_parameters`: normalized configuration, or `null` when preparation
+  did not complete.
+- `stats`: the runner's final `MTRHopStat` snapshot; empty is `[]`.
+- `end_reason`, `path_end`, optional `error` and `signal`.
+
+Example validation failure:
+
+```json
+{"schema_version":1,"version":"v0.0.0.alpha","target":"127.0.0.1","resolved_ip":null,"protocol":"icmp","started_at":"2026-09-07T00:00:00Z","effective_parameters":null,"ended_at":"2026-09-07T00:00:00.001Z","duration_ms":1,"end_reason":"error","path_end":null,"error":{"stage":"validation","message":"MTR JSON report requires --queries greater than zero"},"stats":[]}
+```
+
+Statistics are shared with text wide reports, without reaggregation or row
+collapsing. Each [MTRHopStat](../trace/mtr_stats.go) has `ttl`, optional `host`
+and `ip`, `loss_percent`, `snt`, `last_ms`, `avg_ms`, `best_ms`, `wrst_ms`,
+`stdev_ms`, `received`, and optional `geo`, `mpls`, `response`. Multiple responders
+and unknown rows retain the aggregator's existing identity and ordering rules.
+`snt` counts completed events already entered into the aggregator. Interruptions
+do not synthesize timeout events for in-flight probes. RTT units are milliseconds.
+
+## Effective parameters
+
+| Fields | Meaning |
+| --- | --- |
+| `max_per_hop`, `hop_interval_ms`, `timeout_ms` | Normalized count (0 unlimited), interval and timeout |
+| `begin_hop`, `max_hops`, `parallel_requests` | TTL range and concurrency |
+| `source_address`, optional `source_device` | Selected source address and applicable device binding |
+| `source_port`, `port` | TCP/UDP only; source 0 means automatic selection |
+| `packet_size`, `random_packet_size` | Total IP+protocol+payload size; negative size means randomized up to its absolute value |
+| `tos`, optional `icmp_mode` | Traffic class; ICMP listener setting where supported |
+| `data_provider`, `language`, optional `dot_server` | Effective metadata provider, language and DNS override |
+| `rdns`, `always_wait_rdns`, `disable_mpls`, `dn42` | Query/metadata configuration |
+
+Ignored options such as `-y`, `-z`, and display width are not recorded as effective
+parameters. Source selection describes configured behavior, not proof that the
+OS routed packets through a particular interface.
+
+## Completion and errors
+
+| Outcome | `end_reason` | Exit code |
+| --- | --- | --- |
+| Completed, including no replies | `completed` | 0 |
+| DNS, permission, initialization, unrecoverable execution or output failure | `error` | 1 |
+| Session validation failure | `error` | 2 |
+| SIGINT / SIGTERM | `interrupted` | 130 / 143 |
+
+`completed` is not a reachability verdict. `path_end` independently describes
+`destination_reached`, `unreachable`, or `max_hops`, with `hop` and optional `responses`
+and `markers`. It is `null` without a current conclusion. A stream may emit
+`path_end: null` after an earlier unreachable conclusion and later emit a new
+conclusion.
+
+Session errors preserve partial statistics and have `error.stage` and
+`error.message`; signals use `signal: "SIGINT"` or `"SIGTERM"`. Internal
+cancellation retains its error cause and is not reported as user interruption.
+Syntax and conflicting-mode errors occur before a session: stdout is empty,
+stderr carries the diagnostic, and exit code is 2. Help/version retain their
+existing output behavior. All session diagnostics go to stderr.

--- a/docs/mtr-json.md
+++ b/docs/mtr-json.md
@@ -43,7 +43,8 @@ session fields are `null`. Write/encoding failures cancel probing and stop
 output, with no retry of the final event/report.
 
 Each RAW callback maps to one `probe` in the same order. `iteration` keeps its
-RAW meaning and is not a unique event identifier. There are no separate Geo/PTR
+RAW meaning and is not a unique event identifier. A probe precedes the path
+change it triggers; final max-hops conclusions precede `end`. There are no separate Geo/PTR
 update events, no retained event history, and no final stream statistics.
 
 Example finite stream with metadata queries disabled (version/times illustrative):
@@ -121,7 +122,9 @@ and `markers`. It is `null` without a current conclusion. A stream may emit
 conclusion.
 
 Session errors preserve partial statistics and have `error.stage` and
-`error.message`; signals use `signal: "SIGINT"` or `"SIGTERM"`. Internal
+`error.message`. Probe-resource initialization and replacement failures use
+`stage: "initialize"`; other runner failures use `stage: "probe"`.
+Signals use `signal: "SIGINT"` or `"SIGTERM"`. Internal
 cancellation retains its error cause and is not reported as user interruption.
 Syntax and conflicting-mode errors occur before a session: stdout is empty,
 stderr carries the diagnostic, and exit code is 2. Help/version retain their

--- a/scripts/regression/unix.sh
+++ b/scripts/regression/unix.sh
@@ -219,6 +219,38 @@ run_cmd_check() {
   record "${name}" PASS "${note}"
 }
 
+check_mtr_json() {
+  local name="$1" mode="$2" binary="$3" flags="$4"
+  local out="${ART_DIR}/${name}.json" rc=0
+  run_timeout_cmd 30 "\"${binary}\" ${flags} --json --data-provider disable-geoip -n -q 2 -i 100 --timeout 500 -m 1 127.0.0.1" >"${out}" 2>"${out}.stderr" || rc=$?
+  if [[ "${rc}" != 0 ]]; then
+    record "${name}" FAIL "MTR JSON exit=${rc}"
+    return
+  fi
+  if python3 - "${out}" "${mode}" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    if sys.argv[2] == "report":
+        report = json.load(f)
+        assert report["schema_version"] == 1 and report["end_reason"] == "completed"
+        assert isinstance(report["stats"], list) and report["stats"]
+        assert sum(row["snt"] for row in report["stats"]) == 2
+    else:
+        events = [json.loads(line) for line in f]
+        assert events[0]["type"] == "start" and events[-1]["type"] == "end"
+        assert events[-1]["end_reason"] == "completed"
+        assert [e["seq"] for e in events] == list(range(1, len(events) + 1))
+        assert all(e["schema_version"] == 1 for e in events)
+        assert sum(e["type"] == "probe" for e in events) == 2
+PY
+  then
+    record "${name}" PASS "MTR JSON ${mode} contract"
+  else
+    record "${name}" FAIL "MTR JSON ${mode} contract"
+  fi
+}
+
 check_json_pure() {
   local name="$1"
   local note="$2"
@@ -533,6 +565,14 @@ check_output_file output_default 'Default output file path' "TMPDIR=\"${DEFAULT_
 run_cmd mtu_text 'MTU text mode' "\"${BIN}\" --no-color --mtu --timeout 1000 -q 1 -m 3 1.1.1.1"
 check_mtu_tty_color mtu_tty_color 'MTU TTY colorized output' "\"${BIN}\" --mtu --timeout 1000 -q 1 -m 3 1.1.1.1"
 check_mtu_non_tty_plain mtu_non_tty_plain 'MTU non-TTY output has no ANSI' "\"${BIN}\" --mtu --timeout 1000 -q 1 -m 3 1.1.1.1"
+check_mtr_json mtr_json_live stream "${BIN}" "--mtr"
+check_mtr_json mtr_json_report report "${BIN}" "-r"
+check_mtr_json mtr_json_wide report "${BIN}" "-w"
+check_mtr_json tiny_json_live stream "${TINY}" "--mtr -y 4"
+check_mtr_json tiny_json_report report "${TINY}" "-r"
+check_mtr_json ntr_json_live stream "${NTR}" ""
+check_mtr_json ntr_json_report report "${NTR}" "-w"
+
 run_cmd mtr_report 'MTR report ICMP' "\"${BIN}\" --no-color -r -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"
 run_cmd mtr_wide 'MTR wide + show-ips' "\"${BIN}\" --no-color -w --show-ips -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"
 run_cmd mtr_raw 'MTR raw stream' "\"${BIN}\" --no-color -r --raw -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"

--- a/scripts/regression/windows.ps1
+++ b/scripts/regression/windows.ps1
@@ -393,6 +393,35 @@ function Wait-CaptureReady {
     return -not $Process.HasExited
 }
 
+function Check-MtrJson {
+    param([string]$Name, [string]$Mode, [string]$Binary, [string]$Flags)
+    $out = Join-Path $ArtifactsDir "$Name.json"
+    $command = "`"$Binary`" $Flags --json --data-provider disable-geoip -n -q 2 -i 100 --timeout 500 -m 1 127.0.0.1"
+    $rc = Invoke-CommandWithTimeout -Command $command -OutFile $out -MergeStreams $false -Seconds 30
+    if ($rc -ne 0) {
+        Write-Record $Name FAIL "MTR JSON exit=$rc"
+        return
+    }
+    try {
+        $content = Get-Content -Raw -Encoding UTF8 -Path $out
+        if ($Mode -eq "report") {
+            $report = $content | ConvertFrom-Json -ErrorAction Stop
+            if ($report.schema_version -ne 1 -or $report.end_reason -ne "completed" -or @($report.stats).Count -eq 0) { throw "invalid report" }
+            if (($report.stats | Measure-Object -Property snt -Sum).Sum -ne 2) { throw "wrong probe count" }
+        } else {
+            $events = @($content.Trim() -split '\r?\n' | ForEach-Object { $_ | ConvertFrom-Json -ErrorAction Stop })
+            if ($events[0].type -ne "start" -or $events[-1].type -ne "end" -or $events[-1].end_reason -ne "completed") { throw "invalid lifecycle" }
+            for ($i = 0; $i -lt $events.Count; $i++) {
+                if ($events[$i].seq -ne ($i + 1) -or $events[$i].schema_version -ne 1) { throw "invalid sequence/schema" }
+            }
+            if (@($events | Where-Object { $_.type -eq "probe" }).Count -ne 2) { throw "wrong probe count" }
+        }
+        Write-Record $Name PASS "MTR JSON $Mode contract"
+    } catch {
+        Write-Record $Name FAIL "MTR JSON $Mode contract: $_"
+    }
+}
+
 function Check-JsonPure {
     param(
         [string]$Name,
@@ -765,6 +794,18 @@ Check-OutputFileIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "
 Run-CmdIfSupported $mtuCapability.Supported $mtuCapability.Reason "mtu_text" "MTU text mode" "`"$Bin`" --no-color --mtu --timeout 1000 -q 1 -m 3 1.1.1.1" "Path MTU:"
 Write-Record mtu_tty_color SKIP "MTU TTY colorized output; no portable Windows PTY capture in this script"
 Run-CmdIfSupported $mtuCapability.Supported $mtuCapability.Reason "mtu_non_tty_plain" "MTU non-TTY output has no ANSI" "`"$Bin`" --mtu --timeout 1000 -q 1 -m 3 1.1.1.1" "Path MTU:" "\x1b\[[0-9;]*[A-Za-z]"
+if ($mtrCapability.Supported) {
+    Check-MtrJson "mtr_json_live" "stream" $Bin "--mtr"
+    Check-MtrJson "mtr_json_report" "report" $Bin "-r"
+    Check-MtrJson "mtr_json_wide" "report" $Bin "-w"
+    Check-MtrJson "tiny_json_live" "stream" $Tiny "--mtr -y 4"
+    Check-MtrJson "tiny_json_report" "report" $Tiny "-r"
+    Check-MtrJson "ntr_json_live" "stream" $Ntr ""
+    Check-MtrJson "ntr_json_report" "report" $Ntr "-w"
+} else {
+    Write-Record "mtr_json" SKIP $mtrCapability.Reason
+}
+
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_report" "MTR report ICMP" "`"$Bin`" --no-color -r -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^HOST:"
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_wide" "MTR wide + show-ips" "`"$Bin`" --no-color -w --show-ips -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^HOST:"
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_raw" "MTR raw stream" "`"$Bin`" --no-color -r --raw -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^1\|"

--- a/trace/icmp_ipv4.go
+++ b/trace/icmp_ipv4.go
@@ -7,10 +7,8 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -36,20 +34,8 @@ type ICMPTracer struct {
 	readyICMP chan struct{}
 }
 
-func (t *ICMPTracer) waitAllReady(ctx context.Context) {
-	timeout := time.After(5 * time.Second)
-	waiting := 1
-	for waiting > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.readyICMP:
-			waiting--
-		case <-timeout:
-			return
-		}
-	}
-	<-time.After(100 * time.Millisecond)
+func (t *ICMPTracer) waitAllReady(ctx context.Context) error {
+	return waitProbeListeners(ctx, t.readyICMP)
 }
 
 func (t *ICMPTracer) ttlComp(ttl int) bool {
@@ -269,15 +255,16 @@ func (t *ICMPTracer) Execute() (res *Result, err error) {
 	)
 	applyICMPSourceDevice(s, t.OSType, t.SourceDevice)
 
-	s.InitICMP()
-	defer s.Close()
-
-	baseCtx := t.Context
-	if baseCtx == nil {
-		baseCtx = context.Background()
+	closeSpec := sync.OnceFunc(s.Close)
+	defer closeSpec()
+	if err := s.InitICMP(); err != nil {
+		return nil, wrapProbeSetupError(err)
 	}
-	sigCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+
+	sigCtx, stop := traceSignalContext(t.Context)
 	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer stop()
+	defer cancel(nil)
 	t.final.Store(-1)
 
 	workerN := 16
@@ -288,12 +275,19 @@ func (t *ICMPTracer) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, seq int) {
+		if err := s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, seq int) {
 			t.handleICMPMessage(msg, finish, seq)
 		},
-		)
+		); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
-	t.waitAllReady(ctx)
+	if err := t.waitAllReady(ctx); err != nil {
+		cancel(err)
+		closeSpec()
+		t.wg.Wait()
+		return &t.res, err
+	}
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, cancel)
 

--- a/trace/icmp_ipv6.go
+++ b/trace/icmp_ipv6.go
@@ -7,10 +7,8 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -36,20 +34,8 @@ type ICMPTracerv6 struct {
 	readyICMP chan struct{}
 }
 
-func (t *ICMPTracerv6) waitAllReady(ctx context.Context) {
-	timeout := time.After(5 * time.Second)
-	waiting := 1
-	for waiting > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.readyICMP:
-			waiting--
-		case <-timeout:
-			return
-		}
-	}
-	<-time.After(100 * time.Millisecond)
+func (t *ICMPTracerv6) waitAllReady(ctx context.Context) error {
+	return waitProbeListeners(ctx, t.readyICMP)
 }
 
 func (t *ICMPTracerv6) ttlComp(ttl int) bool {
@@ -269,15 +255,16 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 	)
 	applyICMPSourceDevice(s, t.OSType, t.SourceDevice)
 
-	s.InitICMP()
-	defer s.Close()
-
-	baseCtx := t.Context
-	if baseCtx == nil {
-		baseCtx = context.Background()
+	closeSpec := sync.OnceFunc(s.Close)
+	defer closeSpec()
+	if err := s.InitICMP(); err != nil {
+		return nil, wrapProbeSetupError(err)
 	}
-	sigCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+
+	sigCtx, stop := traceSignalContext(t.Context)
 	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer stop()
+	defer cancel(nil)
 	t.final.Store(-1)
 
 	workerN := 16
@@ -288,12 +275,19 @@ func (t *ICMPTracerv6) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, seq int) {
+		if err := s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, seq int) {
 			t.handleICMPMessage(msg, finish, seq)
 		},
-		)
+		); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
-	t.waitAllReady(ctx)
+	if err := t.waitAllReady(ctx); err != nil {
+		cancel(err)
+		closeSpec()
+		t.wg.Wait()
+		return &t.res, err
+	}
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, cancel)
 

--- a/trace/internal/icmp_close_windows_test.go
+++ b/trace/internal/icmp_close_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows && amd64
+
+package internal
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestClosedICMPSpecCannotReopenLazyWinDivertHandle(t *testing.T) {
+	spec := &ICMPSpec{}
+	spec.Close()
+	spec.Close()
+	_, err := spec.sendICMPv6WithWinDivert(nil, nil, nil, nil)
+	if !errors.Is(err, net.ErrClosed) || spec.sendHandle != 0 {
+		t.Fatalf("closed spec reopened a send handle: handle=%v error=%v", spec.sendHandle, err)
+	}
+}

--- a/trace/internal/icmp_common.go
+++ b/trace/internal/icmp_common.go
@@ -3,15 +3,12 @@ package internal
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"time"
 
 	"github.com/google/gopacket"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-
-	"github.com/nxtrace/NTrace-core/util"
 )
 
 type ipLayer interface {
@@ -23,7 +20,7 @@ func NewICMPSpec(IPVersion, ICMPMode, echoID int, srcIP, dstIP net.IP) *ICMPSpec
 	return &ICMPSpec{IPVersion: IPVersion, ICMPMode: ICMPMode, EchoID: echoID, SrcIP: srcIP, DstIP: dstIP}
 }
 
-func (s *ICMPSpec) InitICMP() {
+func (s *ICMPSpec) InitICMP() error {
 	network := "ip4:icmp"
 	if s.IPVersion == 6 {
 		network = "ip6:ipv6-icmp"
@@ -31,18 +28,12 @@ func (s *ICMPSpec) InitICMP() {
 
 	icmpConn, err := ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitICMP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitICMP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitICMP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	if s.SourceDevice != "" {
 		if err := bindPacketConnToSourceDevice(icmpConn, s.IPVersion, s.SourceDevice); err != nil {
 			_ = icmpConn.Close()
-			if util.EnvDevMode {
-				panic(fmt.Errorf("(InitICMP) bind source device %q failed: %v", s.SourceDevice, err))
-			}
-			log.Fatalf("(InitICMP) bind source device %q failed: %v", s.SourceDevice, err)
+			return fmt.Errorf("(InitICMP) bind source device %q failed: %w", s.SourceDevice, err)
 		}
 	}
 	s.icmp = icmpConn
@@ -52,20 +43,24 @@ func (s *ICMPSpec) InitICMP() {
 	} else {
 		s.icmp6 = ipv6.NewPacketConn(s.icmp)
 	}
+	return nil
 }
 
-func (s *ICMPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) {
-	lc := NewPacketListener(s.icmp)
-	go lc.Start(ctx)
+func (s *ICMPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) error {
+	lc, stop := startPacketListener(ctx, s.icmp)
+	defer stop()
 	close(ready)
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case msg, ok := <-lc.Messages:
 			if !ok {
-				return
+				return listenerStoppedError(ctx)
+			}
+			if msg.Err != nil {
+				return msg.Err
 			}
 			finish, seq, response, ok := s.decodeICMPSocketMessage(msg)
 			if ok {

--- a/trace/internal/icmp_darwin.go
+++ b/trace/internal/icmp_darwin.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"sync"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/nxtrace/NTrace-core/util"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )
@@ -266,15 +264,12 @@ func darwinICMPSocketSpecForNetwork(network string) (darwinICMPSocketSpec, error
 	return darwinICMPSocketSpec{af: syscall.AF_INET, proto: syscall.IPPROTO_ICMP}, nil
 }
 
-func mustOpenDarwinICMPSocket(spec darwinICMPSocketSpec) int {
+func openDarwinICMPSocket(spec darwinICMPSocketSpec) (int, error) {
 	fd, err := syscall.Socket(spec.af, syscall.SOCK_DGRAM, spec.proto)
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("ListenPacket: socket: %w", err))
-		}
-		log.Fatalf("ListenPacket: socket: %v", err)
+		return -1, fmt.Errorf("ListenPacket: socket: %w", err)
 	}
-	return fd
+	return fd, nil
 }
 
 func interfaceHasIP(iface net.Interface, target net.IP) bool {
@@ -366,10 +361,7 @@ func finalizeDarwinICMPSocket(fd, af int) (net.PacketConn, error) {
 	rc, err := f.SyscallConn()
 	if err != nil {
 		_ = f.Close()
-		if util.EnvDevMode {
-			panic(fmt.Errorf("ListenPacket: SyscallConn: %w", err))
-		}
-		log.Fatalf("ListenPacket: SyscallConn: %v", err)
+		return nil, fmt.Errorf("ListenPacket: SyscallConn: %w", err)
 	}
 
 	return &icmpPacketConn{file: f, rc: rc, af: af}, nil
@@ -381,7 +373,10 @@ func ListenPacket(network string, laddr string) (net.PacketConn, error) {
 		return nil, err
 	}
 
-	fd := mustOpenDarwinICMPSocket(spec)
+	fd, err := openDarwinICMPSocket(spec)
+	if err != nil {
+		return nil, err
+	}
 	if err := bindDarwinICMPInterface(fd, spec.proto, laddr); err != nil {
 		_ = syscall.Close(fd)
 		return nil, err
@@ -395,11 +390,13 @@ func ListenPacket(network string, laddr string) (net.PacketConn, error) {
 }
 
 func (s *ICMPSpec) Close() {
-	_ = s.icmp.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
 }
 
-func (s *ICMPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) {
-	s.listenICMPSock(ctx, ready, onICMP)
+func (s *ICMPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) error {
+	return s.listenICMPSock(ctx, ready, onICMP)
 }
 
 func (s *ICMPSpec) SendICMP(ctx context.Context, ipHdr gopacket.NetworkLayer, icmpHdr, icmpEcho gopacket.SerializableLayer, payload []byte) (time.Time, error) {

--- a/trace/internal/icmp_unix.go
+++ b/trace/internal/icmp_unix.go
@@ -34,11 +34,13 @@ func ListenPacket(network string, laddr string) (net.PacketConn, error) {
 }
 
 func (s *ICMPSpec) Close() {
-	_ = s.icmp.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
 }
 
-func (s *ICMPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) {
-	s.listenICMPSock(ctx, ready, onICMP)
+func (s *ICMPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) error {
+	return s.listenICMPSock(ctx, ready, onICMP)
 }
 
 func (s *ICMPSpec) SendICMP(ctx context.Context, ipHdr gopacket.NetworkLayer, icmpHdr, icmpEcho gopacket.SerializableLayer, payload []byte) (time.Time, error) {

--- a/trace/internal/icmp_windows.go
+++ b/trace/internal/icmp_windows.go
@@ -33,6 +33,7 @@ type ICMPSpec struct {
 	icmp4        *ipv4.PacketConn
 	icmp6        *ipv6.PacketConn
 	sendHandle   wd.Handle
+	closed       bool // protected by hopLimitLock, including lazy send-handle initialization
 	sendAddr     wd.Address
 	hopLimitLock sync.Mutex
 }
@@ -42,7 +43,15 @@ func ListenPacket(network string, laddr string) (net.PacketConn, error) {
 }
 
 func (s *ICMPSpec) Close() {
-	_ = s.icmp.Close()
+	s.hopLimitLock.Lock()
+	defer s.hopLimitLock.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
 	if s.sendHandle != 0 {
 		_ = s.sendHandle.Close()
 	}
@@ -89,17 +98,21 @@ func (s *ICMPSpec) resolveICMPMode() int {
 	return 2
 }
 
-func (s *ICMPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) {
+func (s *ICMPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) error {
 	switch s.resolveICMPMode() {
 	case 1:
-		s.listenICMPSock(ctx, ready, onICMP)
+		return s.listenICMPSock(ctx, ready, onICMP)
 	case 2:
-		s.listenICMPWinDivert(ctx, ready, onICMP)
+		return s.listenICMPWinDivert(ctx, ready, onICMP)
 	}
+	return nil
 }
 
-func (s *ICMPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) {
-	handle, closeHandle := openWinDivertSniffHandle(ctx, winDivertICMPFilter(s.IPVersion, s.SrcIP), "ListenICMP")
+func (s *ICMPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, seq int)) error {
+	handle, closeHandle, err := openWinDivertSniffHandle(ctx, winDivertICMPFilter(s.IPVersion, s.SrcIP), "ListenICMP")
+	if err != nil {
+		return err
+	}
 	defer closeHandle()
 	close(ready)
 
@@ -107,12 +120,12 @@ func (s *ICMPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{},
 	var addr wd.Address
 
 	for {
-		raw, finish, ok := receiveWinDivertPacket(ctx, handle, buf, &addr)
-		if !ok {
+		raw, finish, err := receiveWinDivertPacket(ctx, handle, buf, &addr)
+		if err != nil {
 			if ctx.Err() != nil {
-				return
+				return nil
 			}
-			continue
+			return err
 		}
 
 		packet, ok := decodeWinDivertICMPPacket(s.IPVersion, raw)
@@ -237,9 +250,12 @@ func shouldUseICMPv6RawSend(ip6 *layers.IPv6) bool {
 func (s *ICMPSpec) sendICMPv6WithWinDivert(ip6 *layers.IPv6, icmpHdr, icmpEcho gopacket.SerializableLayer, payload []byte) (time.Time, error) {
 	s.hopLimitLock.Lock()
 	defer s.hopLimitLock.Unlock()
+	if s.closed {
+		return time.Time{}, net.ErrClosed
+	}
 
 	if err := s.ensureICMPSendHandle(true); err != nil {
-		return time.Time{}, err
+		return time.Time{}, &InitializationError{Err: err}
 	}
 
 	buf := gopacket.NewSerializeBuffer()

--- a/trace/internal/initialization_error.go
+++ b/trace/internal/initialization_error.go
@@ -1,0 +1,8 @@
+package internal
+
+// InitializationError distinguishes unavailable probe resources from send errors.
+// The scheduler must terminate instead of converting it into a timeout.
+type InitializationError struct{ Err error }
+
+func (e *InitializationError) Error() string { return e.Err.Error() }
+func (e *InitializationError) Unwrap() error { return e.Err }

--- a/trace/internal/packet_listener.go
+++ b/trace/internal/packet_listener.go
@@ -31,22 +31,49 @@ func NewPacketListener(conn net.PacketConn) *PacketListener {
 	return &PacketListener{Conn: conn, Messages: ch, ch: ch}
 }
 
+func startPacketListener(parent context.Context, conn net.PacketConn) (*PacketListener, func()) {
+	ctx, cancel := context.WithCancel(parent)
+	l := NewPacketListener(conn)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		l.Start(ctx)
+	}()
+	return l, func() { cancel(); <-done }
+}
+
+func listenerStoppedError(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return nil
+	}
+	return errors.New("probe listener stopped unexpectedly")
+}
+
 func (l *PacketListener) Start(ctx context.Context) {
 	defer close(l.ch)
 
+	stopCloser, closerDone := make(chan struct{}), make(chan struct{})
 	go func() {
-		<-ctx.Done()
-		_ = l.Conn.Close()
+		defer close(closerDone)
+		select {
+		case <-ctx.Done():
+			_ = l.Conn.Close()
+		case <-stopCloser:
+		}
 	}()
+	defer func() { close(stopCloser); <-closerDone }()
 
 	buf := make([]byte, 4096)
 
 	for {
 		n, peer, err := l.Conn.ReadFrom(buf)
 		if err != nil {
-			// 连接关闭或 ctx 取消：直接退出
-			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+			if ctx.Err() != nil {
 				return
+			}
+			var timeout net.Error
+			if errors.As(err, &timeout) && timeout.Timeout() {
+				continue
 			}
 
 			// 限时等待投递错误；超时或取消就丢弃/退出
@@ -56,7 +83,7 @@ func (l *PacketListener) Start(ctx context.Context) {
 				return
 			case <-time.After(5 * time.Second):
 			}
-			continue
+			return
 		}
 		if n == 0 {
 			continue

--- a/trace/internal/packet_listener_test.go
+++ b/trace/internal/packet_listener_test.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type failingListenerConn struct {
+	net.PacketConn
+	err    error
+	closed atomic.Int32
+}
+
+func (c *failingListenerConn) ReadFrom([]byte) (int, net.Addr, error) { return 0, nil, c.err }
+func (c *failingListenerConn) Close() error                           { c.closed.Add(1); return nil }
+
+func TestSocketListenerReturnsReadErrorAndJoins(t *testing.T) {
+	cause := errors.New("socket read failed")
+	for _, proto := range []string{"icmp", "tcp", "udp"} {
+		t.Run(proto, func(t *testing.T) {
+			conn := &failingListenerConn{err: cause}
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			ready := make(chan struct{})
+			var err error
+			switch proto {
+			case "icmp":
+				spec := &ICMPSpec{icmp: conn}
+				err = spec.listenICMPSock(ctx, ready, nil)
+				spec.Close()
+			case "tcp":
+				spec := &TCPSpec{icmp: conn}
+				err = spec.listenICMPSock(ctx, ready, nil)
+				spec.Close() // Sending socket/handle was never initialized.
+			case "udp":
+				spec := &UDPSpec{icmp: conn}
+				err = spec.listenICMPSock(ctx, ready, nil)
+				spec.Close()
+			}
+			if !errors.Is(err, cause) || ctx.Err() != nil || conn.closed.Load() == 0 {
+				t.Fatalf("error=%v ctx=%v closes=%d", err, ctx.Err(), conn.closed.Load())
+			}
+		})
+	}
+}
+
+func TestUninitializedSpecsCloseSafely(t *testing.T) {
+	(&ICMPSpec{}).Close()
+	(&TCPSpec{}).Close()
+	(&UDPSpec{}).Close()
+}

--- a/trace/internal/tcp_common.go
+++ b/trace/internal/tcp_common.go
@@ -3,18 +3,15 @@ package internal
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"time"
-
-	"github.com/nxtrace/NTrace-core/util"
 )
 
 func NewTCPSpec(IPVersion, ICMPMode int, srcIP, dstIP net.IP, dstPort int, pktSize int) *TCPSpec {
 	return &TCPSpec{IPVersion: IPVersion, ICMPMode: ICMPMode, SrcIP: srcIP, DstIP: dstIP, DstPort: dstPort, PktSize: pktSize}
 }
 
-func (s *TCPSpec) InitICMP() {
+func (s *TCPSpec) InitICMP() error {
 	network := "ip4:icmp"
 	if s.IPVersion == 6 {
 		network = "ip6:ipv6-icmp"
@@ -22,26 +19,27 @@ func (s *TCPSpec) InitICMP() {
 
 	icmpConn, err := net.ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitICMP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitICMP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitICMP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	s.icmp = icmpConn
+	return nil
 }
 
-func (s *TCPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	lc := NewPacketListener(s.icmp)
-	go lc.Start(ctx)
+func (s *TCPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	lc, stop := startPacketListener(ctx, s.icmp)
+	defer stop()
 	close(ready)
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case msg, ok := <-lc.Messages:
 			if !ok {
-				return
+				return listenerStoppedError(ctx)
+			}
+			if msg.Err != nil {
+				return msg.Err
 			}
 			finish, data, response, ok := s.decodeICMPSocketMessage(msg)
 			if ok {

--- a/trace/internal/tcp_darwin.go
+++ b/trace/internal/tcp_darwin.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -35,7 +34,7 @@ type TCPSpec struct {
 	hopLimitLock sync.Mutex
 }
 
-func (s *TCPSpec) InitTCP() {
+func (s *TCPSpec) InitTCP() error {
 	network := "ip4:tcp"
 	if s.IPVersion == 6 {
 		network = "ip6:tcp"
@@ -43,18 +42,12 @@ func (s *TCPSpec) InitTCP() {
 
 	tcp, err := net.ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitTCP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitTCP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitTCP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	if s.SourceDevice != "" {
 		if err := bindPacketConnToSourceDevice(tcp, s.IPVersion, s.SourceDevice); err != nil {
 			_ = tcp.Close()
-			if util.EnvDevMode {
-				panic(fmt.Errorf("(InitTCP) bind source device %q failed: %v", s.SourceDevice, err))
-			}
-			log.Fatalf("(InitTCP) bind source device %q failed: %v", s.SourceDevice, err)
+			return fmt.Errorf("(InitTCP) bind source device %q failed: %w", s.SourceDevice, err)
 		}
 	}
 	s.tcp = tcp
@@ -64,15 +57,20 @@ func (s *TCPSpec) InitTCP() {
 	} else {
 		s.tcp6 = ipv6.NewPacketConn(s.tcp)
 	}
+	return nil
 }
 
 func (s *TCPSpec) Close() {
-	_ = s.icmp.Close()
-	_ = s.tcp.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
+	if s.tcp != nil {
+		_ = s.tcp.Close()
+	}
 }
 
-func (s *TCPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	s.listenICMPSock(ctx, ready, onICMP)
+func (s *TCPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	return s.listenICMPSock(ctx, ready, onICMP)
 }
 
 func (s *TCPSpec) captureDevice() string {
@@ -92,34 +90,34 @@ func (s *TCPSpec) tcpCaptureFilter() string {
 	)
 }
 
-func mustOpenDarwinTCPSniffHandle(dev string) *pcap.Handle {
+func openDarwinTCPSniffHandle(dev string) (*pcap.Handle, error) {
 	// TCP traceroute only needs packets destined to or sourced from this host.
 	// Some macOS interfaces refuse promiscuous mode even under sudo, so avoid
 	// requesting it for this narrowly filtered capture.
 	handle, err := util.OpenLiveImmediate(dev, 65535, false, 4<<20)
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(ListenTCP) pcap open failed on %s: %v", dev, err))
-		}
-		log.Fatalf("(ListenTCP) pcap open failed on %s: %v", dev, err)
+		return nil, fmt.Errorf("(ListenTCP) pcap open failed on %s: %w", dev, err)
 	}
-	return handle
+	return handle, nil
 }
 
-func mustSetDarwinTCPFilter(handle *pcap.Handle, filter string) {
+func setDarwinTCPFilter(handle *pcap.Handle, filter string) error {
 	if err := handle.SetBPFFilter(filter); err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(ListenTCP) set BPF failed: %v (filter=%q)", err, filter))
-		}
-		log.Fatalf("(ListenTCP) set BPF failed: %v (filter=%q)", err, filter)
+		return fmt.Errorf("(ListenTCP) set BPF failed: %w (filter=%q)", err, filter)
 	}
+	return nil
 }
 
-func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func(srcPort, seq, ack int, peer net.Addr, finish time.Time)) {
-	handle := mustOpenDarwinTCPSniffHandle(s.captureDevice())
+func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func(srcPort, seq, ack int, peer net.Addr, finish time.Time)) error {
+	handle, err := openDarwinTCPSniffHandle(s.captureDevice())
+	if err != nil {
+		return err
+	}
 	defer handle.Close()
 
-	mustSetDarwinTCPFilter(handle, s.tcpCaptureFilter())
+	if err := setDarwinTCPFilter(handle, s.tcpCaptureFilter()); err != nil {
+		return err
+	}
 	src := gopacket.NewPacketSource(handle, handle.LinkType())
 	pktCh := src.Packets()
 	close(ready)
@@ -127,10 +125,10 @@ func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case pkt, ok := <-pktCh:
 			if !ok {
-				return
+				return listenerStoppedError(ctx)
 			}
 			finish := pkt.Metadata().Timestamp
 			srcPort, seq, ack, peer, ok := decodeTCPProbePacket(s.IPVersion, s.DstPort, pkt)

--- a/trace/internal/tcp_unix.go
+++ b/trace/internal/tcp_unix.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -15,8 +14,6 @@ import (
 	"github.com/google/gopacket/layers"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-
-	"github.com/nxtrace/NTrace-core/util"
 )
 
 type TCPSpec struct {
@@ -34,7 +31,7 @@ type TCPSpec struct {
 	hopLimitLock sync.Mutex
 }
 
-func (s *TCPSpec) InitTCP() {
+func (s *TCPSpec) InitTCP() error {
 	network := "ip4:tcp"
 	if s.IPVersion == 6 {
 		network = "ip6:tcp"
@@ -42,18 +39,12 @@ func (s *TCPSpec) InitTCP() {
 
 	tcp, err := net.ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitTCP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitTCP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitTCP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	if s.SourceDevice != "" {
 		if err := bindPacketConnToSourceDevice(tcp, s.IPVersion, s.SourceDevice); err != nil {
 			_ = tcp.Close()
-			if util.EnvDevMode {
-				panic(fmt.Errorf("(InitTCP) bind source device %q failed: %v", s.SourceDevice, err))
-			}
-			log.Fatalf("(InitTCP) bind source device %q failed: %v", s.SourceDevice, err)
+			return fmt.Errorf("(InitTCP) bind source device %q failed: %w", s.SourceDevice, err)
 		}
 	}
 	s.tcp = tcp
@@ -63,33 +54,38 @@ func (s *TCPSpec) InitTCP() {
 	} else {
 		s.tcp6 = ipv6.NewPacketConn(s.tcp)
 	}
+	return nil
 }
 
 func (s *TCPSpec) Close() {
-	_ = s.icmp.Close()
-	_ = s.tcp.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
+	if s.tcp != nil {
+		_ = s.tcp.Close()
+	}
 }
 
-func (s *TCPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	s.listenICMPSock(ctx, ready, onICMP)
+func (s *TCPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	return s.listenICMPSock(ctx, ready, onICMP)
 }
 
-func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func(srcPort, seq, ack int, peer net.Addr, finish time.Time)) {
-	lc := NewPacketListener(s.tcp)
-	go lc.Start(ctx)
+func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func(srcPort, seq, ack int, peer net.Addr, finish time.Time)) error {
+	lc, stop := startPacketListener(ctx, s.tcp)
+	defer stop()
 	close(ready)
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case msg, ok := <-lc.Messages:
 			if !ok {
-				return
+				return listenerStoppedError(ctx)
 			}
 
 			if msg.Err != nil {
-				continue
+				return msg.Err
 			}
 			finish := time.Now()
 

--- a/trace/internal/tcp_windows.go
+++ b/trace/internal/tcp_windows.go
@@ -34,14 +34,14 @@ func (s *TCPSpec) sourceDeviceUnsupportedErr() error {
 	return fmt.Errorf("source_device %q is not supported on Windows TCP traces", s.SourceDevice)
 }
 
-func (s *TCPSpec) InitTCP() {
+func (s *TCPSpec) InitTCP() error {
 	if err := s.sourceDeviceUnsupportedErr(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	handle, err := OpenWinDivertHandle("false", 0)
 	if err != nil {
-		log.Fatal(formatWinDivertRequiredError("Windows TCP 探测", err))
+		return fmt.Errorf("%s: %w", formatWinDivertRequiredError("Windows TCP 探测", err), err)
 	}
 	s.handle = handle
 
@@ -49,11 +49,16 @@ func (s *TCPSpec) InitTCP() {
 	s.addr.SetLayer(wd.LayerNetwork)
 	s.addr.SetEvent(wd.EventNetworkPacket)
 	s.addr.SetOutbound()
+	return nil
 }
 
 func (s *TCPSpec) Close() {
-	_ = s.icmp.Close()
-	_ = s.handle.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
+	if s.handle != 0 {
+		_ = s.handle.Close()
+	}
 }
 
 // resolveICMPMode 进行最终模式判定
@@ -79,21 +84,25 @@ func (s *TCPSpec) resolveICMPMode() int {
 	return 2
 }
 
-func (s *TCPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
+func (s *TCPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
 	switch s.resolveICMPMode() {
 	case 1:
-		s.listenICMPSock(ctx, ready, onICMP)
+		return s.listenICMPSock(ctx, ready, onICMP)
 	case 2:
-		s.listenICMPWinDivert(ctx, ready, onICMP)
+		return s.listenICMPWinDivert(ctx, ready, onICMP)
 	}
+	return nil
 }
 
-func (s *TCPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
+func (s *TCPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
 	if err := s.sourceDeviceUnsupportedErr(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	sniffHandle, closeHandleICMP := openWinDivertSniffHandle(ctx, winDivertICMPFilter(s.IPVersion, s.SrcIP), "ListenICMP")
+	sniffHandle, closeHandleICMP, err := openWinDivertSniffHandle(ctx, winDivertICMPFilter(s.IPVersion, s.SrcIP), "ListenICMP")
+	if err != nil {
+		return err
+	}
 	defer closeHandleICMP()
 	close(ready)
 
@@ -101,12 +110,12 @@ func (s *TCPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, 
 	var addr wd.Address
 
 	for {
-		raw, finish, ok := receiveWinDivertPacket(ctx, sniffHandle, buf, &addr)
-		if !ok {
+		raw, finish, err := receiveWinDivertPacket(ctx, sniffHandle, buf, &addr)
+		if err != nil {
 			if ctx.Err() != nil {
-				return
+				return nil
 			}
-			continue
+			return err
 		}
 
 		packet, ok := decodeWinDivertICMPPacket(s.IPVersion, raw)
@@ -121,16 +130,19 @@ func (s *TCPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, 
 	}
 }
 
-func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func(srcPort, seq, ack int, peer net.Addr, finish time.Time)) {
+func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func(srcPort, seq, ack int, peer net.Addr, finish time.Time)) error {
 	if err := s.sourceDeviceUnsupportedErr(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	sniffHandle, closeHandleTCP := openWinDivertSniffHandle(
+	sniffHandle, closeHandleTCP, err := openWinDivertSniffHandle(
 		ctx,
 		winDivertTCPFilter(s.IPVersion, s.SrcIP, s.DstPort),
 		"ListenTCP",
 	)
+	if err != nil {
+		return err
+	}
 	defer closeHandleTCP()
 
 	close(ready)
@@ -139,12 +151,12 @@ func (s *TCPSpec) ListenTCP(ctx context.Context, ready chan struct{}, onTCP func
 	var addr wd.Address
 
 	for {
-		raw, finish, ok := receiveWinDivertPacket(ctx, sniffHandle, buf, &addr)
-		if !ok {
+		raw, finish, err := receiveWinDivertPacket(ctx, sniffHandle, buf, &addr)
+		if err != nil {
 			if ctx.Err() != nil {
-				return
+				return nil
 			}
-			continue
+			return err
 		}
 
 		srcPort, seq, ack, peer, ok := decodeWinDivertTCPPacket(s.IPVersion, raw, s.DstPort)

--- a/trace/internal/udp_common.go
+++ b/trace/internal/udp_common.go
@@ -3,18 +3,15 @@ package internal
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"time"
-
-	"github.com/nxtrace/NTrace-core/util"
 )
 
 func NewUDPSpec(IPVersion, ICMPMode int, srcIP, dstIP net.IP, dstPort int) *UDPSpec {
 	return &UDPSpec{IPVersion: IPVersion, ICMPMode: ICMPMode, SrcIP: srcIP, DstIP: dstIP, DstPort: dstPort}
 }
 
-func (s *UDPSpec) InitICMP() {
+func (s *UDPSpec) InitICMP() error {
 	network := "ip4:icmp"
 	if s.IPVersion == 6 {
 		network = "ip6:ipv6-icmp"
@@ -22,26 +19,27 @@ func (s *UDPSpec) InitICMP() {
 
 	icmpConn, err := net.ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitICMP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitICMP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitICMP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	s.icmp = icmpConn
+	return nil
 }
 
-func (s *UDPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	lc := NewPacketListener(s.icmp)
-	go lc.Start(ctx)
+func (s *UDPSpec) listenICMPSock(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	lc, stop := startPacketListener(ctx, s.icmp)
+	defer stop()
 	close(ready)
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case msg, ok := <-lc.Messages:
 			if !ok {
-				return
+				return listenerStoppedError(ctx)
+			}
+			if msg.Err != nil {
+				return msg.Err
 			}
 			finish, data, response, ok := s.decodeICMPSocketMessage(msg)
 			if ok {

--- a/trace/internal/udp_darwin.go
+++ b/trace/internal/udp_darwin.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -33,7 +32,7 @@ type UDPSpec struct {
 	hopLimitLock sync.Mutex
 }
 
-func (s *UDPSpec) InitUDP() {
+func (s *UDPSpec) InitUDP() error {
 	network := "ip4:udp"
 	if s.IPVersion == 6 {
 		network = "ip6:udp"
@@ -41,18 +40,12 @@ func (s *UDPSpec) InitUDP() {
 
 	udp, err := net.ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitUDP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitUDP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitUDP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	if s.SourceDevice != "" {
 		if err := bindPacketConnToSourceDevice(udp, s.IPVersion, s.SourceDevice); err != nil {
 			_ = udp.Close()
-			if util.EnvDevMode {
-				panic(fmt.Errorf("(InitUDP) bind source device %q failed: %v", s.SourceDevice, err))
-			}
-			log.Fatalf("(InitUDP) bind source device %q failed: %v", s.SourceDevice, err)
+			return fmt.Errorf("(InitUDP) bind source device %q failed: %w", s.SourceDevice, err)
 		}
 	}
 	s.udp = udp
@@ -62,14 +55,19 @@ func (s *UDPSpec) InitUDP() {
 	} else {
 		s.udp6 = ipv6.NewPacketConn(s.udp)
 	}
+	return nil
 }
 
 func (s *UDPSpec) Close() {
-	_ = s.icmp.Close()
-	_ = s.udp.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
+	if s.udp != nil {
+		_ = s.udp.Close()
+	}
 }
 
-func (s *UDPSpec) ListenOut(ctx context.Context, ready chan struct{}, onOut func(srcPort, seq, ttl int, start time.Time)) {
+func (s *UDPSpec) ListenOut(ctx context.Context, ready chan struct{}, onOut func(srcPort, seq, ttl int, start time.Time)) error {
 	// 选择捕获设备与本地接口
 	dev := "en0"
 	if s.SourceDevice != "" {
@@ -82,10 +80,7 @@ func (s *UDPSpec) ListenOut(ctx context.Context, ready chan struct{}, onOut func
 	// 接口即使在 sudo 下也会拒绝 promisc，继续请求只会让探测直接失败。
 	handle, err := util.OpenLiveImmediate(dev, 65535, false, 4<<20)
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(ListenOut) pcap open failed on %s: %v", dev, err))
-		}
-		log.Fatalf("(ListenOut) pcap open failed on %s: %v", dev, err)
+		return fmt.Errorf("(ListenOut) pcap open failed on %s: %w", dev, err)
 	}
 	defer handle.Close()
 
@@ -100,10 +95,7 @@ func (s *UDPSpec) ListenOut(ctx context.Context, ready chan struct{}, onOut func
 	)
 
 	if err := handle.SetBPFFilter(filter); err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(ListenOut) set BPF failed: %v (filter=%q)", err, filter))
-		}
-		log.Fatalf("(ListenOut) set BPF failed: %v (filter=%q)", err, filter)
+		return fmt.Errorf("(ListenOut) set BPF failed: %w (filter=%q)", err, filter)
 	}
 
 	src := gopacket.NewPacketSource(handle, handle.LinkType())
@@ -113,10 +105,10 @@ func (s *UDPSpec) ListenOut(ctx context.Context, ready chan struct{}, onOut func
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case pkt, ok := <-pktCh:
 			if !ok {
-				return
+				return listenerStoppedError(ctx)
 			}
 
 			// 解包
@@ -146,8 +138,8 @@ func (s *UDPSpec) ListenOut(ctx context.Context, ready chan struct{}, onOut func
 	}
 }
 
-func (s *UDPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	s.listenICMPSock(ctx, ready, onICMP)
+func (s *UDPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	return s.listenICMPSock(ctx, ready, onICMP)
 }
 
 func (s *UDPSpec) SendUDP(ctx context.Context, ipHdr gopacket.NetworkLayer, udpHdr *layers.UDP, payload []byte) (time.Time, error) {

--- a/trace/internal/udp_unix.go
+++ b/trace/internal/udp_unix.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -34,7 +33,7 @@ type UDPSpec struct {
 	mtu          int
 }
 
-func (s *UDPSpec) InitUDP() {
+func (s *UDPSpec) InitUDP() error {
 	network := "ip4:udp"
 	if s.IPVersion == 6 {
 		network = "ip6:udp"
@@ -42,18 +41,12 @@ func (s *UDPSpec) InitUDP() {
 
 	udp, err := net.ListenPacket(network, s.SrcIP.String())
 	if err != nil {
-		if util.EnvDevMode {
-			panic(fmt.Errorf("(InitUDP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err))
-		}
-		log.Fatalf("(InitUDP) ListenPacket(%s, %s) failed: %v", network, s.SrcIP, err)
+		return fmt.Errorf("(InitUDP) ListenPacket(%s, %s) failed: %w", network, s.SrcIP, err)
 	}
 	if s.SourceDevice != "" {
 		if err := bindPacketConnToSourceDevice(udp, s.IPVersion, s.SourceDevice); err != nil {
 			_ = udp.Close()
-			if util.EnvDevMode {
-				panic(fmt.Errorf("(InitUDP) bind source device %q failed: %v", s.SourceDevice, err))
-			}
-			log.Fatalf("(InitUDP) bind source device %q failed: %v", s.SourceDevice, err)
+			return fmt.Errorf("(InitUDP) bind source device %q failed: %w", s.SourceDevice, err)
 		}
 	}
 	s.udp = udp
@@ -61,11 +54,9 @@ func (s *UDPSpec) InitUDP() {
 	if s.IPVersion == 4 {
 		s.udp4, err = ipv4.NewRawConn(s.udp)
 		if err != nil {
-			s.Close()
-			if util.EnvDevMode {
-				panic(fmt.Errorf("(InitUDP) create NewRawConn failed: %v", err))
-			}
-			log.Fatalf("(InitUDP) create NewRawConn failed: %v", err)
+			_ = udp.Close()
+			s.udp = nil
+			return fmt.Errorf("(InitUDP) create NewRawConn failed: %w", err)
 		}
 
 		// 获取本地接口的 MTU
@@ -77,18 +68,24 @@ func (s *UDPSpec) InitUDP() {
 	} else {
 		s.udp6 = ipv6.NewPacketConn(s.udp)
 	}
+	return nil
 }
 
 func (s *UDPSpec) Close() {
-	_ = s.icmp.Close()
-	_ = s.udp.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
+	if s.udp != nil {
+		_ = s.udp.Close()
+	}
 }
 
-func (s *UDPSpec) ListenOut(_ context.Context, _ chan struct{}, _ func(srcPort, seq, ttl int, start time.Time)) {
+func (s *UDPSpec) ListenOut(_ context.Context, _ chan struct{}, _ func(srcPort, seq, ttl int, start time.Time)) error {
+	return nil
 }
 
-func (s *UDPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	s.listenICMPSock(ctx, ready, onICMP)
+func (s *UDPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	return s.listenICMPSock(ctx, ready, onICMP)
 }
 
 func serializeUDPPacket(payload []byte, layersToSerialize ...gopacket.SerializableLayer) ([]byte, error) {

--- a/trace/internal/udp_windows.go
+++ b/trace/internal/udp_windows.go
@@ -26,10 +26,10 @@ type UDPSpec struct {
 	handle       wd.Handle
 }
 
-func (s *UDPSpec) InitUDP() {
+func (s *UDPSpec) InitUDP() error {
 	handle, err := OpenWinDivertHandle("false", 0)
 	if err != nil {
-		log.Fatal(formatWinDivertRequiredError("Windows UDP 探测", err))
+		return fmt.Errorf("%s: %w", formatWinDivertRequiredError("Windows UDP 探测", err), err)
 	}
 	s.handle = handle
 
@@ -37,14 +37,20 @@ func (s *UDPSpec) InitUDP() {
 	s.addr.SetLayer(wd.LayerNetwork)
 	s.addr.SetEvent(wd.EventNetworkPacket)
 	s.addr.SetOutbound()
+	return nil
 }
 
 func (s *UDPSpec) Close() {
-	_ = s.icmp.Close()
-	_ = s.handle.Close()
+	if s.icmp != nil {
+		_ = s.icmp.Close()
+	}
+	if s.handle != 0 {
+		_ = s.handle.Close()
+	}
 }
 
-func (s *UDPSpec) ListenOut(_ context.Context, _ chan struct{}, _ func(srcPort, seq, ttl int, start time.Time)) {
+func (s *UDPSpec) ListenOut(_ context.Context, _ chan struct{}, _ func(srcPort, seq, ttl int, start time.Time)) error {
+	return nil
 }
 
 // resolveICMPMode 进行最终模式判定
@@ -70,17 +76,21 @@ func (s *UDPSpec) resolveICMPMode() int {
 	return 2
 }
 
-func (s *UDPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
+func (s *UDPSpec) ListenICMP(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
 	switch s.resolveICMPMode() {
 	case 1:
-		s.listenICMPSock(ctx, ready, onICMP)
+		return s.listenICMPSock(ctx, ready, onICMP)
 	case 2:
-		s.listenICMPWinDivert(ctx, ready, onICMP)
+		return s.listenICMPWinDivert(ctx, ready, onICMP)
 	}
+	return nil
 }
 
-func (s *UDPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) {
-	sniffHandle, closeHandle := openWinDivertSniffHandle(ctx, winDivertICMPFilter(s.IPVersion, s.SrcIP), "ListenICMP")
+func (s *UDPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, onICMP func(msg ReceivedMessage, finish time.Time, data []byte)) error {
+	sniffHandle, closeHandle, err := openWinDivertSniffHandle(ctx, winDivertICMPFilter(s.IPVersion, s.SrcIP), "ListenICMP")
+	if err != nil {
+		return err
+	}
 	defer closeHandle()
 	close(ready)
 
@@ -88,12 +98,12 @@ func (s *UDPSpec) listenICMPWinDivert(ctx context.Context, ready chan struct{}, 
 	var addr wd.Address
 
 	for {
-		raw, finish, ok := receiveWinDivertPacket(ctx, sniffHandle, buf, &addr)
-		if !ok {
+		raw, finish, err := receiveWinDivertPacket(ctx, sniffHandle, buf, &addr)
+		if err != nil {
 			if ctx.Err() != nil {
-				return
+				return nil
 			}
-			continue
+			return err
 		}
 
 		packet, ok := decodeWinDivertICMPPacket(s.IPVersion, raw)

--- a/trace/internal/windivert_sniff_windows.go
+++ b/trace/internal/windivert_sniff_windows.go
@@ -6,14 +6,12 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/nxtrace/NTrace-core/util"
 	wd "github.com/xjasonlyu/windivert-go"
 )
 
@@ -28,11 +26,7 @@ type winDivertICMPPacket struct {
 	echoReply bool
 }
 
-var (
-	openWinDivertSniffCall = OpenWinDivertHandle
-	winDivertSniffFatal    = func(msg string) { log.Fatal(msg) }
-	winDivertSniffDevMode  = func() bool { return util.EnvDevMode }
-)
+var openWinDivertSniffCall = OpenWinDivertHandle
 
 func winDivertICMPFilter(ipVersion int, srcIP net.IP) string {
 	if ipVersion == 4 {
@@ -54,15 +48,11 @@ func winDivertTCPFilter(ipVersion int, srcIP net.IP, dstPort int) string {
 	)
 }
 
-func openWinDivertSniffHandle(ctx context.Context, filter, action string) (wd.Handle, func()) {
+func openWinDivertSniffHandle(ctx context.Context, filter, action string) (wd.Handle, func(), error) {
 	handle, err := openWinDivertSniffCall(filter, wd.FlagSniff|wd.FlagRecvOnly)
 	if err != nil {
 		msg := formatWinDivertRequiredError(fmt.Sprintf("Windows WinDivert 嗅探 (%s, filter=%q)", action, filter), err)
-		if winDivertSniffDevMode() {
-			panic(msg)
-		}
-		winDivertSniffFatal(msg)
-		panic(msg)
+		return 0, nil, fmt.Errorf("%s: %w", msg, err)
 	}
 
 	var closeOnce sync.Once
@@ -74,7 +64,7 @@ func openWinDivertSniffHandle(ctx context.Context, filter, action string) (wd.Ha
 
 	_ = handle.SetParam(wd.QueueLength, 8192)
 	_ = handle.SetParam(wd.QueueTime, 4000)
-	return handle, closeHandle
+	return handle, closeHandle, nil
 }
 
 func packetDecoderForIPVersion(ipVersion int) gopacket.Decoder {
@@ -84,27 +74,18 @@ func packetDecoderForIPVersion(ipVersion int) gopacket.Decoder {
 	return layers.LayerTypeIPv6
 }
 
-func receiveWinDivertPacket(ctx context.Context, handle wd.Handle, buf []byte, addr *wd.Address) ([]byte, time.Time, bool) {
-	select {
-	case <-ctx.Done():
-		return nil, time.Time{}, false
-	default:
+func receiveWinDivertPacket(ctx context.Context, handle wd.Handle, buf []byte, addr *wd.Address) ([]byte, time.Time, error) {
+	if ctx.Err() != nil {
+		return nil, time.Time{}, context.Cause(ctx)
 	}
-
 	n, err := handle.Recv(buf, addr)
 	if err != nil {
-		select {
-		case <-ctx.Done():
-			return nil, time.Time{}, false
-		default:
-			return nil, time.Time{}, false
-		}
+		return nil, time.Time{}, fmt.Errorf("WinDivert receive failed: %w", err)
 	}
-
 	finish := time.Now()
 	raw := make([]byte, n)
 	copy(raw, buf[:n])
-	return raw, finish, true
+	return raw, finish, nil
 }
 
 func decodeWinDivertICMPPacket(ipVersion int, raw []byte) (*winDivertICMPPacket, bool) {

--- a/trace/internal/windivert_sniff_windows_test.go
+++ b/trace/internal/windivert_sniff_windows_test.go
@@ -3,9 +3,7 @@
 package internal
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -81,71 +79,17 @@ func TestWinDivertICMPErrorAllowsAlternateOuterSource(t *testing.T) {
 	}
 }
 
-func TestOpenWinDivertSniffHandlePanicsInDevMode(t *testing.T) {
+func TestOpenWinDivertSniffHandleReturnsSetupError(t *testing.T) {
 	oldOpen := openWinDivertSniffCall
-	oldFatal := winDivertSniffFatal
-	oldDevMode := winDivertSniffDevMode
-	openWinDivertSniffCall = func(string, uint64) (wd.Handle, error) {
-		return 0, wd.Error(windows.ERROR_FILE_NOT_FOUND)
+	t.Cleanup(func() { openWinDivertSniffCall = oldOpen })
+	for _, failure := range []error{wd.Error(windows.ERROR_FILE_NOT_FOUND), errors.New("boom")} {
+		openWinDivertSniffCall = func(string, uint64) (wd.Handle, error) { return 0, failure }
+		handle, cleanup, err := openWinDivertSniffHandle(t.Context(), "false", "test")
+		if handle != 0 || cleanup != nil || !errors.Is(err, failure) {
+			t.Fatalf("open = (%v, cleanup %v, %v)", handle, cleanup != nil, err)
+		}
+		if !strings.Contains(err.Error(), "WinDivert") || !strings.Contains(err.Error(), `filter="false"`) {
+			t.Fatalf("missing setup context: %v", err)
+		}
 	}
-	var gotFatal string
-	winDivertSniffFatal = func(msg string) {
-		gotFatal = msg
-	}
-	winDivertSniffDevMode = func() bool { return true }
-	defer func() {
-		openWinDivertSniffCall = oldOpen
-		winDivertSniffFatal = oldFatal
-		winDivertSniffDevMode = oldDevMode
-	}()
-	defer func() {
-		if gotFatal != "" {
-			t.Fatalf("fatal should not be called in dev mode: %s", gotFatal)
-		}
-	}()
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("openWinDivertSniffHandle() did not panic in dev mode")
-		} else if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "WinDivert") || !strings.Contains(msg, `filter="false"`) {
-			t.Fatalf("panic = %q, want WinDivert context and filter", msg)
-		}
-	}()
-
-	openWinDivertSniffHandle(context.Background(), "false", "test")
-}
-
-func TestOpenWinDivertSniffHandleCallsFatalOutsideDevModeThenPanics(t *testing.T) {
-	oldOpen := openWinDivertSniffCall
-	oldFatal := winDivertSniffFatal
-	oldDevMode := winDivertSniffDevMode
-	openWinDivertSniffCall = func(string, uint64) (wd.Handle, error) {
-		return 0, errors.New("boom")
-	}
-	var gotFatal string
-	winDivertSniffFatal = func(msg string) {
-		gotFatal = msg
-	}
-	winDivertSniffDevMode = func() bool { return false }
-	defer func() {
-		openWinDivertSniffCall = oldOpen
-		winDivertSniffFatal = oldFatal
-		winDivertSniffDevMode = oldDevMode
-	}()
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("openWinDivertSniffHandle() did not panic after fatal hook")
-		} else if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "Windows WinDivert 嗅探 (test") || !strings.Contains(msg, `filter="false"`) {
-			t.Fatalf("panic = %q, want action context and filter", msg)
-		}
-		if gotFatal == "" {
-			t.Fatal("fatal hook was not called")
-		}
-		if !strings.Contains(gotFatal, "Windows WinDivert 嗅探 (test") || !strings.Contains(gotFatal, `filter="false"`) {
-			t.Fatalf("fatal message = %q, want action context and filter", gotFatal)
-		}
-	}()
-
-	openWinDivertSniffHandle(context.Background(), "false", "test")
 }

--- a/trace/mtr_loop_runtime.go
+++ b/trace/mtr_loop_runtime.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -93,7 +94,7 @@ func (rt *mtrLoopRuntime) snapshotContextError() error {
 		return nil
 	}
 	rt.emitSnapshot()
-	return rt.ctx.Err()
+	return context.Cause(rt.ctx)
 }
 
 func (rt *mtrLoopRuntime) emitSnapshot() {
@@ -202,6 +203,11 @@ func (rt *mtrLoopRuntime) emitPreview(peeker mtrPeeker) {
 func (rt *mtrLoopRuntime) handleProbeError(err error) (bool, error) {
 	if rt.ctx.Err() != nil {
 		return false, rt.snapshotContextError()
+	}
+	var setup *probeSetupError
+	if errors.As(err, &setup) {
+		rt.emitSnapshot()
+		return false, err
 	}
 
 	rt.consecutiveErrors++

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net"
@@ -265,13 +266,15 @@ func mtrFillGeoRDNS(workers *mtrWorkerSession, res *Result, config Config) {
 // ---------------------------------------------------------------------------
 
 type mtrICMPEngine struct {
-	config  Config
-	spec    atomic.Pointer[internal.ICMPSpec]
-	specMu  sync.Mutex
-	echoID  atomic.Int32
-	srcIP   net.IP
-	ipVer   int
-	workers *mtrWorkerSession
+	config         Config
+	spec           atomic.Pointer[internal.ICMPSpec]
+	specMu         sync.Mutex
+	echoID         atomic.Int32
+	srcIP          net.IP
+	ipVer          int
+	workers        *mtrWorkerSession
+	listenerCancel context.CancelFunc
+	listenerDone   chan struct{}
 
 	// 单调递增序列号，避免跨轮 seq 冲突
 	seqCounter atomic.Uint32
@@ -367,7 +370,10 @@ func (e *mtrICMPEngine) startMTRSession(workers *mtrWorkerSession) error {
 	ctx := workers.ctx
 	spec := internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, int(e.echoID.Load()), e.srcIP, e.config.DstIP)
 	applyICMPSourceDevice(spec, e.config.OSType, e.config.SourceDevice)
-	spec.InitICMP()
+	if err := spec.InitICMP(); err != nil {
+		spec.Close()
+		return wrapProbeSetupError(err)
+	}
 	e.spec.Store(spec)
 
 	e.notifyCh = make(chan struct{}, 1)
@@ -375,8 +381,7 @@ func (e *mtrICMPEngine) startMTRSession(workers *mtrWorkerSession) error {
 	e.replied = make(map[int]*mtrProbeReply)
 	e.probeNotify = make(map[int]chan struct{})
 
-	ready := make(chan struct{})
-	workers.Go("mtr.icmp-listener", func() { spec.ListenICMP(ctx, ready, e.onICMP) })
+	ready := e.startICMPListener(spec)
 	if err := waitMTRListenerReady(ctx, ready, "ICMP listener startup timeout"); err != nil {
 		return err
 	}
@@ -386,9 +391,34 @@ func (e *mtrICMPEngine) startMTRSession(workers *mtrWorkerSession) error {
 func (e *mtrICMPEngine) close() {
 	e.specMu.Lock()
 	defer e.specMu.Unlock()
+	e.stopICMPListener()
+}
+
+// Caller holds specMu; each rotation owns and joins its listener.
+func (e *mtrICMPEngine) startICMPListener(spec *internal.ICMPSpec) chan struct{} {
+	ctx, cancel := context.WithCancel(e.workers.ctx)
+	done, ready := make(chan struct{}), make(chan struct{})
+	e.listenerCancel, e.listenerDone = cancel, done
+	e.workers.Go("mtr.icmp-listener", func() {
+		defer close(done)
+		if err := spec.ListenICMP(ctx, ready, e.onICMP); err != nil && ctx.Err() == nil {
+			e.workers.cancel(wrapProbeSetupError(err))
+		}
+	})
+	return ready
+}
+
+func (e *mtrICMPEngine) stopICMPListener() {
+	if e.listenerCancel != nil {
+		e.listenerCancel()
+	}
 	if spec := e.spec.Swap(nil); spec != nil {
 		spec.Close()
 	}
+	if e.listenerDone != nil {
+		<-e.listenerDone
+	}
+	e.listenerCancel, e.listenerDone = nil, nil
 }
 
 // resetFinalTTL 清除已知目的地 TTL 缓存（r 键重置统计时调用）。
@@ -457,16 +487,17 @@ func seqWillWrap(seqCounter uint32, probeCount int) bool {
 func (e *mtrICMPEngine) rotateEngine(ctx context.Context) error {
 	e.specMu.Lock()
 	defer e.specMu.Unlock()
-	if spec := e.spec.Swap(nil); spec != nil {
-		spec.Close()
-	}
+	e.stopICMPListener()
 
 	e.echoID.Store(int32(newMTREchoID()))
 	e.seqCounter.Store(0)
 
 	spec := internal.NewICMPSpec(e.ipVer, e.config.ICMPMode, int(e.echoID.Load()), e.srcIP, e.config.DstIP)
 	applyICMPSourceDevice(spec, e.config.OSType, e.config.SourceDevice)
-	spec.InitICMP()
+	if err := spec.InitICMP(); err != nil {
+		spec.Close()
+		return wrapProbeSetupError(err)
+	}
 	e.spec.Store(spec)
 
 	e.mu.Lock()
@@ -481,11 +512,10 @@ func (e *mtrICMPEngine) rotateEngine(ctx context.Context) error {
 	e.probeNotify = make(map[int]chan struct{})
 	e.mu.Unlock()
 
-	ready := make(chan struct{})
 	if e.workers == nil {
-		return fmt.Errorf("ICMP listener has no MTR worker session")
+		return wrapProbeSetupError(fmt.Errorf("ICMP listener has no MTR worker session"))
 	}
-	e.workers.Go("mtr.icmp-listener", func() { spec.ListenICMP(e.workers.ctx, ready, e.onICMP) })
+	ready := e.startICMPListener(spec)
 	return waitMTRListenerReady(ctx, ready, "ICMP listener restart timeout on echoID rotation")
 }
 
@@ -496,9 +526,9 @@ func waitMTRListenerReady(ctx context.Context, ready <-chan struct{}, timeoutMes
 	case <-ready:
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	case <-timer.C:
-		return fmt.Errorf("%s", timeoutMessage)
+		return wrapProbeSetupError(fmt.Errorf("%s", timeoutMessage))
 	}
 }
 
@@ -507,7 +537,7 @@ func waitMTRTimer(ctx context.Context, delay time.Duration) error {
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	case <-timer.C:
 		return nil
 	}
@@ -773,7 +803,7 @@ func (e *mtrICMPEngine) probeRoundDelay() time.Duration {
 func (e *mtrICMPEngine) sendProbeSweep(ctx context.Context, round mtrProbeRoundState) error {
 	for ttl := round.beginHop; ttl <= round.effectiveMax; ttl++ {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 		sent, err := e.sendProbeForTTL(ctx, ttl, round.roundID)
 		if err != nil {
@@ -809,7 +839,11 @@ func (e *mtrICMPEngine) sendProbeForTTL(ctx context.Context, ttl int, roundID ui
 		}
 		e.mu.Unlock()
 		if ctx.Err() != nil {
-			return false, ctx.Err()
+			return false, context.Cause(ctx)
+		}
+		var setup *probeSetupError
+		if errors.As(err, &setup) {
+			return false, err
 		}
 		return false, nil
 	}
@@ -975,9 +1009,13 @@ func (e *mtrICMPEngine) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, 
 		e.closeProbeNotifyLocked(seq)
 		e.mu.Unlock()
 		if ctx.Err() != nil {
-			return mtrProbeResult{TTL: ttl}, ctx.Err()
+			return mtrProbeResult{TTL: ttl}, context.Cause(ctx)
 		}
 		// Send failed: treat as timeout (no response for this TTL)
+		var setup *probeSetupError
+		if errors.As(err, &setup) {
+			return mtrProbeResult{TTL: ttl}, err
+		}
 		return mtrProbeResult{TTL: ttl}, nil
 	}
 
@@ -1030,7 +1068,7 @@ func (e *mtrICMPEngine) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, 
 		delete(e.sentAt, seq)
 		delete(e.probeNotify, seq)
 		e.mu.Unlock()
-		return mtrProbeResult{TTL: ttl}, ctx.Err()
+		return mtrProbeResult{TTL: ttl}, context.Cause(ctx)
 	}
 }
 

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -194,6 +195,9 @@ func (rt *mtrSchedulerRuntime) run() error {
 			return rt.handleCancel()
 		case cp := <-rt.resultCh:
 			rt.processResult(cp)
+			if rt.ctx.Err() != nil {
+				return rt.handleCancel()
+			}
 			if rt.isDone() {
 				rt.finishRun()
 				return nil
@@ -310,6 +314,11 @@ func (rt *mtrSchedulerRuntime) processResult(cp mtrCompletedProbe) {
 }
 
 func (rt *mtrSchedulerRuntime) processProbeError(ttl int, err error, doneAt time.Time) {
+	var setup *probeSetupError
+	if errors.As(err, &setup) {
+		rt.workers.cancel(err)
+		return
+	}
 	if rt.ctx.Err() != nil {
 		return
 	}
@@ -843,5 +852,5 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 
 func (rt *mtrSchedulerRuntime) handleCancel() error {
 	rt.maybeSnapshot(true)
-	return rt.ctx.Err()
+	return context.Cause(rt.ctx)
 }

--- a/trace/mtr_session.go
+++ b/trace/mtr_session.go
@@ -9,12 +9,12 @@ import (
 // mtrWorkerSession owns every cancellable worker created for one MTR run.
 type mtrWorkerSession struct {
 	ctx    context.Context
-	cancel context.CancelFunc
+	cancel context.CancelCauseFunc
 	wg     sync.WaitGroup
 }
 
 func newMTRWorkerSession(parent context.Context) *mtrWorkerSession {
-	ctx, cancel := context.WithCancel(parent)
+	ctx, cancel := context.WithCancelCause(parent)
 	return &mtrWorkerSession{ctx: ctx, cancel: cancel}
 }
 
@@ -27,7 +27,7 @@ func (s *mtrWorkerSession) Go(owner string, fn func()) {
 }
 
 func (s *mtrWorkerSession) shutdown(closeResources func()) {
-	s.cancel()
+	s.cancel(nil)
 	if closeResources != nil {
 		closeResources()
 	}

--- a/trace/probe_setup.go
+++ b/trace/probe_setup.go
@@ -1,0 +1,55 @@
+package trace
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace/internal"
+)
+
+// probeSetupError cannot be recovered by retrying a TTL or counting a timeout.
+type probeSetupError = internal.InitializationError
+
+// A caller-supplied context owns cancellation, including the CLI's signal cause.
+func traceSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent != nil {
+		return context.WithCancel(parent)
+	}
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}
+
+func wrapProbeSetupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	var setup *probeSetupError
+	if errors.As(err, &setup) {
+		return err
+	}
+	return &probeSetupError{Err: err}
+}
+
+func waitProbeListeners(ctx context.Context, ready ...chan struct{}) error {
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for _, ch := range ready {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-timer.C:
+			return wrapProbeSetupError(errors.New("probe listener startup timeout"))
+		case <-ch:
+		}
+	}
+	if !waitForTraceDelay(ctx, 100*time.Millisecond) {
+		return context.Cause(ctx)
+	}
+	return nil
+}

--- a/trace/probe_setup.go
+++ b/trace/probe_setup.go
@@ -14,6 +14,12 @@ import (
 // probeSetupError cannot be recovered by retrying a TTL or counting a timeout.
 type probeSetupError = internal.InitializationError
 
+// IsInitializationError reports failures to initialize or replace probe resources.
+func IsInitializationError(err error) bool {
+	var setup *probeSetupError
+	return errors.As(err, &setup)
+}
+
 // A caller-supplied context owns cancellation, including the CLI's signal cause.
 func traceSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent != nil {

--- a/trace/probe_setup_test.go
+++ b/trace/probe_setup_test.go
@@ -3,12 +3,27 @@ package trace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 )
+
+func TestIsInitializationError(t *testing.T) {
+	cause := errors.New("socket unavailable")
+	for _, err := range []error{wrapProbeSetupError(cause), fmt.Errorf("mtr: %w", wrapProbeSetupError(cause))} {
+		if !IsInitializationError(err) || !errors.Is(err, cause) {
+			t.Fatalf("lost initialization classification or cause: %v", err)
+		}
+	}
+	for _, err := range []error{nil, cause, context.Canceled, context.DeadlineExceeded} {
+		if IsInitializationError(err) {
+			t.Fatalf("misclassified ordinary error: %v", err)
+		}
+	}
+}
 
 func TestProbeListenersWaitForEveryListenerAndPreserveCause(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {

--- a/trace/probe_setup_test.go
+++ b/trace/probe_setup_test.go
@@ -1,0 +1,121 @@
+package trace
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestProbeListenersWaitForEveryListenerAndPreserveCause(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		first, second := make(chan struct{}), make(chan struct{})
+		close(first)
+		done := make(chan error, 1)
+		go func() { done <- waitProbeListeners(ctx, first, second) }()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("returned before second listener was ready: %v", err)
+		default:
+		}
+		cause := wrapProbeSetupError(errors.New("pcap initialization failed"))
+		cancel(cause)
+		if err := <-done; !errors.Is(err, cause) {
+			t.Fatalf("lost setup cause: %v", err)
+		}
+	})
+	synctest.Test(t, func(t *testing.T) {
+		err := waitProbeListeners(t.Context(), make(chan struct{}))
+		var setup *probeSetupError
+		if !errors.As(err, &setup) {
+			t.Fatalf("readiness timeout must be terminal: %v", err)
+		}
+	})
+}
+
+func TestSchedulerSetupFailurePreservesStatsAndClosesProber(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	cause := errors.New("ICMP rotation failed")
+	prober := &mockTTLProber{}
+	prober.probeFn = func(context.Context, int) (mtrProbeResult, error) {
+		if prober.getProbeCount() == 1 {
+			return mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.IPv4(192, 0, 2, 1)}}, nil
+		}
+		return mtrProbeResult{}, wrapProbeSetupError(cause)
+	}
+	var final []MTRHopStat
+	probes := 0
+	err := runMTRScheduler(ctx, prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 1, HopInterval: time.Millisecond, MaxPerHop: 3,
+		ParallelRequests: 1, MaxInFlightPerHop: 1, MaxConsecErrors: 1,
+	}, func(_ int, stats []MTRHopStat) { final = stats }, func(mtrProbeResult, int, time.Time) { probes++ })
+	if !errors.Is(err, cause) || errors.Is(err, context.Canceled) {
+		t.Fatalf("lost setup cause: %v", err)
+	}
+	if probes != 1 || len(final) != 1 || final[0].Snt != 1 || final[0].Last != 0 {
+		t.Fatalf("setup failure was counted as timeout or discarded stats: probes=%d stats=%+v", probes, final)
+	}
+	if prober.getProbeCount() != 2 || atomic.LoadInt32(&prober.closeCnt) != 1 {
+		t.Fatalf("unexpected retry/cleanup: probes=%d closes=%d", prober.getProbeCount(), prober.closeCnt)
+	}
+}
+
+func TestMTRICMPSetupAndRotationReturnErrors(t *testing.T) {
+	for _, rotate := range []bool{false, true} {
+		workers := newMTRWorkerSession(t.Context())
+		engine := newMTRICMPEngineState(Config{DstIP: net.IPv4(127, 0, 0, 1)}, 4, net.IP{1, 2, 3})
+		engine.workers = workers
+		var err error
+		if rotate {
+			err = engine.rotateEngine(workers.ctx)
+		} else {
+			err = engine.startMTRSession(workers)
+		}
+		workers.shutdown(engine.close)
+		var setup *probeSetupError
+		if !errors.As(err, &setup) || engine.spec.Load() != nil {
+			t.Fatalf("rotate=%v: err=%v spec=%v", rotate, err, engine.spec.Load())
+		}
+	}
+}
+
+func TestMTRICMPRotationFailureClosesPreviousListener(t *testing.T) {
+	workers := newMTRWorkerSession(t.Context())
+	engine := newMTRICMPEngineState(Config{DstIP: net.IPv4(127, 0, 0, 1), ICMPMode: 1}, 4, net.IPv4(127, 0, 0, 1))
+	defer workers.shutdown(engine.close)
+	if err := engine.startMTRSession(workers); err != nil {
+		t.Skipf("ICMP loopback socket unavailable: %v", err)
+	}
+	oldDone := engine.listenerDone
+	engine.srcIP = net.IP{1, 2, 3}
+	err := engine.rotateEngine(workers.ctx)
+	var setup *probeSetupError
+	if !errors.As(err, &setup) || engine.spec.Load() != nil || workers.ctx.Err() != nil {
+		t.Fatalf("rotation error=%v spec=%v session=%v", err, engine.spec.Load(), workers.ctx.Err())
+	}
+	select {
+	case <-oldDone:
+	default:
+		t.Fatal("old listener was not joined before failed rotation returned")
+	}
+}
+
+func TestMTRLegacyLoopDoesNotRetrySetupFailure(t *testing.T) {
+	cause := errors.New("probe initialization failed")
+	calls := 0
+	prober := &mockProber{roundFn: func(context.Context) (*Result, error) {
+		calls++
+		return nil, wrapProbeSetupError(cause)
+	}}
+	err := mtrLoop(t.Context(), prober, Config{MaxHops: 1}, MTROptions{MaxRounds: 1}, NewMTRAggregator(), nil, false, fastBackoff)
+	if !errors.Is(err, cause) || calls != 1 || atomic.LoadInt32(&prober.closed) != 1 {
+		t.Fatalf("error=%v calls=%d closed=%d", err, calls, prober.closed)
+	}
+}

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -7,10 +7,8 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -36,22 +34,8 @@ type TCPTracer struct {
 	readyTCP  chan struct{}
 }
 
-func (t *TCPTracer) waitAllReady(ctx context.Context) {
-	timeout := time.After(5 * time.Second)
-	waiting := 2
-	for waiting > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.readyICMP:
-			waiting--
-		case <-t.readyTCP:
-			waiting--
-		case <-timeout:
-			return
-		}
-	}
-	<-time.After(100 * time.Millisecond)
+func (t *TCPTracer) waitAllReady(ctx context.Context) error {
+	return waitProbeListeners(ctx, t.readyICMP, t.readyTCP)
 }
 
 func (t *TCPTracer) ttlComp(ttl int) bool {
@@ -270,16 +254,19 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 	)
 	s.SourceDevice = t.SourceDevice
 
-	s.InitICMP()
-	s.InitTCP()
-	defer s.Close()
-
-	baseCtx := t.Context
-	if baseCtx == nil {
-		baseCtx = context.Background()
+	closeSpec := sync.OnceFunc(s.Close)
+	defer closeSpec()
+	if err := s.InitICMP(); err != nil {
+		return nil, wrapProbeSetupError(err)
 	}
-	sigCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+	if err := s.InitTCP(); err != nil {
+		return nil, wrapProbeSetupError(err)
+	}
+
+	sigCtx, stop := traceSignalContext(t.Context)
 	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer stop()
+	defer cancel(nil)
 	t.final.Store(-1)
 
 	workerN := 16
@@ -290,15 +277,17 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
+		if err := s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
 			t.handleICMPMessage(msg, finish, data)
 		},
-		)
+		); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenTCP(ctx, t.readyTCP, func(srcPort, seq, ack int, peer net.Addr, finish time.Time) {
+		if err := s.ListenTCP(ctx, t.readyTCP, func(srcPort, seq, ack int, peer net.Addr, finish time.Time) {
 			// 非阻塞投递，队列满则丢弃任务
 			select {
 			case t.matchQ <- matchTask{
@@ -308,9 +297,16 @@ func (t *TCPTracer) Execute() (res *Result, err error) {
 			default:
 				// 丢弃以避免阻塞抓包循环
 			}
-		})
+		}); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
-	t.waitAllReady(ctx)
+	if err := t.waitAllReady(ctx); err != nil {
+		cancel(err)
+		closeSpec()
+		t.wg.Wait()
+		return &t.res, err
+	}
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, cancel)
 

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -7,10 +7,8 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -36,22 +34,8 @@ type TCPTracerIPv6 struct {
 	readyTCP  chan struct{}
 }
 
-func (t *TCPTracerIPv6) waitAllReady(ctx context.Context) {
-	timeout := time.After(5 * time.Second)
-	waiting := 2
-	for waiting > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.readyICMP:
-			waiting--
-		case <-t.readyTCP:
-			waiting--
-		case <-timeout:
-			return
-		}
-	}
-	<-time.After(100 * time.Millisecond)
+func (t *TCPTracerIPv6) waitAllReady(ctx context.Context) error {
+	return waitProbeListeners(ctx, t.readyICMP, t.readyTCP)
 }
 
 func (t *TCPTracerIPv6) ttlComp(ttl int) bool {
@@ -270,16 +254,19 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 	)
 	s.SourceDevice = t.SourceDevice
 
-	s.InitICMP()
-	s.InitTCP()
-	defer s.Close()
-
-	baseCtx := t.Context
-	if baseCtx == nil {
-		baseCtx = context.Background()
+	closeSpec := sync.OnceFunc(s.Close)
+	defer closeSpec()
+	if err := s.InitICMP(); err != nil {
+		return nil, wrapProbeSetupError(err)
 	}
-	sigCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+	if err := s.InitTCP(); err != nil {
+		return nil, wrapProbeSetupError(err)
+	}
+
+	sigCtx, stop := traceSignalContext(t.Context)
 	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer stop()
+	defer cancel(nil)
 	t.final.Store(-1)
 
 	workerN := 16
@@ -290,15 +277,17 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
+		if err := s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
 			t.handleICMPMessage(msg, finish, data)
 		},
-		)
+		); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenTCP(ctx, t.readyTCP, func(srcPort, seq, ack int, peer net.Addr, finish time.Time) {
+		if err := s.ListenTCP(ctx, t.readyTCP, func(srcPort, seq, ack int, peer net.Addr, finish time.Time) {
 			// 非阻塞投递，队列满则丢弃任务
 			select {
 			case t.matchQ <- matchTask{
@@ -308,9 +297,16 @@ func (t *TCPTracerIPv6) Execute() (res *Result, err error) {
 			default:
 				// 丢弃以避免阻塞抓包循环
 			}
-		})
+		}); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
-	t.waitAllReady(ctx)
+	if err := t.waitAllReady(ctx); err != nil {
+		cancel(err)
+		closeSpec()
+		t.wg.Wait()
+		return &t.res, err
+	}
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, cancel)
 

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -34,7 +34,6 @@ type UDPTracer struct {
 	matchQ    chan matchTask
 	readyOut  chan struct{}
 	readyICMP chan struct{}
-	readyUDP  chan struct{}
 }
 
 func (t *UDPTracer) waitAllReady(ctx context.Context) error {
@@ -264,7 +263,6 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 	// 创建就绪通道
 	t.readyOut = make(chan struct{})
 	t.readyICMP = make(chan struct{})
-	t.readyUDP = make(chan struct{})
 
 	if len(t.res.Hops) > 0 {
 		return &t.res, errTracerouteExecuted

--- a/trace/udp_ipv4.go
+++ b/trace/udp_ipv4.go
@@ -7,10 +7,8 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -39,24 +37,8 @@ type UDPTracer struct {
 	readyUDP  chan struct{}
 }
 
-func (t *UDPTracer) waitAllReady(ctx context.Context) {
-	timeout := time.After(5 * time.Second)
-	waiting := 3
-	for waiting > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.readyOut:
-			waiting--
-		case <-t.readyICMP:
-			waiting--
-		case <-t.readyUDP:
-			waiting--
-		case <-timeout:
-			return
-		}
-	}
-	<-time.After(100 * time.Millisecond)
+func (t *UDPTracer) waitAllReady(ctx context.Context) error {
+	return waitProbeListeners(ctx, t.readyOut, t.readyICMP)
 }
 
 func (t *UDPTracer) ttlComp(ttl int) bool {
@@ -312,16 +294,19 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 	)
 	s.SourceDevice = t.SourceDevice
 
-	s.InitICMP()
-	s.InitUDP()
-	defer s.Close()
-
-	baseCtx := t.Context
-	if baseCtx == nil {
-		baseCtx = context.Background()
+	closeSpec := sync.OnceFunc(s.Close)
+	defer closeSpec()
+	if err := s.InitICMP(); err != nil {
+		return nil, wrapProbeSetupError(err)
 	}
-	sigCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+	if err := s.InitUDP(); err != nil {
+		return nil, wrapProbeSetupError(err)
+	}
+
+	sigCtx, stop := traceSignalContext(t.Context)
 	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer stop()
+	defer cancel(nil)
 	t.final.Store(-1)
 
 	workerN := 16
@@ -333,14 +318,16 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 		t.wg.Add(1)
 		go func() {
 			defer t.wg.Done()
-			s.ListenOut(ctx, t.readyOut, func(srcPort, seq, ttl int, start time.Time) {
+			if err := s.ListenOut(ctx, t.readyOut, func(srcPort, seq, ttl int, start time.Time) {
 				// 严格按队列头端口匹配；不匹配就丢弃，避免混入其它进程/杂包
 				i, ok := t.tryMatchTTLPort(ttl, srcPort)
 				if !ok {
 					return
 				}
 				t.storeSent(seq, ttl, i, srcPort, start)
-			})
+			}); err != nil {
+				cancel(wrapProbeSetupError(err))
+			}
 		}()
 	} else {
 		close(t.readyOut)
@@ -348,12 +335,19 @@ func (t *UDPTracer) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
+		if err := s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
 			t.handleICMPMessage(msg, finish, data)
 		},
-		)
+		); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
-	t.waitAllReady(ctx)
+	if err := t.waitAllReady(ctx); err != nil {
+		cancel(err)
+		closeSpec()
+		t.wg.Wait()
+		return &t.res, err
+	}
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, cancel)
 

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -7,10 +7,8 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -36,22 +34,8 @@ type UDPTracerIPv6 struct {
 	readyUDP  chan struct{}
 }
 
-func (t *UDPTracerIPv6) waitAllReady(ctx context.Context) {
-	timeout := time.After(5 * time.Second)
-	waiting := 2
-	for waiting > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.readyICMP:
-			waiting--
-		case <-t.readyUDP:
-			waiting--
-		case <-timeout:
-			return
-		}
-	}
-	<-time.After(100 * time.Millisecond)
+func (t *UDPTracerIPv6) waitAllReady(ctx context.Context) error {
+	return waitProbeListeners(ctx, t.readyICMP)
 }
 
 func (t *UDPTracerIPv6) ttlComp(ttl int) bool {
@@ -262,16 +246,19 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 	)
 	s.SourceDevice = t.SourceDevice
 
-	s.InitICMP()
-	s.InitUDP()
-	defer s.Close()
-
-	baseCtx := t.Context
-	if baseCtx == nil {
-		baseCtx = context.Background()
+	closeSpec := sync.OnceFunc(s.Close)
+	defer closeSpec()
+	if err := s.InitICMP(); err != nil {
+		return nil, wrapProbeSetupError(err)
 	}
-	sigCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+	if err := s.InitUDP(); err != nil {
+		return nil, wrapProbeSetupError(err)
+	}
+
+	sigCtx, stop := traceSignalContext(t.Context)
 	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer stop()
+	defer cancel(nil)
 	t.final.Store(-1)
 
 	workerN := 16
@@ -282,12 +269,19 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
+		if err := s.ListenICMP(ctx, t.readyICMP, func(msg internal.ReceivedMessage, finish time.Time, data []byte) {
 			t.handleICMPMessage(msg, finish, data)
 		},
-		)
+		); err != nil {
+			cancel(wrapProbeSetupError(err))
+		}
 	}()
-	t.waitAllReady(ctx)
+	if err := t.waitAllReady(ctx); err != nil {
+		cancel(err)
+		closeSpec()
+		t.wg.Wait()
+		return &t.res, err
+	}
 	t.wg.Add(1)
 	go t.PrintFunc(ctx, cancel)
 

--- a/trace/udp_ipv6.go
+++ b/trace/udp_ipv6.go
@@ -31,7 +31,6 @@ type UDPTracerIPv6 struct {
 	sem       *semaphore.Weighted
 	matchQ    chan matchTask
 	readyICMP chan struct{}
-	readyUDP  chan struct{}
 }
 
 func (t *UDPTracerIPv6) waitAllReady(ctx context.Context) error {
@@ -216,7 +215,6 @@ func (t *UDPTracerIPv6) Execute() (res *Result, err error) {
 
 	// 创建就绪通道
 	t.readyICMP = make(chan struct{})
-	t.readyUDP = make(chan struct{})
 
 	if len(t.res.Hops) > 0 {
 		return &t.res, errTracerouteExecuted


### PR DESCRIPTION
### Summary

- 为 nexttrace、nexttrace-tiny、ntr 增加实时 NDJSON 和最终 JSON 报告。
- 统一结构化错误、信号退出码和输出失败收尾，修复探测初始化及监听器清理链路。

### Motivation

实现 nxtrace/NTrace-core#388 的 MTR 机器可读输出需求。实时模式复用 RAW 事件，报告模式与文字报告共用最终统计快照；保留传统 traceroute JSON 和原有统计口径。

### Changes

- `--mtr --json` 输出 start/probe/path_end/end 事件；`-q` 只限制次数，`-r/-w --json` 等价输出一个最终报告。
- JSON 固定 FULL、忽略 `-y`，保留数据源、语言及 Geo/PTR 查询配置。
- ntr 默认选择 MTR JSON；full/tiny 单独 `--json` 保持传统模式，包括未来默认模式切换时。
- socket、pcap、WinDivert 初始化失败返回错误，防止被调度器吞成超时；等待监听器就绪并清理部分初始化资源。
- 中断保留已有统计及原始信号；写入失败取消探测并停止后续输出。
- JSON probe 先于其触发的 path_end；资源初始化/轮换失败标记 initialize，传统及文字 MTR 执行失败返回非零状态。
- 更新中英文 README、CLI help、JSON v1 契约和 Unix/Windows 回归检查。

### Testing

- `go test ./...`、`go build ./...` 通过。
- tiny/ntr 的 `./cmd ./server` 测试通过。
- 默认 JSON 与 `GOEXPERIMENT=nojsonv2` 全量及 flavor 测试通过。
- `go test -race ./cmd ./trace ./trace/internal` 通过。
- macOS arm64 及 amd64（Rosetta）回环验收通过：NDJSON、单对象报告、SIGINT/SIGTERM、断管退出。
- TCP/UDP 非管理员权限失败返回结构化 JSON 和退出码 1，已验证。
- Linux、Windows、OpenBSD、FreeBSD 主要发布架构及 ARM v5/v6/v7、MIPS softfloat 构建通过。
- 新增 Unix JSON 回归函数及文档 JSON 示例解析通过。
- 当前 head `60e0b8d` 的 CI lint、全量测试、race、默认 JSON/nojsonv2 和构建矩阵通过。
- [三平台运行回归](https://github.com/nxtrace/NTrace-dev/actions/runs/34085044856)：Linux/macOS 各 51 PASS、0 FAIL、6 SKIP；Windows 48 PASS、0 FAIL、10 SKIP。三版本新增 MTR JSON 用例全部 PASS。
- 传统/JSON/RAW/文字 MTR 的 TCP/UDP 权限失败共 14 组实测均退出 1；新增子进程退出码测试通过。

- [性能证据 CI](https://github.com/nxtrace/NTrace-dev/actions/runs/34085044911) 通过：基准分支与当前分支 benchmark、profile、测试和构建证据完整；不据此宣称性能提升。
- 最终 head `60e0b8d`：48 个检查成功，release 按 PR 规则跳过，无失败或待完成检查。

### Notes for Reviewers

- Codex 与 CodeRabbit 已对最终 head `60e0b8d` 复审，未提出新问题；8 个评审线程均已逐条核实并处理。
- 已修复 CI errcheck、遗留 UDP readiness 字段、版本输出测试断言、初始化错误分类、JSON 事件因果顺序和非 JSON 失败退出码。
- 帮助参数 finding 经实测不成立，已补三版本回归；传统配置 stdout 属于既有行为，保留范围说明见下。
- CI 的 IPv6 用例因环境限制跳过；Windows 缺少 tshark 和便携 PTY 捕获，对应抓包/TTY 检查跳过，未视为通过。
- 本机无免交互 sudo；TCP/UDP 成功运行路径由 CI 回归验证。
- 传统配置入口的 stdout 诊断属于 main 的既有行为，本 PR 保留；MTR JSON 的配置入口显式写 stderr。
- 本 PR 不改变统计字段含义，不包含 CSV、监控上报或 #393 的统计口径改造。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * MTR 支持 JSON 输出，包括持续 NDJSON 流、限次流和汇总报告。
  * JSON 结果包含探测事件、序列号、路径变化、统计信息、结束状态及退出码。
  * 支持信号中断与错误状态的结构化输出。

* **改进**
  * 更新 CLI 帮助，明确 JSON 流、报告模式及参数行为。
  * MTR 模式允许与 `--json` 同时使用。
  * 探测初始化和监听失败将返回明确错误，避免静默失败或异常终止。

* **文档**
  * 新增 MTR JSON v1 使用说明、字段定义、示例和错误处理规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
