### PR TITLE
feat(mtr): 支持自定义统计列与 TUI 列编辑

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,13 @@ jobs:
           go build -buildvcs=false -trimpath -tags flavor_tiny -o "${RUNNER_TEMP}/nexttrace-tiny" .
           go build -buildvcs=false -trimpath -tags flavor_ntr -o "${RUNNER_TEMP}/ntr" .
 
+      - name: MTR column editor PTY smoke
+        if: ${{ matrix.os != 'windows-latest' }}
+        shell: bash
+        run: |
+          go build -o "${RUNNER_TEMP}/nexttrace-mtr-columns" .
+          sudo python3 scripts/test_mtr_columns_pty.py "${RUNNER_TEMP}/nexttrace-mtr-columns"
+
       - name: Test with windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: go test -v -covermode=count -coverprofile="coverage.out" ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,14 @@ jobs:
           go build -o "${RUNNER_TEMP}/nexttrace-mtr-columns" .
           sudo python3 scripts/test_mtr_columns_pty.py "${RUNNER_TEMP}/nexttrace-mtr-columns"
 
+      - name: MTR column editor ConPTY smoke
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          python -m pip install pywinpty==3.0.5
+          go build -o "$env:RUNNER_TEMP/nexttrace-mtr-columns.exe" .
+          python scripts/test_mtr_columns_pty.py "$env:RUNNER_TEMP/nexttrace-mtr-columns.exe"
+
       - name: Test with windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: go test -v -covermode=count -coverprofile="coverage.out" ./...

--- a/README.md
+++ b/README.md
@@ -645,6 +645,22 @@ JSON always includes all available metadata (FULL), ignores `-y`, and honors Geo
 
 NDJSON emits `start`, `probe`, `path_end`, and `end` objects with consecutive `seq` values. Reports emit exactly one object, including partial statistics on interruption or failure. Diagnostics go to stderr. Exit codes: completion `0`, runtime/initialization error `1`, invalid arguments `2`, SIGINT `130`, SIGTERM `143`. Completion does not imply reachability; use `path_end`. See the [MTR JSON v1 contract and examples](docs/mtr-json.md).
 
+Select and reorder human-readable MTR columns:
+
+```sh
+nexttrace -t --mtr-columns loss,received,avg 1.1.1.1
+nexttrace -w --mtr-columns received,snt,last 1.1.1.1
+ntr --mtr-columns received 1.1.1.1
+```
+
+`--mtr-columns` accepts any nonempty selection of `loss,snt,received,last,avg,best,wrst,stdev`, in the supplied order. Names ignore case and surrounding spaces; unknown names, duplicates and empty entries are errors. `received` is displayed as `Rcv`. The default remains `Loss%, Snt, Last, Avg, Best, Wrst, StDev`.
+
+The option applies to TUI, non-TTY tables and report/wide output. It does not enable MTR: full/tiny require `-t`, `-r` or `-w`; ntr uses its default MTR mode. RAW, JSON, traditional traceroute and standalone modes reject it before initialization. Custom TUI columns keep complete numbers and at least 8 Host cells; a narrow terminal shows a notice until widened or fewer columns are selected.
+
+Press `o/O` to edit the current column codes: `L=Loss S=Snt R=Received N=Last A=Avg B=Best W=Wrst V=StDev`. Codes ignore case; spaces separate codes. Enter validates and applies, Esc cancels, Backspace deletes and Ctrl-U clears. Invalid or duplicate codes and an empty draft keep the editor open. Bracketed paste converts newlines to spaces without submitting. The draft is limited to 256 ASCII characters.
+
+While editing, other shortcuts are inactive and Ctrl-C still exits. Editing does not pause probes, reset counters or change the paused state. Applying a selection from history view returns to the statistics table; cancellation preserves the view. History columns stay fixed. Changes last only for this session; editing and resizing work while paused.
+
 When running in a terminal (TTY), MTR mode uses an **interactive full-screen TUI**:
 
 - **`q` / `Q`** — quit (restores terminal, no output left behind)
@@ -656,6 +672,7 @@ When running in a terminal (TTY), MTR mode uses an **interactive full-screen TUI
   - default: PTR (or IP fallback) ↔ IP only
   - with `--show-ips`: PTR (IP) ↔ IP only
 - **`e`** — toggle MPLS label display on/off
+- **`o` / `O`** — edit statistic columns
 - **`d` / `D`** — toggle the optional history display; the default TUI remains the classic metric table
 - **`g` / `G`** — in history display only, cycle History chart mode: heatmap → bars → sparkline
 - The TUI header displays **source → destination**, with `--source`/`--dev` information when specified.
@@ -886,7 +903,7 @@ usage: nexttrace [-h|--help] [-4|--ipv4] [-6|--ipv6] [-T|--tcp] [-U|--udp]
                  <integer>] [--dot-server
                  (dnssb|aliyun|dnspod|google|cloudflare)] [-g|--language
                  (en|cn)] [-C|--no-color] [--from "<value>"] [-t|--mtr]
-                 [-r|--report] [-w|--wide] [--show-ips] [-y|--ipinfo <integer>]
+                 [-r|--report] [-w|--wide] [--show-ips] [--mtr-columns <string>] [-y|--ipinfo <integer>]
                  [--file "<value>"] [TARGET "<value>"]
 
                  An open source visual route tracking CLI tool
@@ -1019,6 +1036,9 @@ Arguments:
   -w  --wide                         MTR wide report mode (implies --mtr
                                      --report); alone equals --mtr --report
                                      --wide
+      --mtr-columns                  MTR text columns in order: loss,snt,
+                                     received,last,avg,best,wrst,stdev;
+                                     does not enable MTR
       --show-ips                     MTR only: display both PTR hostnames and
                                      numeric IPs (PTR first, IP in parentheses)
   -y  --ipinfo                       Set initial MTR TUI host info mode (0-4).

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -636,6 +636,22 @@ JSON 固定输出完整可用元数据（FULL），忽略 `-y`，仍遵守 Geo/P
 
 NDJSON 输出 `start`、`probe`、`path_end`、`end` 事件，`seq` 连续递增。报告只输出一个对象，中断或失败时保留已有统计。诊断写入 stderr。退出码：完成 `0`，初始化/执行错误 `1`，参数错误 `2`，SIGINT `130`，SIGTERM `143`。完成不表示目的地可达，可达性读取 `path_end`。详见 [MTR JSON v1 契约及示例](docs/mtr-json.md)。
 
+选择并排列 MTR 文字统计列：
+
+```sh
+nexttrace -t --mtr-columns loss,received,avg 1.1.1.1
+nexttrace -w --mtr-columns received,snt,last 1.1.1.1
+ntr --mtr-columns received 1.1.1.1
+```
+
+`--mtr-columns` 支持 `loss,snt,received,last,avg,best,wrst,stdev` 的任意非空子集及顺序，忽略大小写与列名两端空格；未知列、重复列、空项报错。`received` 显示为 `Rcv`。默认仍为 `Loss%、Snt、Last、Avg、Best、Wrst、StDev`。
+
+参数适用于 TUI、非 TTY 表格和 report/wide，不自动开启 MTR：full/tiny 需配合 `-t/-r/-w`，ntr 使用默认 MTR 模式。RAW、JSON、传统 traceroute 和独立模式会在初始化前拒绝该参数。自定义 TUI 保留完整数字及至少 8 格 Host；空间不足时显示提示，加宽终端或减少列后恢复。
+
+按 `o/O` 编辑当前字段码：`L=Loss S=Snt R=Received N=Last A=Avg B=Best W=Wrst V=StDev`。输入不区分大小写，空格用于分隔。Enter 校验并应用，Esc 取消，Backspace 删除末尾字符，Ctrl-U 清空。空串、未知码和重复码保留编辑状态并显示错误。括号粘贴中的换行转为空格，不自动提交；草稿最多 256 个 ASCII 字符。
+
+编辑期间其他快捷键不生效，Ctrl-C 仍退出；探测、计数及暂停状态保持不变。从历史视图应用列后返回统计表，取消则保留历史视图。历史图表的固定列不变，列选择仅在当前会话有效；暂停期间仍可编辑和调整窗口大小。
+
 在终端（TTY）中运行时，MTR 模式使用**交互式全屏 TUI**：
 
 - **`q` / `Q`** — 退出（恢复终端，不留下输出）
@@ -647,6 +663,7 @@ NDJSON 输出 `start`、`probe`、`path_end`、`end` 事件，`seq` 连续递增
   - 默认：PTR（无 PTR 时回退 IP）↔ 仅 IP
   - 启用 `--show-ips`：PTR (IP) ↔ 仅 IP
 - **`e`** — 切换 MPLS 标签显示开/关
+- **`o` / `O`** — 编辑统计列
 - **`d` / `D`** — 切换可选历史显示；默认 TUI 仍是经典指标表
 - **`g` / `G`** — 仅在历史显示中循环切换 History 图表：heatmap → bars → sparkline
 - TUI 标题栏显示**源 → 目标**路由信息，指定 `--source`/`--dev` 时会展示对应信息。
@@ -861,7 +878,7 @@ usage: nexttrace [-h|--help] [-4|--ipv4] [-6|--ipv6] [-T|--tcp] [-U|--udp]
                  <integer>] [--dot-server
                  (dnssb|aliyun|dnspod|google|cloudflare)] [-g|--language
                  (en|cn)] [-C|--no-color] [--from "<value>"] [-t|--mtr]
-                 [-r|--report] [-w|--wide] [--show-ips] [-y|--ipinfo <integer>]
+                 [-r|--report] [-w|--wide] [--show-ips] [--mtr-columns <string>] [-y|--ipinfo <integer>]
                  [--file "<value>"] [TARGET "<value>"]
 
                  An open source visual route tracking CLI tool
@@ -994,6 +1011,9 @@ Arguments:
   -w  --wide                         MTR wide report mode (implies --mtr
                                      --report); alone equals --mtr --report
                                      --wide
+      --mtr-columns                  MTR text columns in order: loss,snt,
+                                     received,last,avg,best,wrst,stdev;
+                                     does not enable MTR
       --show-ips                     MTR only: display both PTR hostnames and
                                      numeric IPs (PTR first, IP in parentheses)
   -y  --ipinfo                       Set initial MTR TUI host info mode (0-4).

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1119,6 +1119,7 @@ func maybeRunMTRMode(
 	dataOrigin string,
 	showIPs bool,
 	ipInfoMode int,
+	columns ...printer.MTRColumn,
 ) bool {
 	if !modes.mtr {
 		return false
@@ -1136,13 +1137,13 @@ func maybeRunMTRMode(
 	case mtrRunRaw:
 		err = runMTRRaw(method, conf, mtrHopIntervalMs, mtrMaxPerHop, dataOrigin)
 	case mtrRunReport:
-		err = runMTRReport(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, modes.wide, showIPs)
+		err = runMTRReport(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, modes.wide, showIPs, columns...)
 	default:
 		if ipInfoMode < 0 || ipInfoMode > 4 {
 			fmt.Fprintf(os.Stderr, "--ipinfo/-y 必须在 0-4 范围内，当前值: %d\n", ipInfoMode)
 			os.Exit(1)
 		}
-		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode)
+		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode, columns...)
 	}
 	// Mode-local defers restore the terminal and close listeners before exit.
 	exitOnTraceRunError(err)
@@ -1547,7 +1548,6 @@ func Execute() {
 		fmt.Fprintln(os.Stderr, columnsErr)
 		os.Exit(2)
 	}
-	_ = mtrColumns // Connected to human printers in the layout change.
 	if mtrModes.mtr && *jsonPrint {
 		if maybePrintVersion(*ver) {
 			return
@@ -1946,7 +1946,7 @@ func Execute() {
 	)
 	conf.Context = rootCtx
 
-	if maybeRunMTRMode(mtrModes, method, conf, queriesExplicit, *numMeasurements, ttlTimeExplicit, *ttlInterval, domain, *dataOrigin, *showIPs, *ipInfoMode) {
+	if maybeRunMTRMode(mtrModes, method, conf, queriesExplicit, *numMeasurements, ttlTimeExplicit, *ttlInterval, domain, *dataOrigin, *showIPs, *ipInfoMode, mtrColumns...) {
 		return
 	}
 	if err := writeIgnoredTraceOutputWarning(os.Stderr, outputMode, resolvedOutputPath); err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -351,6 +351,7 @@ type deployRunOptions struct {
 }
 
 type mtrCLIFlags struct {
+	columns    *string
 	mtrMode    *bool
 	reportMode *bool
 	wideMode   *bool
@@ -567,6 +568,7 @@ func registerMTRFlags(parser *argparse.Parser) mtrCLIFlags {
 		}
 		return mtrCLIFlags{
 			mtrMode:    mtrMode,
+			columns:    parser.String("", "mtr-columns", &argparse.Options{Help: "MTR text columns in order: loss,snt,received,last,avg,best,wrst,stdev (does not enable MTR)"}),
 			reportMode: parser.Flag("r", "report", &argparse.Options{Help: "MTR report mode (non-interactive, implies --mtr); can trigger MTR without --mtr"}),
 			wideMode:   parser.Flag("w", "wide", &argparse.Options{Help: "MTR wide report mode (implies --mtr --report); alone equals --mtr --report --wide"}),
 			showIPs:    parser.Flag("", "show-ips", &argparse.Options{Help: "MTR only: display both PTR hostnames and numeric IPs (PTR first, IP in parentheses)"}),
@@ -575,6 +577,7 @@ func registerMTRFlags(parser *argparse.Parser) mtrCLIFlags {
 	}
 	return mtrCLIFlags{
 		mtrMode:    ptrBool(false),
+		columns:    new(string),
 		reportMode: ptrBool(false),
 		wideMode:   ptrBool(false),
 		showIPs:    ptrBool(false),
@@ -1495,6 +1498,10 @@ func Execute() {
 		}
 		os.Exit(1)
 	}
+	if *setupNextTraceAPIV4Token && parsedFlag(parser, "mtr-columns") {
+		fmt.Fprintln(os.Stderr, "--mtr-columns cannot be combined with token setup")
+		os.Exit(2)
+	}
 	if *setupNextTraceAPIV4Token {
 		if err := runNextTraceAPIV4TokenSetup(nextTraceAPIV4TokenSetupOptions{
 			stdin:  os.Stdin,
@@ -1535,6 +1542,12 @@ func Execute() {
 		}
 		os.Exit(1)
 	}
+	mtrColumns, columnsErr := resolveMTRColumns(*mtrFlags.columns, parsedFlag(parser, "mtr-columns"), mtrModes, *jsonPrint, standalone)
+	if columnsErr != nil {
+		fmt.Fprintln(os.Stderr, columnsErr)
+		os.Exit(2)
+	}
+	_ = mtrColumns // Connected to human printers in the layout change.
 	if mtrModes.mtr && *jsonPrint {
 		if maybePrintVersion(*ver) {
 			return

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1543,7 +1543,11 @@ func Execute() {
 		}
 		os.Exit(1)
 	}
-	mtrColumns, columnsErr := resolveMTRColumns(*mtrFlags.columns, parsedFlag(parser, "mtr-columns"), mtrModes, *jsonPrint, standalone)
+	columnsStandalone := standalone
+	if *init {
+		columnsStandalone = "--init"
+	}
+	mtrColumns, columnsErr := resolveMTRColumns(*mtrFlags.columns, parsedFlag(parser, "mtr-columns"), mtrModes, *jsonPrint, columnsStandalone)
 	if columnsErr != nil {
 		fmt.Fprintln(os.Stderr, columnsErr)
 		os.Exit(2)

--- a/cmd/dns_mode.go
+++ b/cmd/dns_mode.go
@@ -38,7 +38,7 @@ func maybeRunDNSModeWithAvailability(
 		return true, 1
 	}
 	if containsMTRColumnsFlag(rawArgs) {
-		fmt.Fprintln(stderr, "--mtr-columns cannot be combined with a standalone mode")
+		_, _ = fmt.Fprintln(stderr, "--mtr-columns cannot be combined with a standalone mode")
 		return true, 2
 	}
 	return true, runner(rawArgs[1:], stdout, stderr)

--- a/cmd/dns_mode.go
+++ b/cmd/dns_mode.go
@@ -37,6 +37,10 @@ func maybeRunDNSModeWithAvailability(
 		_, _ = fmt.Fprintln(stderr, "--traceroute cannot be combined with --dns")
 		return true, 1
 	}
+	if containsMTRColumnsFlag(rawArgs) {
+		fmt.Fprintln(stderr, "--mtr-columns cannot be combined with a standalone mode")
+		return true, 2
+	}
 	return true, runner(rawArgs[1:], stdout, stderr)
 }
 

--- a/cmd/mtr_column_editor.go
+++ b/cmd/mtr_column_editor.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"strings"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/printer"
+)
+
+const mtrColumnDraftLimit = 256
+const mtrEscapeDelay = 50 * time.Millisecond
+
+func (u *mtrUI) columnSnapshot() ([]printer.MTRColumn, printer.MTRColumnEditor) {
+	u.columnsMu.Lock()
+	defer u.columnsMu.Unlock()
+	return append([]printer.MTRColumn(nil), u.columns...), u.columnEditor
+}
+
+func (u *mtrUI) requestRedraw() {
+	select {
+	case u.redraw <- struct{}{}:
+	default:
+	}
+}
+
+func (u *mtrUI) openColumnEditor() {
+	u.columnsMu.Lock()
+	defer u.columnsMu.Unlock()
+	columns := u.columns
+	if columns == nil {
+		columns = printer.DefaultMTRColumns()
+	}
+	u.columnEditor = printer.MTRColumnEditor{Active: true, Draft: printer.MTRColumnCodes(columns)}
+}
+
+func (u *mtrUI) editColumn(b byte, paste bool) {
+	u.columnsMu.Lock()
+	defer u.columnsMu.Unlock()
+	e := &u.columnEditor
+	if !e.Active {
+		return
+	}
+	if paste {
+		if b == '\r' || b == '\n' || b == '\t' {
+			b = ' '
+		}
+		if b < 32 || b > 126 {
+			return
+		}
+	} else {
+		switch b {
+		case 27:
+			e.Active = false
+			return
+		case 8, 127:
+			if len(e.Draft) > 0 {
+				e.Draft = e.Draft[:len(e.Draft)-1]
+			}
+			e.Error = ""
+			return
+		case 21:
+			e.Draft = ""
+			e.Error = ""
+			return
+		case '\r', '\n':
+			columns, err := printer.ParseMTRColumns(e.Draft, true)
+			if err != nil {
+				e.Error = err.Error()
+				return
+			}
+			u.columns = columns
+			e.Active = false
+			e.Error = ""
+			u.historyMode.Store(false)
+			return
+		}
+	}
+	if b >= 32 && b <= 126 {
+		if len(e.Draft) >= mtrColumnDraftLimit {
+			e.Error = "Maximum 256 characters"
+			return
+		}
+		e.Draft += string(b)
+		e.Error = ""
+	}
+}
+
+// Input state is owned by the key loop, independently of the renderer's snapshot.
+type mtrKeyInput struct {
+	parser   mtrInputParser
+	escapeAt time.Time
+	paste    bool
+	pasteEnd string
+}
+
+func (k *mtrKeyInput) expireEscape(u *mtrUI, now time.Time) {
+	if k.parser.state == mtrStateEsc && !k.escapeAt.IsZero() && now.Sub(k.escapeAt) >= mtrEscapeDelay {
+		k.parser.state = mtrStateGround
+		k.escapeAt = time.Time{}
+		u.editColumn(27, false)
+		u.requestRedraw()
+	}
+}
+
+func (k *mtrKeyInput) feed(u *mtrUI, b byte, now time.Time) bool {
+	if b == 3 {
+		return u.applyInputAction(mtrActionQuit)
+	}
+	if k.paste {
+		k.feedPaste(u, b)
+		u.requestRedraw()
+		return false
+	}
+	k.expireEscape(u, now)
+	_, editor := u.columnSnapshot()
+	k.parser.trackPaste = editor.Active
+	if k.parser.state == mtrStateGround && b != 27 && editor.Active {
+		u.editColumn(b, false)
+	} else {
+		action := k.parser.Feed(b)
+		if action == mtrActionPasteStart {
+			k.paste = true
+		} else if u.applyInputAction(action) {
+			return true
+		}
+	}
+	if k.parser.state == mtrStateEsc {
+		if k.escapeAt.IsZero() {
+			k.escapeAt = now
+		}
+	} else {
+		k.escapeAt = time.Time{}
+	}
+	u.requestRedraw()
+	return false
+}
+
+func (k *mtrKeyInput) feedPaste(u *mtrUI, b byte) {
+	const end = "\x1b[201~"
+	k.pasteEnd += string(b)
+	for k.pasteEnd != "" && !strings.HasPrefix(end, k.pasteEnd) {
+		u.editColumn(k.pasteEnd[0], true)
+		k.pasteEnd = k.pasteEnd[1:]
+	}
+	if k.pasteEnd == end {
+		k.paste = false
+		k.pasteEnd = ""
+	}
+}
+
+func (u *mtrUI) applyInputAction(action mtrInputAction) bool {
+	switch action {
+	case mtrActionQuit:
+		if u.cancel != nil {
+			u.cancel()
+		}
+		return true
+	case mtrActionPause:
+		u.paused.Store(true)
+	case mtrActionResume:
+		u.paused.Store(false)
+	case mtrActionRestart:
+		u.restartReq.Store(true)
+	case mtrActionDisplayMode:
+		u.CycleDisplayMode()
+	case mtrActionNameToggle:
+		u.ToggleNameMode()
+	case mtrActionMPLSToggle:
+		u.ToggleMPLS()
+	case mtrActionHistoryToggle:
+		u.ToggleHistoryMode()
+	case mtrActionHistoryChart:
+		u.CycleHistoryChartMode()
+	case mtrActionColumns:
+		u.openColumnEditor()
+	}
+	return false
+}

--- a/cmd/mtr_column_editor_test.go
+++ b/cmd/mtr_column_editor_test.go
@@ -112,8 +112,8 @@ func TestMTRColumnEditorEscapePasteAndLimit(t *testing.T) {
 
 func TestMTRKeyLoopCancelWhileReadBlocked(t *testing.T) {
 	r, w := io.Pipe()
-	defer r.Close()
-	defer w.Close()
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
 	ctx, cancel := context.WithCancel(context.Background())
 	u := newMTRUI(cancel, 0)
 	done := make(chan struct{})

--- a/cmd/mtr_column_editor_test.go
+++ b/cmd/mtr_column_editor_test.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func feedMTRKeys(u *mtrUI, k *mtrKeyInput, text string) {
+	for _, b := range []byte(text) {
+		k.feed(u, b, time.Now())
+	}
+}
+
+func TestMTRColumnEditorApplyCancelAndIsolation(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	u.paused.Store(true)
+	u.historyMode.Store(true)
+	var k mtrKeyInput
+	feedMTRKeys(u, &k, "O")
+	_, e := u.columnSnapshot()
+	if !e.Active || e.Draft != "LSNABWV" {
+		t.Fatal(e)
+	}
+	feedMTRKeys(u, &k, "\x15qprynedgo ")
+	if !u.IsPaused() || u.ConsumeRestartRequest() || u.CurrentDisplayMode() != 0 || u.CurrentNameMode() != 0 || !u.IsHistoryMode() || u.IsMPLSDisabled() {
+		t.Fatal("shortcut leaked")
+	}
+	feedMTRKeys(u, &k, "\r")
+	_, e = u.columnSnapshot()
+	if !e.Active || e.Error == "" {
+		t.Fatal("invalid input applied")
+	}
+	feedMTRKeys(u, &k, "\x15rL\x7f n\r")
+	c, e := u.columnSnapshot()
+	if e.Active || printer.MTRColumnCodes(c) != "RN" || u.IsHistoryMode() || !u.IsPaused() {
+		t.Fatalf("%v %+v", c, e)
+	}
+	// Invalid/duplicate/empty drafts stay open, cancellation preserves applied columns and view.
+	u.historyMode.Store(true)
+	for _, draft := range []string{"", "ll", "?"} {
+		feedMTRKeys(u, &k, "o\x15"+draft+"\r")
+		_, e = u.columnSnapshot()
+		if !e.Active || e.Error == "" {
+			t.Fatal(e)
+		}
+		feedMTRKeys(u, &k, "\x1b")
+		k.expireEscape(u, time.Now().Add(mtrEscapeDelay))
+		c, e = u.columnSnapshot()
+		if e.Active || printer.MTRColumnCodes(c) != "RN" || !u.IsHistoryMode() {
+			t.Fatal("cancel changed state")
+		}
+	}
+	// Returned selection is isolated from callers.
+	c[0] = printer.MTRColumnLoss
+	c, _ = u.columnSnapshot()
+	if printer.MTRColumnCodes(c) != "RN" {
+		t.Fatal("snapshot aliases state")
+	}
+}
+
+func TestMTRColumnEditorEscapePasteAndLimit(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	var k mtrKeyInput
+	feedMTRKeys(u, &k, "o\x15")
+	now := time.Now()
+	k.feed(u, 27, now)
+	k.expireEscape(u, now.Add(49*time.Millisecond))
+	k.feed(u, '[', now.Add(49*time.Millisecond))
+	k.feed(u, 'A', now.Add(60*time.Millisecond))
+	_, e := u.columnSnapshot()
+	if !e.Active || e.Draft != "" {
+		t.Fatal("arrow cancelled editor")
+	}
+	// Arbitrarily split paste wrappers; embedded newline never submits.
+	for _, part := range []string{"\x1b[2", "00~", "r\n", " n\r\nl", "\x1b[20", "1~"} {
+		feedMTRKeys(u, &k, part)
+	}
+	_, e = u.columnSnapshot()
+	if !e.Active || e.Draft != "r  n  l" {
+		t.Fatal(e)
+	}
+	feedMTRKeys(u, &k, "\r")
+	c, e := u.columnSnapshot()
+	if e.Active || printer.MTRColumnCodes(c) != "RNL" {
+		t.Fatal(c, e)
+	}
+	feedMTRKeys(u, &k, "o\x15"+strings.Repeat("a", 300))
+	_, e = u.columnSnapshot()
+	if len(e.Draft) != 256 || e.Error == "" {
+		t.Fatal(e)
+	}
+	feedMTRKeys(u, &k, "\x08")
+	_, e = u.columnSnapshot()
+	if len(e.Draft) != 255 {
+		t.Fatal(e)
+	}
+	var cancelled bool
+	u.cancel = func() { cancelled = true }
+	feedMTRKeys(u, &k, "\x1b[200~\x03")
+	if !cancelled {
+		t.Fatal("paste swallowed Ctrl-C")
+	}
+}
+
+func TestMTRKeyLoopCancelWhileReadBlocked(t *testing.T) {
+	r, w := io.Pipe()
+	defer r.Close()
+	defer w.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	u := newMTRUI(cancel, 0)
+	done := make(chan struct{})
+	go func() { u.readKeysLoop(ctx, r); close(done) }()
+	_, _ = w.Write([]byte("o\x1b"))
+	time.Sleep(75 * time.Millisecond)
+	_, e := u.columnSnapshot()
+	if e.Active {
+		t.Fatal("bare Esc did not cancel without another read")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("key loop did not stop")
+	}
+}
+
+func TestMTRRedrawInitialPausedResizeAndCleanup(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	u.paused.Store(true)
+	var width atomic.Int32
+	width.Store(80)
+	var renders atomic.Int32
+	frames := make(chan string, 100)
+	snapshot, stop := startMTRRedraw(u.redraw, func() (int, int) { return int(width.Load()), 24 }, func(_ int, stats []trace.MTRHopStat) {
+		_, e := u.columnSnapshot()
+		renders.Add(1)
+		select {
+		case frames <- e.Draft:
+		default:
+		}
+	})
+	wait := func(want string) {
+		t.Helper()
+		select {
+		case got := <-frames:
+			if got != want {
+				t.Fatalf("frame %q want %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("missing frame")
+		}
+	}
+	wait("") // Visible before the first probe.
+	var k mtrKeyInput
+	feedMTRKeys(u, &k, "o")
+	wait("LSNABWV")
+	width.Store(120)
+	wait("LSNABWV")
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Go(func() {
+			for i := range 100 {
+				snapshot(i, []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1", Snt: i}})
+				u.requestRedraw()
+			}
+		})
+	}
+	wg.Wait()
+	stop()
+	stop()
+	count := renders.Load()
+	snapshot(101, nil)
+	u.requestRedraw()
+	time.Sleep(120 * time.Millisecond)
+	if renders.Load() != count {
+		t.Fatal("wrote after cleanup")
+	}
+}

--- a/cmd/mtr_columns.go
+++ b/cmd/mtr_columns.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/nxtrace/NTrace-core/printer"
 	"strings"
+
+	"github.com/nxtrace/NTrace-core/printer"
 )
 
 func containsMTRColumnsFlag(args []string) bool {

--- a/cmd/mtr_columns.go
+++ b/cmd/mtr_columns.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/nxtrace/NTrace-core/printer"
+	"strings"
+)
+
+func containsMTRColumnsFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if arg == "--mtr-columns" || strings.HasPrefix(arg, "--mtr-columns=") {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveMTRColumns(value string, explicit bool, modes effectiveMTRModes, json bool, standalone string) ([]printer.MTRColumn, error) {
+	if !explicit {
+		return nil, nil
+	}
+	if !modes.mtr || modes.raw || json || standalone != "" {
+		return nil, fmt.Errorf("--mtr-columns requires MTR text mode (--mtr/--report/--wide); unavailable with raw, JSON, traceroute or standalone modes")
+	}
+	return printer.ParseMTRColumns(value, false)
+}

--- a/cmd/mtr_columns_test.go
+++ b/cmd/mtr_columns_test.go
@@ -1,8 +1,16 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"github.com/akamensky/argparse"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestMTRColumnsModeContract(t *testing.T) {
@@ -40,4 +48,51 @@ func TestMTRColumnsModeContract(t *testing.T) {
 	if *f.columns != "received" || *f.mtrMode {
 		t.Fatal("column flag changed mode")
 	}
+}
+
+func TestMTRColumnsCLIRejectsBeforeInitialization(t *testing.T) {
+	cases := [][]string{
+		{"-r", "--mtr-columns", "loss,LOSS"}, {"-r", "--mtr-columns", ""},
+		{"-r", "--mtr-columns", "received,"}, {"-r", "--mtr-columns", "jitter"},
+		{"-r", "--raw", "--mtr-columns", "loss"}, {"-r", "--json", "--mtr-columns", "loss"},
+	}
+	if enableTraceroute {
+		cases = append(cases, []string{"--mtr-columns", "loss"}, []string{"-k", "--mtr-columns", "loss"}, []string{"--mtu", "--mtr-columns", "loss"})
+	}
+	if appBinName == "nexttrace" {
+		cases = append(cases, []string{"--dns", "--mtr-columns", "loss"})
+	}
+	if enableSpeed {
+		cases = append(cases, []string{"--speed", "--mtr-columns", "loss"})
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			data, _ := json.Marshal(append(args, "invalid.example"))
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			process := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestMTRColumnsCLIProcess$")
+			process.Env = append(os.Environ(), "NTRACE_TEST_COLUMNS_ARGS="+string(data))
+			var stdout, stderr bytes.Buffer
+			process.Stdout = &stdout
+			process.Stderr = &stderr
+			err := process.Run()
+			var exit *exec.ExitError
+			if !errors.As(err, &exit) || exit.ExitCode() != 2 || stdout.Len() != 0 || !strings.Contains(strings.ToLower(stderr.String()), "column") {
+				t.Fatalf("err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestMTRColumnsCLIProcess(t *testing.T) {
+	raw := os.Getenv("NTRACE_TEST_COLUMNS_ARGS")
+	if raw == "" {
+		return
+	}
+	var args []string
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		t.Fatal(err)
+	}
+	os.Args = append([]string{"nexttrace"}, args...)
+	Execute()
 }

--- a/cmd/mtr_columns_test.go
+++ b/cmd/mtr_columns_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ func TestMTRColumnsModeContract(t *testing.T) {
 		{"raw", effectiveMTRModes{mtr: true, raw: true}, false, "", false},
 		{"json", effectiveMTRModes{mtr: true}, true, "", false},
 		{"standalone", effectiveMTRModes{mtr: true}, false, "--mtu", false},
+		{"init", effectiveMTRModes{mtr: true}, false, "--init", false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := resolveMTRColumns("received", true, tt.modes, tt.json, tt.standalone)
@@ -56,6 +58,14 @@ func TestMTRColumnsCLIRejectsBeforeInitialization(t *testing.T) {
 		{"-r", "--mtr-columns", "loss,LOSS"}, {"-r", "--mtr-columns", ""},
 		{"-r", "--mtr-columns", "received,"}, {"-r", "--mtr-columns", "jitter"},
 		{"-r", "--raw", "--mtr-columns", "loss"}, {"-r", "--json", "--mtr-columns", "loss"},
+	}
+	if runtime.GOOS == "windows" {
+		cases = append(cases, []string{"-r", "--init", "--mtr-columns", "loss"})
+		if defaultMTR {
+			cases = append(cases, []string{"--init", "--mtr-columns", "loss"})
+		} else {
+			cases = append(cases, []string{"-t", "--init", "--mtr-columns", "loss"})
+		}
 	}
 	if enableTraceroute {
 		cases = append(cases, []string{"--mtr-columns", "loss"}, []string{"-k", "--mtr-columns", "loss"}, []string{"--mtu", "--mtr-columns", "loss"})

--- a/cmd/mtr_columns_test.go
+++ b/cmd/mtr_columns_test.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/akamensky/argparse"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/akamensky/argparse"
 )
 
 func TestMTRColumnsModeContract(t *testing.T) {

--- a/cmd/mtr_columns_test.go
+++ b/cmd/mtr_columns_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/akamensky/argparse"
+	"testing"
+)
+
+func TestMTRColumnsModeContract(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		modes      effectiveMTRModes
+		json       bool
+		standalone string
+		valid      bool
+	}{
+		{"traditional", effectiveMTRModes{}, false, "", false},
+		{"tui", effectiveMTRModes{mtr: true}, false, "", true},
+		{"report", effectiveMTRModes{mtr: true, report: true}, false, "", true},
+		{"wide", effectiveMTRModes{mtr: true, report: true, wide: true}, false, "", true},
+		{"raw", effectiveMTRModes{mtr: true, raw: true}, false, "", false},
+		{"json", effectiveMTRModes{mtr: true}, true, "", false},
+		{"standalone", effectiveMTRModes{mtr: true}, false, "--mtu", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveMTRColumns("received", true, tt.modes, tt.json, tt.standalone)
+			if (err == nil) != tt.valid {
+				t.Fatalf("%v", err)
+			}
+			cols, err := resolveMTRColumns("", false, tt.modes, tt.json, tt.standalone)
+			if err != nil || cols != nil {
+				t.Fatal("implicit selection changed")
+			}
+		})
+	}
+	p := argparse.NewParser("test", "")
+	f := registerMTRFlags(p)
+	if err := p.Parse([]string{"test", "--mtr-columns", "received"}); err != nil {
+		t.Fatal(err)
+	}
+	if *f.columns != "received" || *f.mtrMode {
+		t.Fatal("column flag changed mode")
+	}
+}

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -48,7 +48,7 @@ func checkMTRConflicts(flags map[string]bool) (conflict string, ok bool) {
 // runMTRTUI 执行 MTR 交互式 TUI 模式。
 // 当 stdin 为 TTY 时启用全屏 TUI（备用屏幕、按键控制）；
 // 非 TTY 时降级为简单表格刷新。
-func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int) error {
+func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int, columns ...printer.MTRColumn) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -95,10 +95,10 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		onSnapshot = printer.MTRTUIPrinter(target, domain, target, config.Version, startTime,
 			srcHost, srcIP, lang, func() string { return buildAPIInfo(dataOrigin) }, showIPs, ui.IsPaused,
 			ui.CurrentDisplayMode, ui.CurrentNameMode, ui.IsMPLSDisabled,
-			ui.IsHistoryMode, ui.CurrentHistoryChartMode, history.Snapshot)
+			ui.IsHistoryMode, ui.CurrentHistoryChartMode, history.Snapshot, func() ([]printer.MTRColumn, printer.MTRColumnEditor) { return columns, printer.MTRColumnEditor{} })
 	} else {
 		onSnapshot = func(iteration int, stats []trace.MTRHopStat) {
-			printer.MTRTablePrinter(stats, iteration, ui.CurrentDisplayMode(), ui.CurrentNameMode(), lang, showIPs)
+			printer.MTRTablePrinterWithColumns(stats, iteration, ui.CurrentDisplayMode(), ui.CurrentNameMode(), lang, showIPs, columns)
 		}
 	}
 
@@ -139,7 +139,7 @@ func attachMTRHistoryIfTTY(ui *mtrUI, opts *trace.MTROptions) *printer.MTRHistor
 
 // runMTRReport 执行 MTR 非全屏报告模式（对齐 mtr -rzw 风格）。
 // 探测完 maxPerHop 后一次性输出最终统计到 stdout，不进入 alternate screen。
-func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, wide bool, showIPs bool) error {
+func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, wide bool, showIPs bool, columns ...printer.MTRColumn) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -179,6 +179,7 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 	}
 
 	printer.MTRReportPrint(finalStats, printer.MTRReportOptions{
+		Columns:   columns,
 		StartTime: startTime,
 		SrcHost:   srcHost,
 		Wide:      wide,

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nxtrace/NTrace-core/printer"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
+	"golang.org/x/term"
 )
 
 const defaultMTRInternalTTLIntervalMs = 0
@@ -61,11 +62,15 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 
 	// 初始化 TUI 控制器
 	ui := newMTRUI(cancel, initialDisplayMode)
+	ui.columns = append([]printer.MTRColumn(nil), columns...)
 	ui.Enter()
 	defer ui.Leave()
 
 	// 按键读取协程（非 TTY 时内部 no-op）
-	go ui.ReadKeysLoop(ctx)
+	keysCtx, stopKeys := context.WithCancel(ctx)
+	keysDone := make(chan struct{})
+	go func() { defer close(keysDone); ui.ReadKeysLoop(keysCtx) }()
+	defer func() { stopKeys(); <-keysDone }()
 
 	startTime := time.Now()
 	target := conf.DstIP.String()
@@ -92,10 +97,28 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	var onSnapshot trace.MTROnSnapshot
 	if ui.IsTTY() {
 		opts.IsPaused = ui.IsPaused
-		onSnapshot = printer.MTRTUIPrinter(target, domain, target, config.Version, startTime,
+		var frameColumns []printer.MTRColumn
+		var frameEditor printer.MTRColumnEditor
+		render := printer.MTRTUIPrinter(target, domain, target, config.Version, startTime,
 			srcHost, srcIP, lang, func() string { return buildAPIInfo(dataOrigin) }, showIPs, ui.IsPaused,
 			ui.CurrentDisplayMode, ui.CurrentNameMode, ui.IsMPLSDisabled,
-			ui.IsHistoryMode, ui.CurrentHistoryChartMode, history.Snapshot, func() ([]printer.MTRColumn, printer.MTRColumnEditor) { return columns, printer.MTRColumnEditor{} })
+			ui.IsHistoryMode, ui.CurrentHistoryChartMode, history.Snapshot, func() ([]printer.MTRColumn, printer.MTRColumnEditor) { return frameColumns, frameEditor })
+		pasteEnabled := false
+		var stopRedraw func()
+		onSnapshot, stopRedraw = startMTRRedraw(ui.redraw, func() (int, int) { w, h, _ := term.GetSize(int(os.Stdout.Fd())); return w, h }, func(n int, stats []trace.MTRHopStat) {
+			frameColumns, frameEditor = ui.columnSnapshot()
+			if frameEditor.Active != pasteEnabled {
+				pasteEnabled = frameEditor.Active
+				if pasteEnabled {
+					fmt.Fprint(os.Stdout, "\033[?2004h")
+				} else {
+					fmt.Fprint(os.Stdout, "\033[?2004l")
+				}
+			}
+			render(n, stats)
+		})
+		defer stopRedraw()
+
 	} else {
 		onSnapshot = func(iteration int, stats []trace.MTRHopStat) {
 			printer.MTRTablePrinterWithColumns(stats, iteration, ui.CurrentDisplayMode(), ui.CurrentNameMode(), lang, showIPs, columns)

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -110,15 +110,14 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 			if frameEditor.Active != pasteEnabled {
 				pasteEnabled = frameEditor.Active
 				if pasteEnabled {
-					fmt.Fprint(os.Stdout, "\033[?2004h")
+					_, _ = fmt.Fprint(os.Stdout, "\033[?2004h")
 				} else {
-					fmt.Fprint(os.Stdout, "\033[?2004l")
+					_, _ = fmt.Fprint(os.Stdout, "\033[?2004l")
 				}
 			}
 			render(n, stats)
 		})
 		defer stopRedraw()
-
 	} else {
 		onSnapshot = func(iteration int, stats []trace.MTRHopStat) {
 			printer.MTRTablePrinterWithColumns(stats, iteration, ui.CurrentDisplayMode(), ui.CurrentNameMode(), lang, showIPs, columns)

--- a/cmd/mtr_redraw.go
+++ b/cmd/mtr_redraw.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"sync"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+// One worker owns all frame writes, including input and resize redraws. Probe
+// callbacks only replace the immutable latest snapshot and coalesce a wakeup.
+func startMTRRedraw(notify chan struct{}, size func() (int, int), render trace.MTROnSnapshot) (trace.MTROnSnapshot, func()) {
+	var mu sync.Mutex
+	var latest []trace.MTRHopStat
+	iteration := 0
+	stopped := false
+	stop, done := make(chan struct{}), make(chan struct{})
+	draw := func() {
+		mu.Lock()
+		stats, n := latest, iteration
+		mu.Unlock()
+		render(n, stats)
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		width, height := size()
+		draw()
+		for {
+			select {
+			case <-stop:
+				draw()
+				return
+			case <-notify:
+				draw()
+			case <-ticker.C:
+				w, h := size()
+				if w != width || h != height {
+					width, height = w, h
+					draw()
+				}
+			}
+		}
+	}()
+	snapshot := func(n int, stats []trace.MTRHopStat) {
+		mu.Lock()
+		defer mu.Unlock()
+		if stopped {
+			return
+		}
+		iteration = n
+		latest = cloneMTRDisplayStats(stats)
+		select {
+		case notify <- struct{}{}:
+		default:
+		}
+	}
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() { mu.Lock(); stopped = true; mu.Unlock(); close(stop); <-done })
+	}
+	return snapshot, cleanup
+}
+
+func cloneMTRDisplayStats(stats []trace.MTRHopStat) []trace.MTRHopStat {
+	result := append([]trace.MTRHopStat(nil), stats...)
+	for i := range result {
+		s := &result[i]
+		s.MPLS = append([]string(nil), s.MPLS...)
+		if s.Geo != nil {
+			geo := *s.Geo
+			s.Geo = &geo
+		}
+		if s.Response != nil {
+			response := *s.Response
+			s.Response = &response
+		}
+	}
+	return result
+}

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -3,9 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/nxtrace/NTrace-core/printer"
 	"io"
 	"os"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"golang.org/x/term"
 )
@@ -16,16 +19,20 @@ import (
 
 // mtrUI 管理终端交互状态：备份屏幕、raw mode、按键处理。
 type mtrUI struct {
-	isTTY       bool
-	oldState    *term.State // raw mode 之前的终端状态
-	paused      atomic.Bool
-	restartReq  atomic.Bool
-	displayMode atomic.Int32 // 显示模式 0-4
-	nameMode    atomic.Int32 // Host 基础显示 0=PTR/IP, 1=IP only
-	disableMPLS atomic.Bool
-	historyMode atomic.Bool
-	chartMode   atomic.Int32 // history chart mode 0-2
-	cancel      context.CancelFunc
+	columnsMu    sync.Mutex
+	columns      []printer.MTRColumn
+	columnEditor printer.MTRColumnEditor
+	redraw       chan struct{}
+	isTTY        bool
+	oldState     *term.State // raw mode 之前的终端状态
+	paused       atomic.Bool
+	restartReq   atomic.Bool
+	displayMode  atomic.Int32 // 显示模式 0-4
+	nameMode     atomic.Int32 // Host 基础显示 0=PTR/IP, 1=IP only
+	disableMPLS  atomic.Bool
+	historyMode  atomic.Bool
+	chartMode    atomic.Int32 // history chart mode 0-2
+	cancel       context.CancelFunc
 }
 
 // newMTRUI 创建 TUI 控制器。cancel 是用于退出 MTR 的 context cancel 函数。
@@ -33,6 +40,7 @@ type mtrUI struct {
 // stdin 和 stdout 都必须是终端才会启用交互式 TUI。
 func newMTRUI(cancel context.CancelFunc, initialDisplayMode int) *mtrUI {
 	ui := &mtrUI{
+		redraw: make(chan struct{}, 1),
 		isTTY:  term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())),
 		cancel: cancel,
 	}
@@ -221,13 +229,17 @@ const (
 	mtrActionMPLSToggle                          // e
 	mtrActionHistoryToggle                       // d
 	mtrActionHistoryChart                        // g
+	mtrActionColumns
+	mtrActionPasteStart
 )
 
 // mtrInputParser 是一个字节级状态机，能区分普通按键与
 // CSI/SS3/OSC/鼠标/焦点等转义序列，对后者整体吞掉。
 type mtrInputParser struct {
-	state mtrParserState
-	csiN  int // CSI 体内已读字节数（用于限制吞掉长度）
+	state      mtrParserState
+	trackPaste bool
+	csi        string
+	csiN       int // CSI 体内已读字节数（用于限制吞掉长度）
 }
 
 type mtrParserState int
@@ -282,6 +294,7 @@ func (p *mtrInputParser) feedEsc(b byte) mtrInputAction {
 	case '[':
 		p.state = mtrStateCSI
 		p.csiN = 0
+		p.csi = ""
 	case 'O':
 		p.state = mtrStateSS3
 	case ']':
@@ -294,6 +307,13 @@ func (p *mtrInputParser) feedEsc(b byte) mtrInputAction {
 
 func (p *mtrInputParser) feedCSI(b byte) mtrInputAction {
 	p.csiN++
+	if p.trackPaste && len(p.csi) < mtrParserMaxCSI {
+		p.csi += string(b)
+	}
+	if p.trackPaste && p.csi == "200~" {
+		p.state = mtrStateGround
+		return mtrActionPasteStart
+	}
 	switch {
 	case b == 'M':
 		p.state = mtrStateX10Mouse
@@ -361,6 +381,8 @@ func mapKeyToAction(b byte) mtrInputAction {
 		return mtrActionHistoryToggle
 	case 'g', 'G':
 		return mtrActionHistoryChart
+	case 'o', 'O':
+		return mtrActionColumns
 	default:
 		return mtrActionNone
 	}
@@ -389,48 +411,49 @@ func (u *mtrUI) ReadKeysLoop(ctx context.Context) {
 }
 
 func (u *mtrUI) readKeysLoop(ctx context.Context, input io.Reader) {
-	var parser mtrInputParser
-	buf := make([]byte, 64) // 批量读取，减少 syscall
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	// The reader never writes to the terminal. Cancellation stops the parser even
+	// when an injected reader cannot be interrupted.
+	chunks := make(chan []byte)
+	go func() {
+		defer close(chunks)
+		buf := make([]byte, 64)
+		for {
+			n, err := input.Read(buf)
+			if n > 0 {
+				select {
+				case chunks <- append([]byte(nil), buf[:n]...):
+				case <-ctx.Done():
+					return
+				}
+			}
+			if err != nil || n == 0 {
+				return
+			}
+		}
+	}()
+	var keys mtrKeyInput
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-		}
-		n, err := input.Read(buf)
-		if err != nil || n == 0 {
-			if err == io.EOF {
+		case now := <-ticker.C:
+			keys.expireEscape(u, now)
+		case data, ok := <-chunks:
+			if !ok {
 				return
 			}
-			return
-		}
-		for i := 0; i < n; i++ {
-			action := parser.Feed(buf[i])
-			switch action {
-			case mtrActionQuit:
-				if u.cancel != nil {
-					u.cancel()
+			for _, b := range data {
+				if ctx.Err() != nil || keys.feed(u, b, time.Now()) {
+					return
 				}
-				return
-			case mtrActionPause:
-				u.paused.Store(true)
-			case mtrActionResume:
-				u.paused.Store(false)
-			case mtrActionRestart:
-				u.restartReq.Store(true)
-			case mtrActionDisplayMode:
-				u.CycleDisplayMode()
-			case mtrActionNameToggle:
-				u.ToggleNameMode()
-			case mtrActionMPLSToggle:
-				u.ToggleMPLS()
-			case mtrActionHistoryToggle:
-				u.ToggleHistoryMode()
-			case mtrActionHistoryChart:
-				u.CycleHistoryChartMode()
 			}
 		}
 	}
+
 }
 
 // ConsumeRestartRequest 原子读取并清除重置请求标志。
@@ -461,6 +484,8 @@ func ParseMTRKey(b byte) string {
 		return "history_toggle"
 	case 'g', 'G':
 		return "history_chart"
+	case 'o', 'O':
+		return "columns"
 	default:
 		return ""
 	}

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/nxtrace/NTrace-core/printer"
 	"io"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/nxtrace/NTrace-core/printer"
 	"golang.org/x/term"
 )
 
@@ -453,7 +453,6 @@ func (u *mtrUI) readKeysLoop(ctx context.Context, input io.Reader) {
 			}
 		}
 	}
-
 }
 
 // ConsumeRestartRequest 原子读取并清除重置请求标志。

--- a/cmd/mtr_ui_fuzz_test.go
+++ b/cmd/mtr_ui_fuzz_test.go
@@ -17,7 +17,7 @@ func FuzzMTRInputParser(f *testing.F) {
 		var parser mtrInputParser
 		for _, b := range data {
 			action := parser.Feed(b)
-			if action < mtrActionNone || action > mtrActionHistoryChart {
+			if action < mtrActionNone || action > mtrActionPasteStart {
 				t.Fatalf("action = %d, outside known range", action)
 			}
 		}

--- a/cmd/speed_mode.go
+++ b/cmd/speed_mode.go
@@ -55,7 +55,7 @@ func maybeRunSpeedModeWithAvailability(enabled bool, rawArgs []string, stdout, s
 		return true, 1
 	}
 	if containsMTRColumnsFlag(rawArgs) {
-		fmt.Fprintln(stderr, "--mtr-columns cannot be combined with a standalone mode")
+		_, _ = fmt.Fprintln(stderr, "--mtr-columns cannot be combined with a standalone mode")
 		return true, 2
 	}
 	return true, runSpeedMode(rawArgs, stdout, stderr)

--- a/cmd/speed_mode.go
+++ b/cmd/speed_mode.go
@@ -54,6 +54,10 @@ func maybeRunSpeedModeWithAvailability(enabled bool, rawArgs []string, stdout, s
 		_, _ = fmt.Fprintln(stderr, "--traceroute cannot be combined with --speed")
 		return true, 1
 	}
+	if containsMTRColumnsFlag(rawArgs) {
+		fmt.Fprintln(stderr, "--mtr-columns cannot be combined with a standalone mode")
+		return true, 2
+	}
 	return true, runSpeedMode(rawArgs, stdout, stderr)
 }
 

--- a/printer/mtr_columns.go
+++ b/printer/mtr_columns.go
@@ -1,0 +1,149 @@
+package printer
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+// MTRColumn selects a human-readable statistic; it never changes probe data.
+type MTRColumn uint8
+
+const (
+	MTRColumnLoss MTRColumn = iota
+	MTRColumnSnt
+	MTRColumnReceived
+	MTRColumnLast
+	MTRColumnAvg
+	MTRColumnBest
+	MTRColumnWrst
+	MTRColumnStDev
+)
+
+var mtrColumnDefinitions = [...]struct {
+	name, title string
+	code        byte
+}{
+	{"loss", "Loss%", 'L'}, {"snt", "Snt", 'S'}, {"received", "Rcv", 'R'},
+	{"last", "Last", 'N'}, {"avg", "Avg", 'A'}, {"best", "Best", 'B'},
+	{"wrst", "Wrst", 'W'}, {"stdev", "StDev", 'V'},
+}
+
+func DefaultMTRColumns() []MTRColumn {
+	return []MTRColumn{MTRColumnLoss, MTRColumnSnt, MTRColumnLast, MTRColumnAvg, MTRColumnBest, MTRColumnWrst, MTRColumnStDev}
+}
+
+// ParseMTRColumns accepts comma-separated CLI names, or space-separated TUI codes.
+func ParseMTRColumns(input string, codes bool) ([]MTRColumn, error) {
+	tokens := strings.Split(strings.ToLower(input), ",")
+	if codes {
+		tokens = nil
+		for _, c := range strings.ToUpper(input) {
+			if c != ' ' {
+				tokens = append(tokens, string(c))
+			}
+		}
+	}
+	var columns []MTRColumn
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		found := false
+		for i, def := range mtrColumnDefinitions {
+			if (!codes && token == def.name) || (codes && token == string(def.code)) {
+				columns = append(columns, MTRColumn(i))
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("unknown MTR column %q", token)
+		}
+	}
+	if err := ValidateMTRColumns(columns); err != nil {
+		return nil, err
+	}
+	return columns, nil
+}
+
+func ValidateMTRColumns(columns []MTRColumn) error {
+	if len(columns) == 0 {
+		return fmt.Errorf("select at least one MTR column")
+	}
+	seen := make(map[MTRColumn]bool)
+	for _, c := range columns {
+		if int(c) >= len(mtrColumnDefinitions) {
+			return fmt.Errorf("unknown MTR column %d", c)
+		}
+		if seen[c] {
+			return fmt.Errorf("duplicate MTR column %s", mtrColumnDefinitions[c].name)
+		}
+		seen[c] = true
+	}
+	return nil
+}
+
+func MTRColumnCodes(columns []MTRColumn) string {
+	var b strings.Builder
+	for _, c := range columns {
+		if int(c) < len(mtrColumnDefinitions) {
+			b.WriteByte(mtrColumnDefinitions[c].code)
+		}
+	}
+	return b.String()
+}
+
+func isDefaultMTRColumns(columns []MTRColumn) bool { return slices.Equal(columns, DefaultMTRColumns()) }
+
+func mtrColumnValue(c MTRColumn, s trace.MTRHopStat) string {
+	if isWaitingHopStat(s) {
+		return ""
+	}
+	switch c {
+	case MTRColumnLoss:
+		return formatLoss(s.Loss)
+	case MTRColumnSnt:
+		return fmt.Sprint(s.Snt)
+	case MTRColumnReceived:
+		return fmt.Sprint(s.Received)
+	case MTRColumnLast:
+		return formatMs(s.Last)
+	case MTRColumnAvg:
+		return formatMs(s.Avg)
+	case MTRColumnBest:
+		return formatMs(s.Best)
+	case MTRColumnWrst:
+		return formatMs(s.Wrst)
+	case MTRColumnStDev:
+		return formatMs(s.StDev)
+	default:
+		return ""
+	}
+}
+
+func mtrColumnWidths(columns []MTRColumn, stats []trace.MTRHopStat) []int {
+	widths := make([]int, len(columns))
+	for i, c := range columns {
+		widths[i] = len(mtrColumnDefinitions[c].title)
+		for _, s := range stats {
+			widths[i] = max(widths[i], len(mtrColumnValue(c, s)))
+		}
+	}
+	return widths
+}
+
+func mtrSelectedMetrics(columns []MTRColumn, widths []int, stat *trace.MTRHopStat, colorize bool) string {
+	cells := make([]string, len(columns))
+	for i, c := range columns {
+		value := mtrColumnDefinitions[c].title
+		if stat != nil {
+			value = mtrColumnValue(c, *stat)
+		}
+		cells[i] = padLeft(value, widths[i])
+		if colorize && stat != nil && (c == MTRColumnLoss || c == MTRColumnSnt || c == MTRColumnReceived) {
+			cells[i], _ = mtrColorPacketsByLoss(cells[i], "", stat.Loss, isWaitingHopStat(*stat))
+		}
+	}
+	return strings.Join(cells, " ")
+}

--- a/printer/mtr_columns.go
+++ b/printer/mtr_columns.go
@@ -49,6 +49,9 @@ func ParseMTRColumns(input string, codes bool) ([]MTRColumn, error) {
 	var columns []MTRColumn
 	for _, token := range tokens {
 		token = strings.TrimSpace(token)
+		if token == "" {
+			return nil, fmt.Errorf("empty MTR column entry")
+		}
 		found := false
 		for i, def := range mtrColumnDefinitions {
 			if (!codes && token == def.name) || (codes && token == string(def.code)) {

--- a/printer/mtr_columns_layout.go
+++ b/printer/mtr_columns_layout.go
@@ -2,12 +2,13 @@ package printer
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/nxtrace/NTrace-core/trace"
-	"github.com/rodaine/table"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/rodaine/table"
 )
 
 // MTRColumnEditor is an immutable frame snapshot supplied by the TUI controller.

--- a/printer/mtr_columns_layout.go
+++ b/printer/mtr_columns_layout.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rodaine/table"
 	"os"
 	"strings"
+	"time"
 )
 
 // MTRColumnEditor is an immutable frame snapshot supplied by the TUI controller.
@@ -122,5 +123,21 @@ func printMTRSelectedReport(stats []trace.MTRHopStat, opts MTRReportOptions, hos
 	for i, s := range stats {
 		fmt.Printf("%s%s %s\n", mtrReportPrefix(s.TTL, prevTTL), reportPadRight(hosts[i], hostW), mtrSelectedMetrics(opts.Columns, widths, &s, false))
 		prevTTL = s.TTL
+	}
+}
+
+// Keep custom frames within the terminal even when the legacy shortcut bar
+// would wrap over the data. O remains visible in the narrowest supported view.
+func renderMTRSelectedHeader(b *strings.Builder, header MTRTUIHeader, width int) {
+	tuiLine(b, "%s", buildMTRTUITitleLine(header, width))
+	if width < 40 {
+		tuiLine(b, "%s", truncateByDisplayWidth(buildMTRTUIRouteText(header), width))
+	} else {
+		tuiLine(b, "%s", buildMTRTUIRouteLine(header, width, time.Now()))
+	}
+	if width >= 160 {
+		tuiLine(b, "%s", buildMTRTUIControlsLine(header, width))
+	} else {
+		tuiLine(b, "%s", truncateByDisplayWidth("O:cols Q:quit "+mtrTUIStatusText(header.Status), width))
 	}
 }

--- a/printer/mtr_columns_layout.go
+++ b/printer/mtr_columns_layout.go
@@ -16,9 +16,22 @@ type MTRColumnEditor struct {
 }
 
 func renderMTRColumnEditor(b *strings.Builder, editor MTRColumnEditor, width int) {
-	for _, line := range []string{"L=Loss S=Snt R=Received N=Last", "A=Avg B=Best W=Wrst V=StDev", "Enter: apply  Esc: cancel", "Backspace: delete  Ctrl-U: clear"} {
-		tuiLine(b, "%s", truncateByDisplayWidth(line, width))
+	var line string
+	for _, word := range strings.Fields("L=Loss S=Snt R=Received N=Last A=Avg B=Best W=Wrst V=StDev") {
+		if line != "" && len(line)+1+len(word) > width {
+			tuiLine(b, "%s", line)
+			line = ""
+		}
+		if line != "" {
+			line += " "
+		}
+		line += word
 	}
+	tuiLine(b, "%s", truncateByDisplayWidth(line, width))
+	for _, help := range []string{"Enter: apply Esc: cancel", "Backspace: delete", "Ctrl-U: clear"} {
+		tuiLine(b, "%s", truncateByDisplayWidth(help, width))
+	}
+
 	prefix := "Columns: "
 	available := max(1, width-len(prefix)-1)
 	draft := editor.Draft

--- a/printer/mtr_columns_layout.go
+++ b/printer/mtr_columns_layout.go
@@ -1,0 +1,113 @@
+package printer
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/rodaine/table"
+	"os"
+	"strings"
+)
+
+// MTRColumnEditor is an immutable frame snapshot supplied by the TUI controller.
+type MTRColumnEditor struct {
+	Active       bool
+	Draft, Error string
+}
+
+func renderMTRColumnEditor(b *strings.Builder, editor MTRColumnEditor, width int) {
+	for _, line := range []string{"L=Loss S=Snt R=Received N=Last", "A=Avg B=Best W=Wrst V=StDev", "Enter: apply  Esc: cancel", "Backspace: delete  Ctrl-U: clear"} {
+		tuiLine(b, "%s", truncateByDisplayWidth(line, width))
+	}
+	prefix := "Columns: "
+	available := max(1, width-len(prefix)-1)
+	draft := editor.Draft
+	if len(draft) > available {
+		draft = draft[len(draft)-available:]
+	}
+	tuiLine(b, "%s", truncateByDisplayWidth(prefix+draft+"_", width))
+	if editor.Error != "" {
+		tuiLine(b, "%s", truncateByDisplayWidth(editor.Error, width))
+	}
+}
+
+func renderMTRSelectedColumns(b *strings.Builder, header MTRTUIHeader, stats []trace.MTRHopStat, width int) {
+	columns := header.Columns
+	widths := mtrColumnWidths(columns, stats)
+	maxTTL, _ := scanMTRTUIStats(stats)
+	prefixW := max(tuiPrefixW, len(fmt.Sprint(maxTTL))+2)
+	metricsW := len(mtrSelectedMetrics(columns, widths, nil, false))
+	hostW := width - prefixW - 1 - metricsW
+	if hostW < tuiHostMin {
+		for _, line := range []string{"Select fewer columns", "or widen terminal (O)."} {
+			tuiLine(b, "%s", truncateByDisplayWidth(line, width))
+		}
+		return
+	}
+	prefix := strings.Repeat(" ", prefixW)
+	if isDefaultMTRColumns(columns) {
+		packetsW := widths[0] + 1 + widths[1]
+		tuiLine(b, "%s", prefix+padRight("Host", hostW)+" "+mtrTUIHeaderColor(centerIn("Packets", packetsW)+" "+centerIn("Pings", metricsW-packetsW-1)))
+		tuiLine(b, "%s", prefix+strings.Repeat(" ", hostW)+" "+mtrTUIHeaderColor(mtrSelectedMetrics(columns, widths, nil, false)))
+	} else {
+		tuiLine(b, "%s", prefix+mtrTUIHeaderColor(padRight("Host", hostW)+" "+mtrSelectedMetrics(columns, widths, nil, false)))
+	}
+	parts := buildTUIHostPartSet(stats, header)
+	asnW := computeTUIASNWidthFromParts(parts)
+	prevTTL := 0
+	for i, stat := range stats {
+		host := fitMTRHostWithMarker(formatTUIHost(parts[i], asnW), mtrResponseMarker(stat), hostW)
+		hostStyle := mtrTUIHostColor
+		if isWaitingHopStat(stat) {
+			hostStyle = mtrTUIWaitColor
+		}
+		tuiLine(b, "%s", mtrTUIHopColor(formatTUIHopPrefix(stat.TTL, prevTTL, prefixW))+hostStyle(host)+" "+mtrSelectedMetrics(columns, widths, &stat, true))
+		renderMTRTUIMPLSRows(b, mtrTUILayout{prefixW: prefixW, hostW: hostW}, stat.MPLS, header.DisableMPLS)
+		prevTTL = stat.TTL
+	}
+}
+
+// MTRTablePrinterWithColumns preserves Hop/Host placement and the default wrapper.
+func MTRTablePrinterWithColumns(stats []trace.MTRHopStat, iteration, mode, nameMode int, lang string, showIPs bool, columns []MTRColumn) {
+	if columns == nil {
+		MTRTablePrinter(stats, iteration, mode, nameMode, lang, showIPs)
+		return
+	}
+	fmt.Print("\033[H\033[2J")
+	headers := []any{"Hop"}
+	for _, c := range columns {
+		headers = append(headers, mtrColumnDefinitions[c].title)
+	}
+	headers = append(headers, "Host")
+	tbl := table.New(headers...).WithWriter(os.Stdout)
+	tbl.WithHeaderFormatter(color.New(color.FgGreen, color.Underline).SprintfFunc()).WithFirstColumnFormatter(color.New(color.FgYellow).SprintfFunc())
+	prevTTL := 0
+	for _, s := range stats {
+		hop := fmt.Sprint(s.TTL)
+		if s.TTL == prevTTL {
+			hop = ""
+		}
+		prevTTL = s.TTL
+		row := []any{hop}
+		for _, c := range columns {
+			row = append(row, mtrColumnValue(c, s))
+		}
+		row = append(row, appendMTRResponseMarker(formatMTRHostWithMPLS(s, mode, nameMode, lang, showIPs), s))
+		tbl.AddRow(row...)
+	}
+	tbl.Print()
+}
+
+func printMTRSelectedReport(stats []trace.MTRHopStat, opts MTRReportOptions, hosts []string, hostW int) {
+	widths := mtrColumnWidths(opts.Columns, stats)
+	hostHeader := opts.SrcHost
+	if !opts.Wide {
+		hostHeader = reportTruncateToWidth(hostHeader, hostW)
+	}
+	fmt.Printf("HOST: %s %s\n", reportPadRight(hostHeader, hostW), mtrSelectedMetrics(opts.Columns, widths, nil, false))
+	prevTTL := 0
+	for i, s := range stats {
+		fmt.Printf("%s%s %s\n", mtrReportPrefix(s.TTL, prevTTL), reportPadRight(hosts[i], hostW), mtrSelectedMetrics(opts.Columns, widths, &s, false))
+		prevTTL = s.TTL
+	}
+}

--- a/printer/mtr_columns_test.go
+++ b/printer/mtr_columns_test.go
@@ -2,10 +2,12 @@ package printer
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/nxtrace/NTrace-core/trace"
 )
 
@@ -131,5 +133,49 @@ func TestMTRCustomFrameAndEditorStayWithinTerminal(t *testing.T) {
 				t.Fatal("missing O hint")
 			}
 		}
+	}
+}
+
+func TestMTRColumnsDistinguishesEmptyAndUnknownEntries(t *testing.T) {
+	for _, input := range []string{"", " ", ",loss", "loss,", "loss,,snt", "loss, ,snt"} {
+		_, err := ParseMTRColumns(input, false)
+		if err == nil || err.Error() != "empty MTR column entry" {
+			t.Fatalf("input %q: %v", input, err)
+		}
+	}
+	_, err := ParseMTRColumns("jitter", false)
+	if err == nil || err.Error() != `unknown MTR column "jitter"` {
+		t.Fatalf("unknown column: %v", err)
+	}
+}
+
+func TestMTRDefaultControlsFitTerminal(t *testing.T) {
+	for _, width := range []int{24, 40, 60, 80, 120, 160, 200} {
+		for _, history := range []bool{false, true} {
+			line := buildMTRTUIControlsLine(MTRTUIHeader{HistoryMode: history}, width)
+			if displayWidth(line) > width {
+				t.Fatalf("width %d: %q", width, line)
+			}
+			if !strings.Contains(line, "O") {
+				t.Fatal("missing column editor hint")
+			}
+		}
+	}
+	line := buildMTRTUIControlsLine(MTRTUIHeader{}, 120)
+	for _, hint := range []string{"O-columns", "Y-display", "N-host", "D-history(off)"} {
+		if !strings.Contains(line, hint) {
+			t.Fatalf("missing %q: %s", hint, line)
+		}
+	}
+}
+
+func TestMTRDefaultControlsMeasureVisibleColorWidth(t *testing.T) {
+	old := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = old })
+	line := buildMTRTUIControlsLine(MTRTUIHeader{}, 120)
+	plain := regexp.MustCompile(`\x1b\[[0-9;]*m`).ReplaceAllString(line, "")
+	if displayWidth(plain) > 120 || !strings.Contains(plain, "D-history(off)") {
+		t.Fatalf("colored controls: %q", line)
 	}
 }

--- a/printer/mtr_columns_test.go
+++ b/printer/mtr_columns_test.go
@@ -1,7 +1,10 @@
 package printer
 
 import (
+	"fmt"
+	"github.com/nxtrace/NTrace-core/trace"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -38,5 +41,69 @@ func TestMTRColumnContract(t *testing.T) {
 		if _, err := ParseMTRColumns(s, true); err == nil {
 			t.Errorf("accepted %q", s)
 		}
+	}
+}
+
+func TestMTRSelectedLayoutPreservesCompleteNumbers(t *testing.T) {
+	columns, _ := ParseMTRColumns("received,stdev,loss,snt,last,avg,best,wrst", false)
+	maxInt := int(^uint(0) >> 1)
+	stats := []trace.MTRHopStat{
+		{TTL: 1, IP: "192.0.2.1", Host: "中文主机.example.test", Snt: maxInt, Received: 1000, Last: 0, Avg: 1.23, Best: 0, Wrst: 99999.99, StDev: 12.34, MPLS: []string{"[MPLS: Lbl 123 Exp 0 S 1 TTL 1]"}},
+		{TTL: 1, IP: "192.0.2.2", Snt: 1000, Received: 999, Loss: 0.1},
+		{TTL: 2, Loss: 100, Snt: 1000},
+	}
+	before := fmt.Sprint(stats)
+	for _, width := range []int{24, 40, 60, 80, 120, 200} {
+		var b strings.Builder
+		renderMTRSelectedColumns(&b, MTRTUIHeader{Columns: columns, Lang: "cn"}, stats, width)
+		out := b.String()
+		for _, line := range strings.Split(out, "\r\n") {
+			if displayWidth(line) > width {
+				t.Fatalf("width %d overflow: %q", width, line)
+			}
+		}
+		if strings.Contains(out, "Select fewer") {
+			continue
+		}
+		for _, value := range []string{fmt.Sprint(maxInt), "1000", "99999.99", "0.00", "12.34", "Rcv"} {
+			if !strings.Contains(out, value) {
+				t.Fatalf("missing %s at %d: %s", value, width, out)
+			}
+		}
+		if strings.Contains(out, "Packets") || strings.Contains(out, "Pings") {
+			t.Fatal("misleading groups")
+		}
+	}
+	if fmt.Sprint(stats) != before {
+		t.Fatal("renderer changed statistics")
+	}
+	widths := mtrColumnWidths(columns, stats)
+	if widths[0] != 4 || widths[3] != len(fmt.Sprint(maxInt)) {
+		t.Fatalf("count widths %v", widths)
+	}
+	if strings.TrimSpace(mtrSelectedMetrics(columns, widths, &stats[2], false)) != "" {
+		t.Fatal("waiting metrics not blank")
+	}
+	if sntWidthForMax(maxInt) != len(fmt.Sprint(maxInt)) {
+		t.Fatal("max integer width")
+	}
+}
+
+func TestMTRSelectedReportAndTableOrder(t *testing.T) {
+	columns, _ := ParseMTRColumns("received,avg,loss", false)
+	stats := []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1", Snt: 1000, Received: 999, Avg: 1.23, Loss: 0.1}}
+	for _, wide := range []bool{false, true} {
+		out := captureStdout(t, func() { MTRReportPrint(stats, MTRReportOptions{Columns: columns, SrcHost: "source", Wide: wide}) })
+		if !strings.Contains(out, "Rcv  Avg Loss%") || !strings.Contains(out, "999 1.23  0.1%") || strings.Contains(out, "StDev") {
+			t.Fatal(out)
+		}
+	}
+	out := captureStdout(t, func() { MTRTablePrinterWithColumns(stats, 1, 0, 0, "cn", false, columns) })
+	for _, v := range []string{"Hop", "Rcv", "Avg", "Loss%", "Host"} {
+		i := strings.Index(out, v)
+		if i < 0 {
+			t.Fatal(out)
+		}
+		out = out[i+len(v):]
 	}
 }

--- a/printer/mtr_columns_test.go
+++ b/printer/mtr_columns_test.go
@@ -2,10 +2,11 @@ package printer
 
 import (
 	"fmt"
-	"github.com/nxtrace/NTrace-core/trace"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/nxtrace/NTrace-core/trace"
 )
 
 func TestMTRColumnContract(t *testing.T) {

--- a/printer/mtr_columns_test.go
+++ b/printer/mtr_columns_test.go
@@ -1,0 +1,42 @@
+package printer
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestMTRColumnContract(t *testing.T) {
+	for _, tt := range []struct{ names, codes string }{
+		{"loss,snt,last,avg,best,wrst,stdev", "LSNABWV"},
+		{"received", "r"}, {" LAST ", "n"},
+		{"loss,snt,received,last,avg,best,wrst,stdev", "L S R N A B W V"},
+		{"stdev,wrst,best,avg,last,received,snt,loss", "vwb anrsl"},
+		{"avg,received,loss,stdev,snt", "ARLVS"},
+	} {
+		a, err := ParseMTRColumns(tt.names, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := ParseMTRColumns(tt.codes, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Equal(a, b) {
+			t.Fatalf("%q != %q", a, b)
+		}
+		c, err := ParseMTRColumns(MTRColumnCodes(a), true)
+		if err != nil || !slices.Equal(a, c) {
+			t.Fatalf("roundtrip: %v", err)
+		}
+	}
+	for _, s := range []string{"", " ", ",", "loss,", ",snt", "loss,,snt", "loss,LOSS", "rcv", "jitter"} {
+		if _, err := ParseMTRColumns(s, false); err == nil {
+			t.Errorf("accepted %q", s)
+		}
+	}
+	for _, s := range []string{"", " ", "LL", "l L", "X", "L,S", "L\nS", "L\tS", "Ｌ"} {
+		if _, err := ParseMTRColumns(s, true); err == nil {
+			t.Errorf("accepted %q", s)
+		}
+	}
+}

--- a/printer/mtr_columns_test.go
+++ b/printer/mtr_columns_test.go
@@ -150,6 +150,9 @@ func TestMTRColumnsDistinguishesEmptyAndUnknownEntries(t *testing.T) {
 }
 
 func TestMTRDefaultControlsFitTerminal(t *testing.T) {
+	old := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = old })
 	for _, width := range []int{24, 40, 60, 80, 120, 160, 200} {
 		for _, history := range []bool{false, true} {
 			line := buildMTRTUIControlsLine(MTRTUIHeader{HistoryMode: history}, width)
@@ -170,10 +173,16 @@ func TestMTRDefaultControlsFitTerminal(t *testing.T) {
 }
 
 func TestMTRDefaultControlsMeasureVisibleColorWidth(t *testing.T) {
-	old := color.NoColor
-	color.NoColor = false
-	t.Cleanup(func() { color.NoColor = old })
+	oldKey, oldStatus := mtrTUIKeyHiColor, mtrTUIStatusColor
+	t.Cleanup(func() { mtrTUIKeyHiColor, mtrTUIStatusColor = oldKey, oldStatus })
+	key, status := color.New(color.FgHiWhite), color.New(color.FgHiYellow, color.Bold)
+	key.EnableColor()
+	status.EnableColor()
+	mtrTUIKeyHiColor, mtrTUIStatusColor = key.SprintFunc(), status.SprintFunc()
 	line := buildMTRTUIControlsLine(MTRTUIHeader{}, 120)
+	if !strings.Contains(line, "\x1b[") {
+		t.Fatalf("expected colored controls: %q", line)
+	}
 	plain := regexp.MustCompile(`\x1b\[[0-9;]*m`).ReplaceAllString(line, "")
 	if displayWidth(plain) > 120 || !strings.Contains(plain, "D-history(off)") {
 		t.Fatalf("colored controls: %q", line)

--- a/printer/mtr_columns_test.go
+++ b/printer/mtr_columns_test.go
@@ -107,3 +107,28 @@ func TestMTRSelectedReportAndTableOrder(t *testing.T) {
 		out = out[i+len(v):]
 	}
 }
+
+func TestMTRCustomFrameAndEditorStayWithinTerminal(t *testing.T) {
+	columns, _ := ParseMTRColumns("received,loss,snt,last,avg,best,wrst,stdev", false)
+	for _, width := range []int{24, 40, 60, 80, 120, 200} {
+		for _, editing := range []bool{false, true} {
+			header := MTRTUIHeader{Columns: columns, ColumnEditor: MTRColumnEditor{Active: editing, Draft: strings.Repeat("L", 256)}, Target: "192.0.2.1", SrcHost: "中文主机.example", Status: MTRTUIPaused}
+			out := mtrTUIRenderStringWithWidth(header, nil, width)
+			out = strings.TrimPrefix(out, "\x1b[H\x1b[2J")
+			for _, line := range strings.Split(out, "\r\n") {
+				if displayWidth(line) > width {
+					t.Fatalf("width %d: %q", width, line)
+				}
+			}
+			if editing {
+				for _, code := range []string{"L=Loss", "S=Snt", "R=Received", "N=Last", "A=Avg", "B=Best", "W=Wrst", "V=StDev"} {
+					if !strings.Contains(out, code) {
+						t.Fatalf("missing %s in %d: %s", code, width, out)
+					}
+				}
+			} else if !strings.Contains(out, "O") {
+				t.Fatal("missing O hint")
+			}
+		}
+	}
+}

--- a/printer/mtr_table.go
+++ b/printer/mtr_table.go
@@ -430,6 +430,7 @@ func formatMTRGeoData(data *ipgeo.IPGeoData) string {
 
 // MTRReportOptions 控制报告输出细节。
 type MTRReportOptions struct {
+	Columns   []MTRColumn
 	StartTime time.Time
 	SrcHost   string
 	Wide      bool
@@ -457,6 +458,10 @@ func MTRReportPrint(stats []trace.MTRHopStat, opts MTRReportOptions) {
 	fmt.Printf("Start: %s\n", opts.StartTime.Format("2006-01-02T15:04:05-0700"))
 
 	hosts, hostColW := prepareMTRReportHosts(stats, opts, lang)
+	if opts.Columns != nil {
+		printMTRSelectedReport(stats, opts, hosts, hostColW)
+		return
+	}
 	printMTRReportHeader(opts, hostColW)
 	printMTRReportRows(stats, hosts, hostColW)
 }

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -516,30 +516,40 @@ func resolveMTRTUIDestinationLabel(header MTRTUIHeader) string {
 
 func buildMTRTUIControlsLine(header MTRTUIHeader, termWidth int) string {
 	const keysPrefix = "Keys:  "
-	keyLine := strings.Join(buildMTRTUIKeyItems(header), "  ")
+	items := buildMTRTUIKeyItems(header, mtrTUIKeyHiColor)
+	plainItems := buildMTRTUIKeyItems(header, fmt.Sprint)
+	keyLine := strings.Join(items, "  ")
 	statusText := mtrTUIStatusText(header.Status)
 	statusTag := mtrTUIStatusColor("[" + statusText + "]")
-	pad := termWidth - displayWidth(keysPrefix) - displayWidth(keyLine) - len("["+statusText+"]")
+	pad := termWidth - displayWidth(keysPrefix) - displayWidth(strings.Join(plainItems, "  ")) - len("["+statusText+"]")
 	if pad < 2 {
-		pad = 2
+		keyLine = strings.Join(items, " ")
+		pad = termWidth - displayWidth(keysPrefix) - displayWidth(strings.Join(plainItems, " ")) - len("["+statusText+"]")
+	}
+	if pad < 2 {
+		compact := "O:cols Q:quit"
+		if header.HistoryMode {
+			compact += " G-chart(" + mtrTUIHistoryChartLabel(header.HistoryChartMode) + ")"
+		}
+		return truncateByDisplayWidth(compact+" "+statusText, termWidth)
 	}
 	return keysPrefix + keyLine + strings.Repeat(" ", pad) + statusTag
 }
 
-func buildMTRTUIKeyItems(header MTRTUIHeader) []string {
+func buildMTRTUIKeyItems(header MTRTUIHeader, highlight func(...any) string) []string {
 	items := []string{
-		mtrTUIKeyHiColor("Q") + "uit",
-		mtrTUIKeyHiColor("O") + "-columns",
-		mtrTUIKeyHiColor("P") + "ause",
-		mtrTUIKeyHiColor("Space") + "-resume",
-		mtrTUIKeyHiColor("R") + "eset",
-		mtrTUIKeyHiColor("Y") + "-display(" + mtrTUIDisplayModeLabel(header.DisplayMode) + ")",
-		mtrTUIKeyHiColor("N") + "-host(" + mtrTUINameModeLabel(header.NameMode, header.ShowIPs) + ")",
-		mtrTUIKeyHiColor("E") + "-mpls(" + mtrTUIMPLSLabel(header.DisableMPLS) + ")",
-		mtrTUIKeyHiColor("D") + "-history(" + mtrTUIHistoryModeLabel(header.HistoryMode) + ")",
+		highlight("Q") + "uit",
+		highlight("O") + "-columns",
+		highlight("P") + "ause",
+		highlight("Space") + "-resume",
+		highlight("R") + "eset",
+		highlight("Y") + "-display(" + mtrTUIDisplayModeLabel(header.DisplayMode) + ")",
+		highlight("N") + "-host(" + mtrTUINameModeLabel(header.NameMode, header.ShowIPs) + ")",
+		highlight("E") + "-mpls(" + mtrTUIMPLSLabel(header.DisableMPLS) + ")",
+		highlight("D") + "-history(" + mtrTUIHistoryModeLabel(header.HistoryMode) + ")",
 	}
 	if header.HistoryMode {
-		items = append(items, mtrTUIKeyHiColor("G")+"-chart("+mtrTUIHistoryChartLabel(header.HistoryChartMode)+")")
+		items = append(items, highlight("G")+"-chart("+mtrTUIHistoryChartLabel(header.HistoryChartMode)+")")
 	}
 	return items
 }

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -379,7 +379,7 @@ func mtrTUIRenderWithWidth(w io.Writer, header MTRTUIHeader, stats []trace.MTRHo
 		tuiLine(&b, "%s", buildMTRTUITitleLine(header, lo.termWidth))
 		tuiLine(&b, "%s", mtrTUIStatusText(header.Status))
 		renderMTRColumnEditor(&b, header.ColumnEditor, lo.termWidth)
-		fmt.Fprint(w, b.String())
+		_, _ = fmt.Fprint(w, b.String())
 		return
 	}
 	if header.Columns != nil && !header.HistoryMode {

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,10 +29,12 @@ const (
 
 // MTRTUIHeader 包含帧顶部显示的元信息。
 type MTRTUIHeader struct {
-	Target    string
-	StartTime time.Time
-	Status    MTRTUIStatus
-	Iteration int
+	Columns      []MTRColumn // nil preserves the original metrics layout
+	ColumnEditor MTRColumnEditor
+	Target       string
+	StartTime    time.Time
+	Status       MTRTUIStatus
+	Iteration    int
 	// 以下为 v2 新增字段
 	Domain   string // 用户输入的域名（可为空）
 	TargetIP string // 解析后的目标 IP
@@ -125,11 +128,7 @@ func tuiPrefixWidthForMaxTTL(maxTTL int) int {
 // sntWidthForMax returns the display width needed for the given max Snt value.
 // Minimum is tuiSntDefault (3).
 func sntWidthForMax(maxSnt int) int {
-	w := tuiSntDefault
-	for v := 1000; maxSnt >= v; v *= 10 {
-		w++
-	}
-	return w
+	return max(tuiSntDefault, len(strconv.Itoa(maxSnt)))
 }
 
 func computeLayout(termWidth, prefixW, sntHint int) mtrTUILayout {
@@ -377,13 +376,20 @@ func mtrTUIRenderWithWidth(w io.Writer, header MTRTUIHeader, stats []trace.MTRHo
 
 	writeMTRTUIFramePrefix(&b)
 	renderMTRTUIHeader(&b, header, lo.termWidth)
+	if header.ColumnEditor.Active {
+		renderMTRColumnEditor(&b, header.ColumnEditor, lo.termWidth)
+	}
 	if header.HistoryMode {
 		renderMTRTUIHistory(&b, header, stats, lo.termWidth)
 		fmt.Fprint(w, b.String())
 		return
 	}
-	renderDualHeader(&b, lo)
-	renderMTRTUIRows(&b, header, stats, lo)
+	if header.Columns != nil {
+		renderMTRSelectedColumns(&b, header, stats, lo.termWidth)
+	} else {
+		renderDualHeader(&b, lo)
+		renderMTRTUIRows(&b, header, stats, lo)
+	}
 	fmt.Fprint(w, b.String())
 }
 
@@ -515,6 +521,7 @@ func buildMTRTUIControlsLine(header MTRTUIHeader, termWidth int) string {
 func buildMTRTUIKeyItems(header MTRTUIHeader) []string {
 	items := []string{
 		mtrTUIKeyHiColor("Q") + "uit",
+		mtrTUIKeyHiColor("O") + "-columns",
 		mtrTUIKeyHiColor("P") + "ause",
 		mtrTUIKeyHiColor("Space") + "-resume",
 		mtrTUIKeyHiColor("R") + "eset",
@@ -1062,7 +1069,7 @@ func truncateStr(s string, maxLen int) string {
 func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time,
 	srcHost, srcIP, lang string, apiInfo func() string, showIPs bool,
 	isPaused func() bool, displayMode func() int, nameMode func() int, isMPLSDisabled func() bool,
-	isHistoryMode func() bool, historyChartMode func() int, historySnapshot func(time.Time) []MTRHistoryTTL) func(iteration int, stats []trace.MTRHopStat) {
+	isHistoryMode func() bool, historyChartMode func() int, historySnapshot func(time.Time) []MTRHistoryTTL, columnState ...func() ([]MTRColumn, MTRColumnEditor)) func(iteration int, stats []trace.MTRHopStat) {
 	var apiInfoMu sync.Mutex
 	var cachedAPIInfo string
 	var cachedAPIInfoAt time.Time
@@ -1113,7 +1120,14 @@ func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time
 			history = historySnapshot(now)
 		}
 		headerAPIInfo := getAPIInfo()
+		var columns []MTRColumn
+		var editor MTRColumnEditor
+		if len(columnState) > 0 && columnState[0] != nil {
+			columns, editor = columnState[0]()
+		}
 		MTRTUIRender(os.Stdout, MTRTUIHeader{
+			Columns:          columns,
+			ColumnEditor:     editor,
 			Target:           target,
 			StartTime:        startTime,
 			Status:           status,

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -375,10 +375,14 @@ func mtrTUIRenderWithWidth(w io.Writer, header MTRTUIHeader, stats []trace.MTRHo
 	var b strings.Builder
 
 	writeMTRTUIFramePrefix(&b)
-	renderMTRTUIHeader(&b, header, lo.termWidth)
 	if header.ColumnEditor.Active {
+		tuiLine(&b, "%s", buildMTRTUITitleLine(header, lo.termWidth))
+		tuiLine(&b, "%s", mtrTUIStatusText(header.Status))
 		renderMTRColumnEditor(&b, header.ColumnEditor, lo.termWidth)
+		fmt.Fprint(w, b.String())
+		return
 	}
+	renderMTRTUIHeader(&b, header, lo.termWidth)
 	if header.HistoryMode {
 		renderMTRTUIHistory(&b, header, stats, lo.termWidth)
 		fmt.Fprint(w, b.String())

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -382,7 +382,11 @@ func mtrTUIRenderWithWidth(w io.Writer, header MTRTUIHeader, stats []trace.MTRHo
 		fmt.Fprint(w, b.String())
 		return
 	}
-	renderMTRTUIHeader(&b, header, lo.termWidth)
+	if header.Columns != nil && !header.HistoryMode {
+		renderMTRSelectedHeader(&b, header, lo.termWidth)
+	} else {
+		renderMTRTUIHeader(&b, header, lo.termWidth)
+	}
 	if header.HistoryMode {
 		renderMTRTUIHistory(&b, header, stats, lo.termWidth)
 		fmt.Fprint(w, b.String())

--- a/scripts/test_mtr_columns_pty.py
+++ b/scripts/test_mtr_columns_pty.py
@@ -1,0 +1,115 @@
+"""Exercise the real MTR TUI on a Unix PTY using loopback probes only.
+
+Usage: python3 scripts/test_mtr_columns_pty.py /path/to/nexttrace
+Linux needs permission to open ICMP sockets (CI runs this under sudo).
+"""
+
+import fcntl
+import json
+import os
+import platform
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+
+
+def main(binary):
+    master, slave = pty.openpty()
+    original = termios.tcgetattr(slave)
+    log = bytearray()
+
+    def resize(width):
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 32, width, 0, 0))
+
+    def read(seconds=0.3):
+        end = time.monotonic() + seconds
+        data = bytearray()
+        while time.monotonic() < end:
+            if select.select([master], [], [], max(0, end - time.monotonic()))[0]:
+                try:
+                    data.extend(os.read(master, 65536))
+                except OSError:
+                    break
+        log.extend(data)
+        return data.decode(errors="replace")
+
+    def expect(*needles):
+        text = ""
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            text += read()
+            if all(needle in text for needle in needles):
+                return text
+        raise AssertionError(f"Missing {needles!r}: {text!r}")
+
+    def send(keys):
+        os.write(master, keys.encode())
+
+    def counters(text):
+        rows = re.findall(r"^ 1\. 127\.0\.0\.1\s+(.+)$", text, re.M)
+        assert rows, text
+        return rows[-1].split()
+
+    resize(120)
+    process = subprocess.Popen(
+        [os.path.abspath(binary), "-t", "--mtr-columns", "loss,snt,received,avg",
+         "-d", "disable-geoip", "-n", "-s", "127.0.0.1", "-m", "1",
+         "-i", "100", "--timeout", "100", "--no-color", "127.0.0.1"],
+        stdin=slave, stdout=slave, stderr=slave,
+    )
+    try:
+        expect("Rcv", " 1. 127.0.0.1")
+        send("p")
+        paused = expect("Paused") + read(0.6)  # Drain any in-flight probes.
+        send("o")
+        expect("Columns: LSRA_", "\x1b[?2004h")
+        send("\x15\x1b[200~r\nl s n a b w v\x1b[201~")
+        expect("Columns: r l s n a b w v_")
+        send("\r")
+        applied = expect("Rcv", "Last", "Paused", "\x1b[?2004l")
+        old, new = counters(paused), counters(applied)
+        assert old[1:3] == [new[2], new[0]], "Editing changed paused counters"
+
+        resize(24)
+        expect("Select fewer columns")
+        send("o")
+        expect("Columns: RLSNABWV_", "R=Received", "N=Last")
+        send("\x15l\x1b")
+        expect("Select fewer columns")  # Bare Esc needs no subsequent read.
+        resize(120)
+        expect("Rcv", "Paused")
+        send("d")
+        expect("History")
+        send("o\x15ar\r")
+        applied = expect("Avg", "Rcv", "Paused")
+        assert "History" not in applied.split("\x1b[H\x1b[2J")[-1], applied
+        send("q")
+        expect("\x1b[?1049l", "\x1b[?25h")
+        process.wait(timeout=3)
+        assert process.returncode == 0, process.returncode
+        assert termios.tcgetattr(slave) == original, "Terminal attributes not restored"
+        print(json.dumps({
+            "platform": platform.system(), "pty": "PASS",
+            "checks": ["loopback probes", "pause", "prefill", "paste newline",
+                       "apply", "unchanged paused counters", "narrow notice",
+                       "narrow editor", "bare Esc", "resize while paused",
+                       "history apply", "terminal restore"],
+        }, indent=2))
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        with open(os.path.join(tempfile.gettempdir(), "mtr-columns-pty.log"), "wb") as output:
+            output.write(log)
+        os.close(master)
+        os.close(slave)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/scripts/test_mtr_columns_pty.py
+++ b/scripts/test_mtr_columns_pty.py
@@ -1,40 +1,52 @@
-"""Exercise the real MTR TUI on a Unix PTY using loopback probes only.
+"""Exercise the real MTR TUI on a PTY using loopback probes only.
 
 Usage: python3 scripts/test_mtr_columns_pty.py /path/to/nexttrace
+Windows requires pywinpty==3.0.5 for ConPTY.
 Linux needs permission to open ICMP sockets (CI runs this under sudo).
 """
 
-import fcntl
 import json
 import os
 import platform
-import pty
 import re
 import select
 import struct
 import subprocess
 import sys
 import tempfile
-import termios
 import time
+
+if os.name != "nt":
+    import fcntl
+    import pty
+    import termios
 
 
 def main(binary):
-    master, slave = pty.openpty()
-    original = termios.tcgetattr(slave)
     log = bytearray()
+    windows = os.name == "nt"
+    if not windows:
+        master, slave = pty.openpty()
+        original = termios.tcgetattr(slave)
 
     def resize(width):
-        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 32, width, 0, 0))
+        if windows:
+            process.setwinsize(32, width)
+        else:
+            fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 32, width, 0, 0))
 
     def read(seconds=0.3):
         end = time.monotonic() + seconds
         data = bytearray()
         while time.monotonic() < end:
-            if select.select([master], [], [], max(0, end - time.monotonic()))[0]:
+            source = process.fileobj if windows else master
+            if select.select([source], [], [], max(0, end - time.monotonic()))[0]:
                 try:
-                    data.extend(os.read(master, 65536))
-                except OSError:
+                    chunk = process.read(65536).encode() if windows else os.read(master, 65536)
+                    if not chunk:
+                        break
+                    data.extend(chunk)
+                except (OSError, EOFError):
                     break
         log.extend(data)
         return data.decode(errors="replace")
@@ -49,20 +61,28 @@ def main(binary):
         raise AssertionError(f"Missing {needles!r}: {text!r}")
 
     def send(keys):
-        os.write(master, keys.encode())
+        if windows:
+            process.write(keys)
+        else:
+            os.write(master, keys.encode())
 
     def counters(text):
         rows = re.findall(r"^ 1\. 127\.0\.0\.1\s+(.+)$", text, re.M)
         assert rows, text
         return rows[-1].split()
 
-    resize(120)
-    process = subprocess.Popen(
-        [os.path.abspath(binary), "-t", "--mtr-columns", "loss,snt,received,avg",
-         "-d", "disable-geoip", "-n", "-s", "127.0.0.1", "-m", "1",
-         "-i", "100", "--timeout", "100", "--no-color", "127.0.0.1"],
-        stdin=slave, stdout=slave, stderr=slave,
-    )
+    command = [
+        os.path.abspath(binary), "-t", "--mtr-columns", "loss,snt,received,avg",
+        "-d", "disable-geoip", "-n", "-s", "127.0.0.1", "-m", "1",
+        "-i", "100", "--timeout", "100", "--no-color", "127.0.0.1",
+    ]
+    if windows:
+        from winpty import PtyProcess
+        process = PtyProcess.spawn(command, dimensions=(32, 120))
+    else:
+        resize(120)
+        process = subprocess.Popen(command, stdin=slave, stdout=slave, stderr=slave)
+
     try:
         expect("Rcv", " 1. 127.0.0.1")
         send("p")
@@ -91,9 +111,16 @@ def main(binary):
         assert "History" not in applied.split("\x1b[H\x1b[2J")[-1], applied
         send("q")
         expect("\x1b[?1049l", "\x1b[?25h")
-        process.wait(timeout=3)
-        assert process.returncode == 0, process.returncode
-        assert termios.tcgetattr(slave) == original, "Terminal attributes not restored"
+        if windows:
+            deadline = time.monotonic() + 3
+            while process.isalive() and time.monotonic() < deadline:
+                read(0.1)
+            assert not process.isalive(), "Process did not exit"
+            assert process.exitstatus == 0, process.exitstatus
+        else:
+            process.wait(timeout=3)
+            assert process.returncode == 0, process.returncode
+            assert termios.tcgetattr(slave) == original, "Terminal attributes not restored"
         print(json.dumps({
             "platform": platform.system(), "pty": "PASS",
             "checks": ["loopback probes", "pause", "prefill", "paste newline",
@@ -102,13 +129,16 @@ def main(binary):
                        "history apply", "terminal restore"],
         }, indent=2))
     finally:
-        if process.poll() is None:
+        if windows:
+            process.close(force=True)
+        elif process.poll() is None:
             process.kill()
             process.wait()
         with open(os.path.join(tempfile.gettempdir(), "mtr-columns-pty.log"), "wb") as output:
             output.write(log)
-        os.close(master)
-        os.close(slave)
+        if not windows:
+            os.close(master)
+            os.close(slave)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

- 为 MTR TUI、非 TTY 表格与 report/wide 添加 `--mtr-columns`，支持八项既有指标的非空子集和排序。
- TUI 按 `o/O` 编辑列，暂停期间仍支持编辑和窗口缩放；默认七列布局及 RAW/JSON schema 保持不变。

### Motivation

对应 nxtrace/NTrace-core#392：窄终端和专项排障需要选择统计列。直接复用现有统计值，不调整探测或统计算法。

### Changes

- printer 统一列定义、CLI 名称/TUI 字段码校验、完整数值宽度及顺序；新增 `Rcv` 标题。
- 在初始化前拒绝非 MTR 文字模式、未知列、重复列及空项；full/tiny/ntr 均覆盖。
- 自定义表格空间不足时显示提示；保留 Host 最小宽度、中文宽度、waiting、响应标记、MPLS 及颜色。
- 编辑草稿与快捷键隔离，支持 Enter/Esc/Backspace/Ctrl-U、50ms 裸 Esc 判断和括号粘贴。成功应用后从历史视图返回统计表。
- 单独任务串行输出快照、输入与缩放重绘，退出等待重绘停止后恢复终端。
- 评审修复：明确空列项诊断，初始化前拒绝 Windows `--init` 与列参数组合；按可见宽度压缩默认快捷键栏，保留历史图表提示。
- 增加 CLI 子进程、排版与并发测试、PTY/ConPTY 验收脚本及 Linux/macOS/Windows CI 接入；更新中英文 README 与帮助。

### Testing

- 本地通过：`go test ./...`、`go build ./...`。
- 本地通过：tiny/ntr 的 `./cmd ./server` 测试与全包构建。
- 本地通过：`go test -race ./cmd ./printer`、`GOEXPERIMENT=nojsonv2 go test ./...`。
- Linux amd64 / Windows amd64 交叉编译通过。
- macOS 真实 PTY loopback 验收通过：暂停、预填、粘贴换行、应用、计数保持、窄屏、Esc、缩放、历史切换、终端属性恢复。
- 当前提交 `28eb4a5` 的 Linux/macOS PTY、Windows ConPTY loopback 实际交互验收均通过。
- 当前提交的三平台全量测试、tiny/ntr、nojsonv2、全量 Ubuntu race、lint、跨平台构建和运行时回归均通过；性能证据任务也已完成，所有测量步骤成功。
- AI findings 已逐项复核并回复：修复空列项诊断、Windows `--init` 冲突、快捷键宽度和颜色状态测试；堆分配及 Windows select 建议不成立，已附编译器、依赖源码及 CI 证据。
- 远端 Ubuntu 26.04 / x86_64 实测通过：20 项 CLI/公网报告/格式回归，full/tiny/ntr 三套真实 PTY，以及默认 120 列布局、错误取消和暂停 80/120 列缩放。公网探测均收到目的地回复，退出恢复终端且无测试进程残留。
- [Issue #392 最终验收记录](https://github.com/nxtrace/NTrace-core/issues/392#issuecomment-5567839620)。最终提交检查为 48 项成功，发布步骤按 PR 规则跳过；零未解决评审线程。
- 默认 TUI 指标区、非 TTY 表格及 report/wide 与 PR 基线使用相同中文/多路径/waiting/MPLS/响应标记样本逐字节对照一致；排除动态顶部信息与新增 O 快捷键提示。

### Notes for Reviewers

- 默认七列使用原指标布局；显式选择列后使用按完整数值计算的布局。历史图表固定列不受设置影响。
- 列选择只存在于当前会话，不进入 trace.Config、统计模型或机器输出 schema。
- 首版不包含 jitter、持久化、Web/MCP 列设置。Windows 验收通过 CI ConPTY 完成；Unix 同时检查退出前后的终端属性一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `--mtr-columns`，支持自定义 MTR 输出列及显示顺序。
  - TUI 中可使用 `o/O` 快捷键编辑列，支持应用、取消和粘贴输入。
  - 报告模式与交互界面均支持自定义列显示，并适配终端尺寸变化。

- **改进**
  - 对不兼容的输出模式和参数组合提供明确错误提示。

- **文档**
  - 更新中英文 README 及命令帮助，补充参数和快捷键说明。

- **测试**
  - 增加列编辑、渲染、输入处理及跨平台终端交互测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


