### PR TITLE
feat(mtr): 保存 MTR 会话并支持无网络离线回放

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ on:
       - "nt_install.sh"
       - ".cross_compile.sh"
       - "scripts/test_nt_install.sh"
+      - "scripts/test_mtr_session_pty.py"
       - "scripts/perf/**"
       - ".github/workflows/*.yml"
   pull_request:
@@ -33,6 +34,7 @@ on:
       - "nt_install.sh"
       - ".cross_compile.sh"
       - "scripts/test_nt_install.sh"
+      - "scripts/test_mtr_session_pty.py"
       - "scripts/perf/**"
       - ".github/workflows/*.yml"
   workflow_dispatch:
@@ -149,6 +151,36 @@ jobs:
           python -m pip install pywinpty==3.0.5
           go build -o "$env:RUNNER_TEMP/nexttrace-mtr-columns.exe" .
           python scripts/test_mtr_columns_pty.py "$env:RUNNER_TEMP/nexttrace-mtr-columns.exe"
+
+      - name: MTR session recording and replay PTY smoke
+        if: ${{ matrix.os != 'windows-latest' }}
+        shell: bash
+        run: |
+          for flavor in full tiny ntr; do
+            binary="${RUNNER_TEMP}/nexttrace-mtr-session-${flavor}"
+            tags=()
+            if [[ "${flavor}" != full ]]; then
+              tags=(-tags "flavor_${flavor}")
+            fi
+            go build -buildvcs=false "${tags[@]}" -o "${binary}" .
+            sudo python3 scripts/test_mtr_session_pty.py "${binary}"
+          done
+
+      - name: MTR session recording and replay ConPTY smoke
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          foreach ($flavor in @("full", "tiny", "ntr")) {
+            $binary = "$env:RUNNER_TEMP/nexttrace-mtr-session-$flavor.exe"
+            $buildArgs = @("build", "-buildvcs=false", "-o", $binary)
+            if ($flavor -ne "full") {
+              $buildArgs += @("-tags", "flavor_$flavor")
+            }
+            go @buildArgs .
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            python scripts/test_mtr_session_pty.py $binary
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: Test with windows
         if: ${{ matrix.os == 'windows-latest' }}

--- a/README.md
+++ b/README.md
@@ -677,6 +677,18 @@ JSON always includes all available metadata (FULL), ignores `-y`, and honors Geo
 
 NDJSON emits `start`, `probe`, `path_end`, and `end` objects with consecutive `seq` values. Reports emit exactly one object, including partial statistics on interruption or failure. Diagnostics go to stderr. Exit codes: completion `0`, runtime/initialization error `1`, invalid arguments `2`, SIGINT `130`, SIGTERM `143`. Completion does not imply reachability; use `path_end`. See the [MTR JSON v1 contract and examples](docs/mtr-json.md).
 
+Save and reopen an MTR session in any build:
+
+```sh
+nexttrace --mtr --mtr-record session.jsonl 1.1.1.1
+nexttrace --mtr-replay session.jsonl
+nexttrace --mtr-replay session.jsonl -r --json
+```
+
+`--mtr-record` creates a new private file alongside the selected TUI, report, RAW or JSON output. It does not enable MTR by itself; full/tiny require `-t`, `-r` or `-w`, while ntr uses its default mode. Existing files are never overwritten. A recording write failure stops probing and returns an error, preserving the written prefix.
+
+Replay uses recorded probe results and metadata without probing or DNS/Geo/PTR queries. In a terminal it opens paused at the final statistics; Space plays at original speed (from the beginning at EOF), `p` pauses playback, `r` rewinds, and `j/J` seeks to an elapsed `HH:MM:SS[.mmm]`. Existing host, column and history controls remain available. Non-TTY and `-r/-w` output one report; `--json` emits a separate offline report with recording completeness and playback position. Truncated tails are recoverable, explicitly marked incomplete, and return nonzero. The three-minute history window follows the playback position; the file retains the whole recorded session. See the [session format and recovery contract](docs/mtr-session.md).
+
 Select and reorder human-readable MTR columns:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ ntr --mtr-columns received 1.1.1.1
 
 `--mtr-columns` accepts any nonempty selection of `loss,snt,received,last,avg,best,wrst,stdev`, in the supplied order. Names ignore case and surrounding spaces; unknown names, duplicates and empty entries are errors. `received` is displayed as `Rcv`. The default remains `Loss%, Snt, Last, Avg, Best, Wrst, StDev`.
 
-The option applies to TUI, non-TTY tables and report/wide output. It does not enable MTR: full/tiny require `-t`, `-r` or `-w`; ntr uses its default MTR mode. RAW, JSON, traditional traceroute and standalone modes reject it before initialization. Custom TUI columns keep complete numbers and at least 8 Host cells; a narrow terminal shows a notice until widened or fewer columns are selected.
+The option applies to TUI, non-TTY tables and report/wide output, including offline replay text output. It does not enable MTR: full/tiny require `-t`, `-r` or `-w`; ntr uses its default MTR mode. RAW, JSON, traditional traceroute and other standalone modes reject it before initialization. Custom TUI columns keep complete numbers and at least 8 Host cells; a narrow terminal shows a notice until widened or fewer columns are selected.
 
 Press `o/O` to edit the current column codes: `L=Loss S=Snt R=Received N=Last A=Avg B=Best W=Wrst V=StDev`. Codes ignore case; spaces separate codes. Enter validates and applies, Esc cancels, Backspace deletes and Ctrl-U clears. Invalid or duplicate codes and an empty draft keep the editor open. Bracketed paste converts newlines to spaces without submitting. The draft is limited to 256 ASCII characters.
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -690,7 +690,7 @@ ntr --mtr-columns received 1.1.1.1
 
 `--mtr-columns` 支持 `loss,snt,received,last,avg,best,wrst,stdev` 的任意非空子集及顺序，忽略大小写与列名两端空格；未知列、重复列、空项报错。`received` 显示为 `Rcv`。默认仍为 `Loss%、Snt、Last、Avg、Best、Wrst、StDev`。
 
-参数适用于 TUI、非 TTY 表格和 report/wide，不自动开启 MTR：full/tiny 需配合 `-t/-r/-w`，ntr 使用默认 MTR 模式。RAW、JSON、传统 traceroute 和独立模式会在初始化前拒绝该参数。自定义 TUI 保留完整数字及至少 8 格 Host；空间不足时显示提示，加宽终端或减少列后恢复。
+参数适用于 TUI、非 TTY 表格和 report/wide，也支持离线回放的文字输出；不自动开启 MTR：full/tiny 需配合 `-t/-r/-w`，ntr 使用默认 MTR 模式。RAW、JSON、传统 traceroute 和其他独立模式会在初始化前拒绝该参数。自定义 TUI 保留完整数字及至少 8 格 Host；空间不足时显示提示，加宽终端或减少列后恢复。
 
 按 `o/O` 编辑当前字段码：`L=Loss S=Snt R=Received N=Last A=Avg B=Best W=Wrst V=StDev`。输入不区分大小写，空格用于分隔。Enter 校验并应用，Esc 取消，Backspace 删除末尾字符，Ctrl-U 清空。空串、未知码和重复码保留编辑状态并显示错误。括号粘贴中的换行转为空格，不自动提交；草稿最多 256 个 ASCII 字符。
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -668,6 +668,18 @@ JSON 固定输出完整可用元数据（FULL），忽略 `-y`，仍遵守 Geo/P
 
 NDJSON 输出 `start`、`probe`、`path_end`、`end` 事件，`seq` 连续递增。报告只输出一个对象，中断或失败时保留已有统计。诊断写入 stderr。退出码：完成 `0`，初始化/执行错误 `1`，参数错误 `2`，SIGINT `130`，SIGTERM `143`。完成不表示目的地可达，可达性读取 `path_end`。详见 [MTR JSON v1 契约及示例](docs/mtr-json.md)。
 
+三个版本均支持保存和离线重开 MTR 会话：
+
+```sh
+nexttrace --mtr --mtr-record session.jsonl 1.1.1.1
+nexttrace --mtr-replay session.jsonl
+nexttrace --mtr-replay session.jsonl -r --json
+```
+
+`--mtr-record` 在当前 TUI、报告、RAW 或 JSON 输出之外新建私有记录文件，不自动开启 MTR：full/tiny 需配合 `-t/-r/-w`，ntr 使用默认模式。已有文件不会被覆盖。记录写入失败立即停止探测并报错，保留已写部分。
+
+回放只读取已保存的探测和元数据，不探测、不查询 DNS/Geo/PTR。终端默认显示最终统计并暂停；空格原速播放，末尾按空格从头播放；`p` 暂停播放，`r` 返回开头，`j/J` 输入相对会话开始时间 `HH:MM:SS[.mmm]` 定位。Host、统计列和历史视图操作继续可用。非 TTY 或 `-r/-w` 一次输出报告；`--json` 使用独立离线报告，包含记录完整性和回放位置。末尾截断可恢复完整部分，明确标记不完整并返回非零。历史窗口仍为三分钟，随回放位置移动；记录文件保留整个会话。详见[会话格式与恢复规则](docs/mtr-session.md)。
+
 选择并排列 MTR 文字统计列：
 
 ```sh

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1535,8 +1535,6 @@ func Execute() {
 		}
 		return
 	}
-	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 	util.SrcDev = ""
 
 	standalone := ""
@@ -1618,9 +1616,10 @@ func Execute() {
 			applyColorMode(*noColor)
 			code = runMTRRecordedCLI(opts, mtrModes, *showIPs, *ipInfoMode, *mtrFlags.columns, mtrColumns)
 		}
-		stop()
 		os.Exit(code)
 	}
+	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	if *naliMode {
 		applyColorMode(*noColor)
 		if maybePrintVersion(*ver) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1135,15 +1135,15 @@ func maybeRunMTRMode(
 	var err error
 	switch chooseMTRRunMode(modes.raw, modes.report) {
 	case mtrRunRaw:
-		err = runMTRRaw(method, conf, mtrHopIntervalMs, mtrMaxPerHop, dataOrigin)
+		err = runMTRRaw(method, conf, mtrHopIntervalMs, mtrMaxPerHop, dataOrigin, nil)
 	case mtrRunReport:
-		err = runMTRReport(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, modes.wide, showIPs, columns...)
+		err = runMTRReport(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, modes.wide, showIPs, nil, columns...)
 	default:
 		if ipInfoMode < 0 || ipInfoMode > 4 {
 			fmt.Fprintf(os.Stderr, "--ipinfo/-y 必须在 0-4 范围内，当前值: %d\n", ipInfoMode)
 			os.Exit(1)
 		}
-		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode, columns...)
+		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode, nil, columns...)
 	}
 	// Mode-local defers restore the terminal and close listeners before exit.
 	exitOnTraceRunError(err)
@@ -1385,11 +1385,15 @@ func supportsMapTrace(dataOrigin string) bool {
 }
 
 func Execute() {
+	if handled, exitCode := maybeRunMTRReplayMode(os.Args[1:], os.Stdout, os.Stderr); handled {
+		os.Exit(exitCode)
+	}
 	if handled, exitCode := maybeRunDoctorMode(os.Args[1:], os.Stdout, os.Stderr); handled {
 		os.Exit(exitCode)
 	}
 	mtrJSONRequested := requestsMTRJSON(os.Args[1:])
-	if !mtrJSONRequested {
+	mtrRecordingRequested := containsMTRRecordFlag(os.Args[1:])
+	if !mtrJSONRequested && !mtrRecordingRequested {
 		if handled, exitCode := maybeRunDNSMode(os.Args[1:], os.Stdout, os.Stderr); handled {
 			os.Exit(exitCode)
 		}
@@ -1400,7 +1404,7 @@ func Execute() {
 	parser := argparse.NewParser(appBinName, "An open source visual route tracking CLI tool")
 	// Override HelpFunc so positional arg names are sanitized in --help output
 	parser.HelpFunc = func(c *argparse.Command, msg interface{}) string {
-		return sanitizeUsagePositionalArgs(c.Usage(msg)) + "\n  --doctor  Check local probe prerequisites without sending probes; see --doctor --help\n"
+		return sanitizeUsagePositionalArgs(c.Usage(msg)) + "\n  --doctor  Check local probe prerequisites without sending probes; see --doctor --help\n  --mtr-replay FILE  Open a saved MTR session offline; see --mtr-replay --help\n"
 	}
 	init := registerInitFlag(parser)
 	ipv4Only := parser.Flag("4", "ipv4", &argparse.Options{Help: "Use IPv4 only"})
@@ -1467,6 +1471,7 @@ func Execute() {
 
 	// ── MTR flags (all flavors) ──
 	mtrFlags := registerMTRFlags(parser)
+	mtrRecord := parser.String("", "mtr-record", &argparse.Options{Help: "Save this MTR session to a new file for offline replay"})
 	mtrMode := mtrFlags.mtrMode
 	reportMode := mtrFlags.reportMode
 	wideMode := mtrFlags.wideMode
@@ -1481,7 +1486,7 @@ func Execute() {
 	if err != nil {
 		// In case of error print error and print usage
 		// This can also be done by passing -h or --help flags
-		if mtrJSONRequested || containsFWMarkFlag(os.Args[1:]) {
+		if mtrJSONRequested || mtrRecordingRequested || containsFWMarkFlag(os.Args[1:]) {
 			fmt.Fprint(os.Stderr, sanitizeUsagePositionalArgs(parser.Usage(err)))
 			os.Exit(2)
 		}
@@ -1501,13 +1506,17 @@ func Execute() {
 		fmt.Fprintln(os.Stderr, "MTR JSON cannot be combined with a standalone mode")
 		os.Exit(2)
 	}
+	if mtrRecordingRequested && (*setupNextTraceAPIV4Token || *dnsMode || *speedMode) {
+		fmt.Fprintln(os.Stderr, "--mtr-record cannot be combined with a standalone mode")
+		os.Exit(2)
+	}
 	if *dnsMode {
 		fmt.Fprintln(os.Stderr, "-l/--dns must be the first argument")
 		os.Exit(1)
 	}
 	if err := validateGlobalpingAvailability(*from, enableGlobalping); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		if mtrJSONRequested {
+		if mtrJSONRequested || mtrRecordingRequested {
 			os.Exit(2)
 		}
 		os.Exit(1)
@@ -1551,7 +1560,7 @@ func Execute() {
 	}, defaultMTR)
 	if modeErr != nil {
 		fmt.Fprintln(os.Stderr, modeErr)
-		if mtrJSONRequested {
+		if mtrJSONRequested || mtrRecordingRequested {
 			os.Exit(2)
 		}
 		os.Exit(1)
@@ -1560,12 +1569,16 @@ func Execute() {
 	if *init {
 		columnsStandalone = "--init"
 	}
+	if err := validateMTRRecordMode(*mtrRecord, parsedFlag(parser, "mtr-record"), mtrModes, columnsStandalone, *deployMCP); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
 	mtrColumns, columnsErr := resolveMTRColumns(*mtrFlags.columns, parsedFlag(parser, "mtr-columns"), mtrModes, *jsonPrint, columnsStandalone)
 	if columnsErr != nil {
 		fmt.Fprintln(os.Stderr, columnsErr)
 		os.Exit(2)
 	}
-	if mtrModes.mtr && *jsonPrint {
+	if mtrModes.mtr && (*jsonPrint || mtrRecordingRequested) {
 		if maybePrintVersion(*ver) {
 			return
 		}
@@ -1574,18 +1587,20 @@ func Execute() {
 			"routePath": *routePath, "from": *from != "", "fastTrace": *fastTraceFlag, "file": *file != "", "deploy": *deploy,
 		}
 		conflict, ok := checkMTRConflicts(conflicts)
-		if !ok || *rawPrint || *mtuMode || *naliMode || *init || *deployMCP {
+		if !ok || (*rawPrint && *jsonPrint) || *mtuMode || *naliMode || *init || *deployMCP {
 			if ok {
 				conflict = "--raw or a standalone mode"
 			}
-			fmt.Fprintf(os.Stderr, "MTR JSON cannot be combined with %s\n", conflict)
+			fmt.Fprintf(os.Stderr, "MTR cannot be combined with %s\n", conflict)
 			os.Exit(2)
 		}
 		queriesSet, intervalSet, packetSet, _ := detectExplicitProbeFlags(parser)
 		count, interval := deriveMTRProbeParams(mtrModes.report, queriesSet, *numMeasurements, intervalSet, *ttlInterval)
-		code := runMTRJSONCLI(mtrJSONOptions{
+		opts := mtrJSONOptions{
 			Target: *str, Method: resolveTraceMethod(*tcp, *udp), Report: mtrModes.report,
-			MaxPerHop: count, HopIntervalMs: interval, PacketSize: *packetSize, PacketSizeExplicit: packetSet,
+			RecordPath:    *mtrRecord,
+			RecordDisplay: mtrRecordingDisplay{hostMode: *ipInfoMode, showIPs: *showIPs, wide: mtrModes.wide, columns: *mtrFlags.columns},
+			MaxPerHop:     count, HopIntervalMs: interval, PacketSize: *packetSize, PacketSizeExplicit: packetSet,
 			IPv4Only: *ipv4Only, IPv6Only: *ipv6Only, DataProvider: *dataOrigin, PowProvider: *powProvider, DotServer: *dot,
 			Config: trace.Config{
 				OSType: resolveOSType(), ICMPMode: *icmpMode, DN42: *dn42,
@@ -1595,7 +1610,14 @@ func Execute() {
 				Timeout: time.Duration(*timeout) * time.Millisecond, TOS: *tos, Lang: *lang,
 				RDNS: !*norDNS, AlwaysWaitRDNS: *alwaysrDNS, DisableMPLS: *disableMPLS,
 			},
-		})
+		}
+		var code int
+		if *jsonPrint {
+			code = runMTRJSONCLI(opts)
+		} else {
+			applyColorMode(*noColor)
+			code = runMTRRecordedCLI(opts, mtrModes, *showIPs, *ipInfoMode, *mtrFlags.columns, mtrColumns)
+		}
 		stop()
 		os.Exit(code)
 	}

--- a/cmd/doctor_mode.go
+++ b/cmd/doctor_mode.go
@@ -42,7 +42,7 @@ func doctorValueOption(name string) bool {
 	switch name {
 	case "p", "port", "s", "source", "D", "dev", "source-port", "Q", "tos", "timeout", "dot-server", "g", "language", "icmp-mode",
 		"q", "queries", "max-attempts", "parallel-requests", "m", "max-hops", "d", "data-provider", "pow-provider", "f", "first",
-		"o", "output", "listen", "deploy-token", "z", "send-time", "i", "ttl-time", "psize", "from", "mtr-columns", "fwmark", "y", "ipinfo", "file":
+		"o", "output", "listen", "deploy-token", "z", "send-time", "i", "ttl-time", "psize", "from", "mtr-columns", "mtr-record", "mtr-replay", "fwmark", "y", "ipinfo", "file":
 		return true
 	}
 	return false

--- a/cmd/mtr_column_editor.go
+++ b/cmd/mtr_column_editor.go
@@ -97,7 +97,7 @@ func (k *mtrKeyInput) expireEscape(u *mtrUI, now time.Time) {
 	if k.parser.state == mtrStateEsc && !k.escapeAt.IsZero() && now.Sub(k.escapeAt) >= mtrEscapeDelay {
 		k.parser.state = mtrStateGround
 		k.escapeAt = time.Time{}
-		u.editColumn(27, false)
+		u.editMTRInput(27, false)
 		u.requestRedraw()
 	}
 }
@@ -112,10 +112,10 @@ func (k *mtrKeyInput) feed(u *mtrUI, b byte, now time.Time) bool {
 		return false
 	}
 	k.expireEscape(u, now)
-	_, editor := u.columnSnapshot()
-	k.parser.trackPaste = editor.Active
-	if k.parser.state == mtrStateGround && b != 27 && editor.Active {
-		u.editColumn(b, false)
+	editing := u.isMTREditing()
+	k.parser.trackPaste = editing
+	if k.parser.state == mtrStateGround && b != 27 && editing {
+		u.editMTRInput(b, false)
 	} else {
 		action := k.parser.Feed(b)
 		if action == mtrActionPasteStart {
@@ -139,7 +139,7 @@ func (k *mtrKeyInput) feedPaste(u *mtrUI, b byte) {
 	const end = "\x1b[201~"
 	k.pasteEnd += string(b)
 	for k.pasteEnd != "" && !strings.HasPrefix(end, k.pasteEnd) {
-		u.editColumn(k.pasteEnd[0], true)
+		u.editMTRInput(k.pasteEnd[0], true)
 		k.pasteEnd = k.pasteEnd[1:]
 	}
 	if k.pasteEnd == end {
@@ -149,6 +149,9 @@ func (k *mtrKeyInput) feedPaste(u *mtrUI, b byte) {
 }
 
 func (u *mtrUI) applyInputAction(action mtrInputAction) bool {
+	if u.replay != nil && u.applyReplayAction(action) {
+		return false
+	}
 	switch action {
 	case mtrActionQuit:
 		if u.cancel != nil {

--- a/cmd/mtr_json.go
+++ b/cmd/mtr_json.go
@@ -12,35 +12,13 @@ import (
 	"time"
 
 	"github.com/nxtrace/NTrace-core/config"
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
 	"github.com/nxtrace/NTrace-core/trace"
 )
 
 const mtrJSONSchemaVersion = 1
 
-type mtrJSONParameters struct {
-	FWMark           *uint32 `json:"fwmark,omitempty"`
-	MaxPerHop        int     `json:"max_per_hop"`
-	HopIntervalMs    int     `json:"hop_interval_ms"`
-	TimeoutMs        int64   `json:"timeout_ms"`
-	BeginHop         int     `json:"begin_hop"`
-	MaxHops          int     `json:"max_hops"`
-	ParallelRequests int     `json:"parallel_requests"`
-	SourceAddress    string  `json:"source_address"`
-	SourceDevice     string  `json:"source_device,omitempty"`
-	SourcePort       *int    `json:"source_port,omitempty"`
-	Port             *int    `json:"port,omitempty"`
-	PacketSize       int     `json:"packet_size"`
-	RandomPacketSize bool    `json:"random_packet_size"`
-	TOS              int     `json:"tos"`
-	ICMPMode         *int    `json:"icmp_mode,omitempty"`
-	DataProvider     string  `json:"data_provider"`
-	Language         string  `json:"language"`
-	DotServer        string  `json:"dot_server,omitempty"`
-	RDNS             bool    `json:"rdns"`
-	AlwaysWaitRDNS   bool    `json:"always_wait_rdns"`
-	DisableMPLS      bool    `json:"disable_mpls"`
-	DN42             bool    `json:"dn42"`
-}
+type mtrJSONParameters = mtrsession.Parameters
 
 type mtrJSONSession struct {
 	Version             string             `json:"version"`

--- a/cmd/mtr_json_run.go
+++ b/cmd/mtr_json_run.go
@@ -32,6 +32,12 @@ type mtrJSONOptions struct {
 	DataProvider       string
 	PowProvider        string
 	DotServer          string
+	RecordPath         string
+	RecordDisplay      mtrRecordingDisplay
+	PrepareAsync       bool
+	CompactReport      bool
+	HumanOutput        bool
+	OnEvent            func(trace.MTRSessionEvent) error
 }
 
 var runMTRJSONRawFn = trace.RunMTRRaw
@@ -40,11 +46,16 @@ var runMTRJSONRawFn = trace.RunMTRRaw
 // remain the authority for selecting an output mode.
 func requestsMTRJSON(args []string) bool {
 	jsonOutput, mtr := false, !enableTraceroute && defaultMTR
-	for _, arg := range args {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		if arg == "--" {
 			break
 		}
-		name, _, _ := strings.Cut(arg, "=")
+		name, _, inline := strings.Cut(arg, "=")
+		if strings.HasPrefix(arg, "-") && !inline && doctorValueOption(strings.TrimLeft(name, "-")) {
+			i++
+			continue
+		}
 		switch name {
 		case "-j", "--json":
 			jsonOutput = true
@@ -60,6 +71,12 @@ func requestsMTRJSON(args []string) bool {
 }
 
 func runMTRJSONCLI(opts mtrJSONOptions) int {
+	return runMTRCLIWithSignals(func(ctx context.Context) int {
+		return runMTRJSON(ctx, opts, os.Stdout, os.Stderr)
+	})
+}
+
+func runMTRCLIWithSignals(run func(context.Context) int) int {
 	// Let a closed stdout pipe return EPIPE to the writer so the runner can
 	// cancel and join its workers instead of the runtime exiting on SIGPIPE.
 	pipeSignals := make(chan os.Signal, 1)
@@ -74,6 +91,8 @@ func runMTRJSONCLI(opts mtrJSONOptions) int {
 		select {
 		case sig := <-signals:
 			cancel(&mtrJSONSignal{signal: sig})
+		case <-pipeSignals:
+			cancel(io.ErrClosedPipe)
 		case <-ctx.Done():
 		}
 	}()
@@ -82,7 +101,7 @@ func runMTRJSONCLI(opts mtrJSONOptions) int {
 		cancel(nil)
 		<-done
 	}()
-	return runMTRJSON(ctx, opts, os.Stdout, os.Stderr)
+	return run(ctx)
 }
 
 func runMTRJSON(parent context.Context, opts mtrJSONOptions, stdout, stderr io.Writer) int {
@@ -92,9 +111,27 @@ func runMTRJSON(parent context.Context, opts mtrJSONOptions, stdout, stderr io.W
 	stage := "validation"
 	var cleanup func()
 	err := normalizeMTRJSONOptions(&opts, stderr)
+	var recording *mtrRecording
+	if err == nil && opts.RecordPath != "" {
+		stage = "record"
+		recording, err = openMTRRecording(opts.RecordPath)
+		if recording != nil {
+			defer recording.close()
+			opts.OnEvent = recording.event
+		}
+	}
 	if err == nil {
 		stage = "resolve"
 		cleanup, err = prepareMTRJSON(ctx, &opts, out, &stage, stderr)
+	}
+	if recording != nil {
+		display := opts.RecordDisplay
+		if err == nil {
+			display.sourceIP = resolveSrcIP(opts.Config)
+		}
+		if startErr := recording.start(out, display); startErr != nil {
+			err, stage = startErr, "record"
+		}
 	}
 	if err == nil {
 		out.startStream()
@@ -105,6 +142,7 @@ func runMTRJSON(parent context.Context, opts mtrJSONOptions, stdout, stderr io.W
 			out.report.Stats, out.report.PathEnd, err = collectMTRReport(ctx, opts.Method, opts.Config, trace.MTROptions{
 				HopInterval: time.Duration(opts.HopIntervalMs) * time.Millisecond,
 				MaxPerHop:   opts.MaxPerHop,
+				OnEvent:     opts.OnEvent,
 			})
 		} else {
 			err = runMTRJSONStream(ctx, opts, out)
@@ -118,6 +156,11 @@ func runMTRJSON(parent context.Context, opts mtrJSONOptions, stdout, stderr io.W
 	}
 	if cleanup != nil {
 		cleanup()
+	}
+	if recording != nil {
+		if recordErr := recording.finish(err, stage); recordErr != nil {
+			err, stage = recordErr, "record"
+		}
 	}
 	return out.finish(err, stage, stderr)
 }
@@ -135,6 +178,7 @@ func runMTRJSONStream(ctx context.Context, opts mtrJSONOptions, out *mtrJSONOutp
 	}
 	err := runMTRJSONRawFn(ctx, opts.Method, opts.Config, trace.MTRRawOptions{
 		HopInterval: time.Duration(opts.HopIntervalMs) * time.Millisecond,
+		OnEvent:     opts.OnEvent,
 		MaxPerHop:   opts.MaxPerHop, OnPathEnd: func(reason *trace.StopReason) {
 			flushPath()
 			pending, pathChanged = copyMTRPathEnd(reason), true
@@ -194,7 +238,11 @@ func normalizeMTRJSONOptions(opts *mtrJSONOptions, stderr io.Writer) error {
 		cfg.ParallelRequests = 1
 	}
 	applyDefaultPort(&cfg.DstPort, opts.Method == trace.UDPTrace)
-	if opts.Method != trace.ICMPTrace && (cfg.SrcPort < 0 || cfg.SrcPort > 65535 || cfg.DstPort < 1 || cfg.DstPort > 65535) {
+	minimumSourcePort := 0
+	if opts.HumanOutput {
+		minimumSourcePort = -1
+	}
+	if opts.Method != trace.ICMPTrace && (cfg.SrcPort < minimumSourcePort || cfg.SrcPort > 65535 || cfg.DstPort < 1 || cfg.DstPort > 65535) {
 		return errors.New("probe ports must be between 1 and 65535 (source port 0 selects automatically)")
 	}
 	if cfg.ICMPMode <= 0 && util.EnvICMPMode > 0 {
@@ -215,7 +263,7 @@ func prepareMTRJSON(ctx context.Context, opts *mtrJSONOptions, out *mtrJSONOutpu
 	if err := ctx.Err(); err != nil {
 		return cleanup, context.Cause(ctx)
 	}
-	ip, err := lookupTargetIP(ctx, normalizeCLITarget(opts.Target), opts.IPv4Only, opts.IPv6Only, opts.DotServer, true)
+	ip, err := lookupTargetIP(ctx, normalizeCLITarget(opts.Target), opts.IPv4Only, opts.IPv6Only, opts.DotServer, !opts.HumanOutput)
 	if err != nil {
 		return cleanup, err
 	}
@@ -259,7 +307,7 @@ func prepareMTRJSON(ctx context.Context, opts *mtrJSONOptions, out *mtrJSONOutpu
 		}
 		opts.DataProvider, cfg.DN42 = "DN42", true
 	}
-	conn := initNextTraceAPIV3WebSocket(ctx, &opts.DataProvider, &opts.PowProvider, false)
+	conn := initNextTraceAPIV3WebSocket(ctx, &opts.DataProvider, &opts.PowProvider, opts.PrepareAsync)
 	cleanup = func() { closeNextTraceAPIV3WebSocket(conn); restoreOutput() }
 	// Runtime provider fallback can select DN42 as well.
 	if !cfg.DN42 && isDN42Provider(opts.DataProvider) {
@@ -271,7 +319,7 @@ func prepareMTRJSON(ctx context.Context, opts *mtrJSONOptions, out *mtrJSONOutpu
 	descriptor := ipgeo.GetSourceDescriptorSession(opts.DataProvider)
 	session := trace.CachedGeoSourceSession(descriptor)
 	cfg.IPGeoSource, cfg.IPGeoDescriptor, cfg.RefreshIPGeoSource = session.Source, descriptor.Current, session.Refresh
-	*cfg = normalizeMTRReportConfig(*cfg, true)
+	*cfg = normalizeMTRReportConfig(*cfg, !opts.CompactReport)
 	util.SrcPort, util.DstIP = cfg.SrcPort, ip.String()
 	params := &mtrJSONParameters{
 		MaxPerHop: opts.MaxPerHop, HopIntervalMs: opts.HopIntervalMs, TimeoutMs: cfg.Timeout.Milliseconds(),

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -54,8 +54,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		hopIntervalMs = 1000
 	}
 
-	// Ctrl-C 优雅退出
-	sigCtx, stop := signal.NotifyContext(mtrParentContext(conf), os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := mtrRunContext(conf)
 	defer stop()
 	ctx, cancel := context.WithCancel(sigCtx)
 	defer cancel()
@@ -125,7 +124,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		}
 	}
 
-	return trace.RunMTR(ctx, method, roundConf, opts, onSnapshot)
+	return mtrRunError(ctx, trace.RunMTR(ctx, method, roundConf, opts, onSnapshot))
 }
 
 func buildMTRInteractiveOptions(ui *mtrUI, hopIntervalMs int, maxPerHop int) trace.MTROptions {
@@ -170,7 +169,7 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 		maxPerHop = 10
 	}
 
-	ctx, stop := signal.NotifyContext(mtrParentContext(conf), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := mtrRunContext(conf)
 	defer stop()
 
 	startTime := time.Now()
@@ -193,13 +192,13 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 
 	roundConf := normalizeMTRReportConfig(conf, wide)
 	finalStats, _, err := collectMTRReport(ctx, method, roundConf, opts)
-	if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.Cause(ctx)) {
 		return err
 	}
 
 	if len(finalStats) == 0 {
 		fmt.Println("No data collected.")
-		return nil
+		return mtrRunError(ctx, err)
 	}
 
 	printer.MTRReportPrint(finalStats, printer.MTRReportOptions{
@@ -210,7 +209,7 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 		ShowIPs:   showIPs,
 		Lang:      lang,
 	})
-	return nil
+	return mtrRunError(ctx, err)
 }
 
 // runMTRRaw 执行 MTR 原始流式模式（逐事件输出，'|' 分隔）。
@@ -228,7 +227,7 @@ func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		hopIntervalMs = 1000
 	}
 
-	sigCtx, stop := signal.NotifyContext(mtrParentContext(conf), os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := mtrRunContext(conf)
 	defer stop()
 	ctx, cancel := context.WithCancelCause(sigCtx)
 	defer cancel(nil)
@@ -256,17 +255,23 @@ func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 			cancel(writeErr)
 		}
 	})
+	return mtrRunError(ctx, err)
+}
+
+func mtrRunContext(conf trace.Config) (context.Context, context.CancelFunc) {
+	// The caller owns signals when it supplies a context. Another signal
+	// subscriber could cancel first and lose the caller's interruption cause.
+	if conf.Context != nil {
+		return conf.Context, func() {}
+	}
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}
+
+func mtrRunError(ctx context.Context, err error) error {
 	if cause := context.Cause(ctx); cause != nil && (err == nil || errors.Is(err, context.Canceled)) {
 		return cause
 	}
 	return err
-}
-
-func mtrParentContext(conf trace.Config) context.Context {
-	if conf.Context != nil {
-		return conf.Context
-	}
-	return context.Background()
 }
 
 func normalizeMTRTraceConfig(conf trace.Config) trace.Config {

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -49,13 +49,13 @@ func checkMTRConflicts(flags map[string]bool) (conflict string, ok bool) {
 // runMTRTUI 执行 MTR 交互式 TUI 模式。
 // 当 stdin 为 TTY 时启用全屏 TUI（备用屏幕、按键控制）；
 // 非 TTY 时降级为简单表格刷新。
-func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int, columns ...printer.MTRColumn) error {
+func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int, onEvent func(trace.MTRSessionEvent) error, columns ...printer.MTRColumn) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
 
 	// Ctrl-C 优雅退出
-	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(mtrParentContext(conf), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	ctx, cancel := context.WithCancel(sigCtx)
 	defer cancel()
@@ -91,6 +91,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	roundConf := normalizeMTRTraceConfig(conf)
 
 	opts := buildMTRInteractiveOptions(ui, hopIntervalMs, maxPerHop)
+	opts.OnEvent = onEvent
 	history := attachMTRHistoryIfTTY(ui, &opts)
 
 	// TTY 模式下使用 TUI 渲染器 + 暂停支持，非 TTY 使用简单表格
@@ -161,7 +162,7 @@ func attachMTRHistoryIfTTY(ui *mtrUI, opts *trace.MTROptions) *printer.MTRHistor
 
 // runMTRReport 执行 MTR 非全屏报告模式（对齐 mtr -rzw 风格）。
 // 探测完 maxPerHop 后一次性输出最终统计到 stdout，不进入 alternate screen。
-func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, wide bool, showIPs bool, columns ...printer.MTRColumn) error {
+func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, wide bool, showIPs bool, onEvent func(trace.MTRSessionEvent) error, columns ...printer.MTRColumn) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -169,7 +170,7 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 		maxPerHop = 10
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(mtrParentContext(conf), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	startTime := time.Now()
@@ -187,6 +188,7 @@ func runMTRReport(method trace.Method, conf trace.Config, hopIntervalMs int, max
 	opts := trace.MTROptions{
 		HopInterval: time.Duration(hopIntervalMs) * time.Millisecond,
 		MaxPerHop:   maxPerHop,
+		OnEvent:     onEvent,
 	}
 
 	roundConf := normalizeMTRReportConfig(conf, wide)
@@ -221,17 +223,20 @@ func writeMTRRawPathEnd(w io.Writer, reason *trace.StopReason) error {
 	return printer.WriteTraceStopReason(w, reason)
 }
 
-func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, dataOrigin string) error {
+func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, dataOrigin string, onEvent func(trace.MTRSessionEvent) error) error {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(mtrParentContext(conf), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	ctx, cancel := context.WithCancelCause(sigCtx)
+	defer cancel(nil)
 
 	opts := trace.MTRRawOptions{
 		HopInterval: time.Duration(hopIntervalMs) * time.Millisecond,
 		MaxPerHop:   maxPerHop,
+		OnEvent:     onEvent,
 		OnPathEnd: func(reason *trace.StopReason) {
 			if err := writeMTRRawPathEnd(os.Stderr, reason); err != nil {
 				writeMTRRawRuntimeError(os.Stderr, err)
@@ -241,12 +246,27 @@ func runMTRRaw(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 
 	roundConf := normalizeMTRTraceConfig(conf)
 	if apiLine := buildRawAPIInfoLine(dataOrigin); apiLine != "" {
-		fmt.Println(apiLine)
+		if _, err := fmt.Fprintln(os.Stdout, apiLine); err != nil {
+			return err
+		}
 	}
 
-	return trace.RunMTRRaw(ctx, method, roundConf, opts, func(rec trace.MTRRawRecord) {
-		fmt.Println(printer.FormatMTRRawLine(rec))
+	err := trace.RunMTRRaw(ctx, method, roundConf, opts, func(rec trace.MTRRawRecord) {
+		if _, writeErr := fmt.Fprintln(os.Stdout, printer.FormatMTRRawLine(rec)); writeErr != nil {
+			cancel(writeErr)
+		}
 	})
+	if cause := context.Cause(ctx); cause != nil && (err == nil || errors.Is(err, context.Canceled)) {
+		return cause
+	}
+	return err
+}
+
+func mtrParentContext(conf trace.Config) context.Context {
+	if conf.Context != nil {
+		return conf.Context
+	}
+	return context.Background()
 }
 
 func normalizeMTRTraceConfig(conf trace.Config) trace.Config {

--- a/cmd/mtr_mode_context_test.go
+++ b/cmd/mtr_mode_context_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestMTRRunContextBorrowsCaller(t *testing.T) {
+	parent, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	ctx, stop := mtrRunContext(trace.Config{Context: parent})
+	defer stop()
+	if ctx != parent {
+		t.Fatal("mode must reuse the caller's context and signal owner")
+	}
+	stop()
+	if parent.Err() != nil {
+		t.Fatal("mode cleanup canceled the caller")
+	}
+	cause := &mtrJSONSignal{signal: syscall.SIGTERM}
+	cancel(cause)
+	if context.Cause(ctx) != cause {
+		t.Fatalf("cause=%v, want %v", context.Cause(ctx), cause)
+	}
+}
+
+func TestMTRRunContextOwnsStandaloneCancellation(t *testing.T) {
+	ctx, stop := mtrRunContext(trace.Config{})
+	defer stop()
+	if ctx.Err() != nil {
+		t.Fatalf("unexpected initial error: %v", ctx.Err())
+	}
+	stop()
+	if !errors.Is(context.Cause(ctx), context.Canceled) {
+		t.Fatalf("cause=%v, want context.Canceled", context.Cause(ctx))
+	}
+}
+
+func TestMTRRunErrorPreservesCauseAndRuntimeError(t *testing.T) {
+	runtimeErr := errors.New("probe setup failed")
+	for _, cause := range []error{&mtrJSONSignal{signal: os.Interrupt}, &mtrJSONSignal{signal: syscall.SIGTERM}, io.ErrClosedPipe, context.DeadlineExceeded} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			ctx, cancel := context.WithCancelCause(t.Context())
+			cancel(cause)
+			for _, runErr := range []error{nil, context.Canceled, cause} {
+				if got := mtrRunError(ctx, runErr); got != cause {
+					t.Fatalf("run error=%v, result=%v, want %v", runErr, got, cause)
+				}
+			}
+			if got := mtrRunError(ctx, runtimeErr); got != runtimeErr {
+				t.Fatalf("runtime error replaced: %v", got)
+			}
+		})
+	}
+	if got := mtrRunError(t.Context(), nil); got != nil {
+		t.Fatalf("successful run returned %v", got)
+	}
+}
+
+func TestMTRReportInterruptionKeepsFinalOutput(t *testing.T) {
+	for _, sig := range []os.Signal{os.Interrupt, syscall.SIGTERM} {
+		for _, result := range []string{"cause", "canceled", "nil", "runtime-error", "no-data"} {
+			t.Run(sig.String()+"/"+result, func(t *testing.T) {
+				parent, cancel := context.WithCancelCause(t.Context())
+				defer cancel(nil)
+				cause := &mtrJSONSignal{signal: sig}
+				runtimeErr := errors.New("probe setup failed")
+				oldRun := runMTRReportFn
+				t.Cleanup(func() { runMTRReportFn = oldRun })
+				runMTRReportFn = func(ctx context.Context, _ trace.Method, _ trace.Config, _ trace.MTROptions, snapshot trace.MTROnSnapshot) error {
+					if ctx != parent {
+						t.Fatal("report installed another context instead of borrowing its caller")
+					}
+					if result != "no-data" {
+						snapshot(1, []trace.MTRHopStat{{TTL: 1, IP: "127.0.0.1", Snt: 1, Received: 1}})
+					}
+					cancel(cause)
+					switch result {
+					case "canceled":
+						return ctx.Err()
+					case "nil":
+						return nil
+					case "runtime-error":
+						return runtimeErr
+					default:
+						return context.Cause(ctx)
+					}
+				}
+				output, err := os.Create(filepath.Join(t.TempDir(), "report.txt"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				oldStdout := os.Stdout
+				t.Cleanup(func() { os.Stdout = oldStdout; _ = output.Close() })
+				os.Stdout = output
+				err = runMTRReport(trace.ICMPTrace, trace.Config{Context: parent}, 1, 1, "", "", false, false, nil)
+				os.Stdout = oldStdout
+				text, readErr := os.ReadFile(output.Name())
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if result == "runtime-error" {
+					if err != runtimeErr || len(text) != 0 {
+						t.Fatalf("error=%v output=%q", err, text)
+					}
+					return
+				}
+				wantOutput := "127.0.0.1"
+				if result == "no-data" {
+					wantOutput = "No data collected."
+				}
+				if err != cause || !strings.Contains(string(text), wantOutput) {
+					t.Fatalf("error=%v, want %v; output=%q", err, cause, text)
+				}
+			})
+		}
+	}
+}

--- a/cmd/mtr_record.go
+++ b/cmd/mtr_record.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func containsMTRRecordFlag(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		name, _, inline := strings.Cut(arg, "=")
+		if name == "--mtr-record" {
+			return true
+		}
+		if strings.HasPrefix(arg, "-") && !inline && doctorValueOption(strings.TrimLeft(name, "-")) {
+			i++
+		}
+	}
+	return false
+}
+
+func validateMTRRecordMode(path string, explicit bool, modes effectiveMTRModes, standalone string, mcp bool) error {
+	if !explicit {
+		return nil
+	}
+	if strings.TrimSpace(path) == "" {
+		return errors.New("--mtr-record requires a new file path")
+	}
+	if !modes.mtr || standalone != "" || mcp {
+		return errors.New("--mtr-record requires MTR mode and cannot be combined with a standalone mode")
+	}
+	return nil
+}
+
+type mtrRecordingDisplay struct {
+	hostMode int
+	sourceIP string
+	showIPs  bool
+	wide     bool
+	columns  string
+}
+
+type mtrRecording struct {
+	writer  *mtrsession.Writer
+	pathEnd *trace.StopReason
+}
+
+func openMTRRecording(path string) (*mtrRecording, error) {
+	w, err := mtrsession.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open MTR recording: %w", err)
+	}
+	return &mtrRecording{writer: w}, nil
+}
+
+func (r *mtrRecording) start(out *mtrJSONOutput, display mtrRecordingDisplay) error {
+	if display.hostMode < 0 || display.hostMode > 4 {
+		display.hostMode = 0 // Live JSON ignores this presentation option.
+	}
+	host, _ := os.Hostname()
+	session := mtrsession.Session{
+		Version: out.report.Version, Target: out.report.Target, Protocol: out.report.Protocol,
+		StartedAt: out.start, EffectiveParameters: out.report.EffectiveParameters,
+		SourceHost: host, SourceIP: display.sourceIP,
+		Display: mtrsession.DisplayParameters{
+			HostMode: display.hostMode, ShowIPs: display.showIPs, ShowMPLS: true,
+			Wide: display.wide, Columns: display.columns,
+		},
+	}
+	if out.report.ResolvedIP != nil {
+		session.ResolvedIP = *out.report.ResolvedIP
+	}
+	if session.EffectiveParameters != nil {
+		params := *session.EffectiveParameters
+		session.EffectiveParameters = &params
+		session.Display.ShowMPLS = !params.DisableMPLS
+	}
+	return r.writer.Start(session)
+}
+
+func (r *mtrRecording) event(event trace.MTRSessionEvent) error {
+	if event.Type == trace.MTRSessionPathEndEvent {
+		r.pathEnd = copyMTRPathEnd(event.PathEnd)
+	}
+	if event.Type == trace.MTRSessionResetEvent {
+		r.pathEnd = nil
+	}
+	return r.writer.Event(event)
+}
+
+func (r *mtrRecording) finish(err error, stage string) error {
+	end := mtrsession.End{EndedAt: time.Now(), EndReason: "completed", PathEnd: r.pathEnd}
+	var interrupted *mtrJSONSignal
+	switch {
+	case errors.As(err, &interrupted):
+		end.EndReason, end.Signal = "interrupted", "SIGINT"
+		if interrupted.signal == syscall.SIGTERM {
+			end.Signal = "SIGTERM"
+		}
+	case errors.Is(err, context.Canceled):
+		end.EndReason = "interrupted"
+	case err != nil:
+		end.EndReason = "error"
+		end.Error = &mtrsession.Error{Stage: stage, Message: err.Error()}
+	}
+	return r.writer.Finish(end)
+}
+
+func (r *mtrRecording) close() {
+	// Finish owns and reports normal close errors. This also closes an early
+	// failure without inventing a complete end record.
+	_ = r.writer.Close()
+}
+
+func runMTRRecordedCLI(opts mtrJSONOptions, modes effectiveMTRModes, showIPs bool, hostMode int, columnNames string, columns []printer.MTRColumn) int {
+	return runMTRCLIWithSignals(func(ctx context.Context) int {
+		return runMTRRecorded(ctx, opts, modes, showIPs, hostMode, columnNames, columns, os.Stderr)
+	})
+}
+
+func runMTRRecorded(ctx context.Context, opts mtrJSONOptions, modes effectiveMTRModes, showIPs bool, hostMode int, columnNames string, columns []printer.MTRColumn, stderr io.Writer) int {
+	if hostMode < 0 || hostMode > 4 {
+		_, _ = fmt.Fprintln(stderr, "--ipinfo/-y must be between 0 and 4")
+		return 2
+	}
+	if err := normalizeMTRRecordedOptions(&opts, modes, stderr); err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 2
+	}
+	recording, err := openMTRRecording(opts.RecordPath)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
+	}
+	defer recording.close()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	out := newMTRJSONOutput(io.Discard, false, opts.Target, opts.Method, cancel)
+	opts.PrepareAsync = shouldUseAsyncNextTraceAPIV3ForMTR(modes, CheckTTY(int(os.Stdin.Fd())), CheckTTY(int(os.Stdout.Fd())))
+	opts.CompactReport = modes.report && !modes.wide && !modes.raw
+	stage := "resolve"
+	cleanup, err := prepareMTRJSON(ctx, &opts, out, &stage, stderr)
+	display := mtrRecordingDisplay{hostMode: hostMode, showIPs: showIPs, wide: modes.wide, columns: columnNames}
+	if err == nil {
+		display.sourceIP = resolveSrcIP(opts.Config)
+	}
+	if startErr := recording.start(out, display); startErr != nil {
+		err, stage = startErr, "record"
+	}
+	if err == nil {
+		stage = "probe"
+		switch chooseMTRRunMode(modes.raw, modes.report) {
+		case mtrRunRaw:
+			err = runMTRRaw(opts.Method, opts.Config, opts.HopIntervalMs, opts.MaxPerHop, opts.DataProvider, recording.event)
+		case mtrRunReport:
+			err = runMTRReport(opts.Method, opts.Config, opts.HopIntervalMs, opts.MaxPerHop, opts.Target, opts.DataProvider, modes.wide, showIPs, recording.event, columns...)
+		default:
+			err = runMTRTUI(opts.Method, opts.Config, opts.HopIntervalMs, opts.MaxPerHop, opts.Target, opts.DataProvider, showIPs, hostMode, recording.event, columns...)
+		}
+	}
+	if cause := context.Cause(ctx); cause != nil && (err == nil || errors.Is(err, context.Canceled)) {
+		err = cause
+	}
+	if trace.IsInitializationError(err) {
+		stage = "initialize"
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	if finishErr := recording.finish(err, stage); finishErr != nil {
+		err = fmt.Errorf("write MTR recording: %w", finishErr)
+	}
+	var interrupted *mtrJSONSignal
+	if errors.As(err, &interrupted) {
+		if interrupted.signal == syscall.SIGTERM {
+			return 143
+		}
+		return 130
+	}
+	if err != nil && !errors.Is(err, context.Canceled) {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func normalizeMTRRecordedOptions(opts *mtrJSONOptions, modes effectiveMTRModes, stderr io.Writer) error {
+	opts.HumanOutput = true
+	// Human report defaults nonpositive counts to ten; RAW keeps its explicit
+	// unlimited count even when --report was used to select the mode.
+	opts.Report = modes.report && !modes.raw
+	if opts.Report && opts.MaxPerHop <= 0 {
+		opts.MaxPerHop = 10
+	}
+	return normalizeMTRJSONOptions(opts, stderr)
+}

--- a/cmd/mtr_record_test.go
+++ b/cmd/mtr_record_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+func TestMTRRecordFlagsRespectValues(t *testing.T) {
+	for _, args := range [][]string{{"--mtr-record", "out"}, {"--mtr-record=out"}, {"-t", "--mtr-record", "--doctor"}} {
+		if !containsMTRRecordFlag(args) {
+			t.Fatalf("missing record flag: %v", args)
+		}
+	}
+	for _, args := range [][]string{{"--", "--mtr-record"}, {"--file", "--mtr-record"}, {"--mtr-replay", "--mtr-record"}} {
+		if containsMTRRecordFlag(args) {
+			t.Fatalf("mistook value for recording option: %v", args)
+		}
+	}
+	if containsDoctorFlag([]string{"-t", "--mtr-record", "--doctor"}) {
+		t.Fatal("recording filename invoked doctor")
+	}
+	if requestsMTRJSON([]string{"-t", "--mtr-record", "--json"}) {
+		t.Fatal("recording filename invoked JSON output")
+	}
+	if containsFWMarkFlag([]string{"-t", "--mtr-record", "--fwmark"}) {
+		t.Fatal("recording filename invoked fwmark")
+	}
+}
+
+func TestMTRRecordOpenFailurePrecedesResolution(t *testing.T) {
+	old := domainLookupFn
+	t.Cleanup(func() { domainLookupFn = old })
+	domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		t.Fatal("record open failure reached DNS")
+		return nil, nil
+	}
+	opts := testMTRJSONOptions()
+	opts.RecordPath = filepath.Join(t.TempDir(), "existing")
+	if err := os.WriteFile(opts.RecordPath, []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runMTRJSON(t.Context(), opts, &stdout, &stderr); code != 1 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	data, err := os.ReadFile(opts.RecordPath)
+	if err != nil || string(data) != "keep" {
+		t.Fatal("overwrote recording")
+	}
+}
+
+func TestMTRRecordedHumanOptionsPreserveCountAndRandomPort(t *testing.T) {
+	for _, tc := range []struct {
+		modes effectiveMTRModes
+		count int
+	}{
+		{effectiveMTRModes{mtr: true, report: true}, 10},
+		{effectiveMTRModes{mtr: true, report: true, raw: true}, 0},
+		{effectiveMTRModes{mtr: true}, 0},
+	} {
+		opts := testMTRJSONOptions()
+		opts.Method, opts.Config.SrcPort, opts.MaxPerHop = trace.UDPTrace, -1, 0
+		if err := normalizeMTRRecordedOptions(&opts, tc.modes, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		if opts.Config.SrcPort != -1 || opts.MaxPerHop != tc.count {
+			t.Fatalf("changed human semantics: %+v", opts)
+		}
+	}
+}
+
+func TestMTRRecordedHumanKeepsAddressSelection(t *testing.T) {
+	old := domainLookupFn
+	t.Cleanup(func() { domainLookupFn = old })
+	called := false
+	domainLookupFn = func(_ context.Context, _, _, _ string, disableOutput bool) (net.IP, error) {
+		called = true
+		if disableOutput {
+			t.Fatal("recording suppressed human address selection")
+		}
+		return nil, errors.New("test lookup stop")
+	}
+	opts := testMTRJSONOptions()
+	opts.RecordPath = filepath.Join(t.TempDir(), "selection.jsonl")
+	code := runMTRRecorded(t.Context(), opts, effectiveMTRModes{mtr: true}, false, 0, "", nil, io.Discard)
+	if !called || code != 1 {
+		t.Fatalf("lookup=%v code=%d", called, code)
+	}
+}
+
+func TestMTRRecordInitializationFailureIsReadable(t *testing.T) {
+	old := domainLookupFn
+	t.Cleanup(func() { domainLookupFn = old })
+	domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		return nil, errors.New("test resolution failure")
+	}
+	opts := testMTRJSONOptions()
+	opts.RecordPath = filepath.Join(t.TempDir(), "failed.jsonl")
+	var stdout, stderr bytes.Buffer
+	if code := runMTRJSON(t.Context(), opts, &stdout, &stderr); code != 1 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	records := readMTRRecordingFixture(t, opts.RecordPath)
+	if len(records) != 2 || records[0].Session.EffectiveParameters != nil || records[1].End.EndReason != "error" || records[1].End.Error.Stage != "resolve" {
+		t.Fatalf("invalid failed session: %+v", records)
+	}
+}
+
+func readMTRRecordingFixture(t *testing.T, path string) []mtrsession.Record {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	var records []mtrsession.Record
+	for {
+		var record mtrsession.Record
+		err := decoder.Decode(&record)
+		if err == io.EOF {
+			return records
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		records = append(records, record)
+	}
+}
+
+func TestMTRJSONRecordedReportRebuildsSameSnapshot(t *testing.T) {
+	oldLookup, oldReport := domainLookupFn, runMTRReportFn
+	oldPort, oldDst := util.SrcPort, util.DstIP
+	t.Cleanup(func() {
+		domainLookupFn, runMTRReportFn = oldLookup, oldReport
+		util.SrcPort, util.DstIP = oldPort, oldDst
+	})
+	domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		return net.ParseIP("127.0.0.1"), nil
+	}
+	runMTRReportFn = func(_ context.Context, _ trace.Method, cfg trace.Config, opts trace.MTROptions, snapshot trace.MTROnSnapshot) error {
+		state := trace.NewMTRReplayState(true, cfg.MaxHops)
+		events := []trace.MTRSessionEvent{
+			{Type: trace.MTRSessionProbeEvent, Iteration: 1, Probe: &trace.MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Success: true, RTT: 1234567, CompletedAt: time.Now()}},
+			{Type: trace.MTRSessionProbeEvent, Iteration: 1, Probe: &trace.MTRSessionProbe{TTL: 1, CompletedAt: time.Now()}},
+			{Type: trace.MTRSessionMetadataEvent, Metadata: &trace.MTRSessionMetadata{IP: "192.0.2.1", Host: "router.example"}},
+			{Type: trace.MTRSessionPathEndEvent, PathEnd: &trace.StopReason{Hop: cfg.MaxHops, Reason: trace.StopReasonMaxHops}},
+		}
+		for _, event := range events {
+			event.At = time.Now()
+			if err := state.Apply(event); err != nil {
+				return err
+			}
+			if opts.OnEvent != nil {
+				if err := opts.OnEvent(event); err != nil {
+					return err
+				}
+			}
+		}
+		opts.OnPathEnd(state.PathEnd())
+		result := state.Snapshot()
+		snapshot(result.Iteration, result.Stats)
+		return nil
+	}
+	opts := testMTRJSONOptions()
+	opts.Report = true
+	opts.RecordDisplay = mtrRecordingDisplay{hostMode: 4, showIPs: true, wide: true}
+	var plain, recorded, stderr bytes.Buffer
+	if code := runMTRJSON(t.Context(), opts, &plain, &stderr); code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	opts.RecordPath = filepath.Join(t.TempDir(), "report.jsonl")
+	if code := runMTRJSON(t.Context(), opts, &recorded, &stderr); code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	var before, after mtrJSONReport
+	if err := json.Unmarshal(plain.Bytes(), &before); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(recorded.Bytes(), &after); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(before.Stats, after.Stats) || !reflect.DeepEqual(before.EffectiveParameters, after.EffectiveParameters) {
+		t.Fatal("recording changed JSON report data")
+	}
+	state := trace.NewMTRReplayState(true, opts.Config.MaxHops)
+	for _, record := range readMTRRecordingFixture(t, opts.RecordPath) {
+		if record.Session != nil && (record.Session.Display.HostMode != 4 || !record.Session.Display.ShowIPs || !record.Session.Display.Wide) {
+			t.Fatal("recording lost initial display settings")
+		}
+		if record.Type != mtrsession.StartEvent && record.Type != mtrsession.EndEvent {
+			if err := state.Apply(record.MTRSessionEvent); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if !reflect.DeepEqual(state.Snapshot().Stats, after.Stats) || !reflect.DeepEqual(state.PathEnd(), after.PathEnd) {
+		t.Fatalf("replay mismatch: %+v / %+v", state.Snapshot(), after)
+	}
+}
+
+func TestMTRRecordCLIRejectsModesBeforeNetwork(t *testing.T) {
+	if os.Getenv("NTRACE_TEST_MTR_RECORD_ARGS") == "1" {
+		domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+			panic("invalid recording arguments reached resolution")
+		}
+		for i, arg := range os.Args {
+			if arg == "--" {
+				os.Args = append([]string{appBinName}, os.Args[i+1:]...)
+				break
+			}
+		}
+		Execute()
+		os.Exit(0)
+	}
+	for _, extra := range [][]string{{"--speed"}, {"--dns"}, {"--doctor"}, {"--mtu"}, {"--deploy"}, {"--mtr-replay", "missing"}, {"--setup-api-v4-token"}, {"--table"}} {
+		args := []string{"-test.run=^TestMTRRecordCLIRejectsModesBeforeNetwork$", "--", "--mtr-record", filepath.Join(t.TempDir(), "record"), "127.0.0.1"}
+		if enableTraceroute {
+			args = append(args, "--mtr")
+		}
+		args = append(args, extra...)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		process := exec.CommandContext(ctx, os.Args[0], args...)
+		process.Env = append(os.Environ(), "NTRACE_TEST_MTR_RECORD_ARGS=1")
+		output, err := process.CombinedOutput()
+		cancel()
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) || exit.ExitCode() != 2 || strings.Contains(string(output), "panic") {
+			t.Fatalf("args=%v error=%v output=%s", extra, err, output)
+		}
+	}
+}

--- a/cmd/mtr_record_test.go
+++ b/cmd/mtr_record_test.go
@@ -178,6 +178,7 @@ func TestMTRJSONRecordedReportRebuildsSameSnapshot(t *testing.T) {
 		return nil
 	}
 	opts := testMTRJSONOptions()
+	opts.Config.MaxHops = 1
 	opts.Report = true
 	opts.RecordDisplay = mtrRecordingDisplay{hostMode: 4, showIPs: true, wide: true}
 	var plain, recorded, stderr bytes.Buffer

--- a/cmd/mtr_record_test.go
+++ b/cmd/mtr_record_test.go
@@ -127,7 +127,7 @@ func readMTRRecordingFixture(t *testing.T, path string) []mtrsession.Record {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	decoder := json.NewDecoder(f)
 	var records []mtrsession.Record
 	for {

--- a/cmd/mtr_replay.go
+++ b/cmd/mtr_replay.go
@@ -201,6 +201,9 @@ func runMTRReplay(ctx context.Context, opts mtrReplayOptions, stdout, stderr io.
 	}
 	if opts.json {
 		snap := loaded.state.Snapshot()
+		if snap.Stats == nil {
+			snap.Stats = []trace.MTRHopStat{}
+		}
 		return json.NewEncoder(&mtrReplayOutput{w: stdout}).Encode(struct {
 			SchemaVersion  int                 `json:"schema_version"`
 			Type           string              `json:"type"`

--- a/cmd/mtr_replay.go
+++ b/cmd/mtr_replay.go
@@ -43,6 +43,35 @@ func containsMTRReplayFlag(args []string) bool {
 	return false
 }
 
+func normalizeMTRReplayHelpArgs(args []string) []string {
+	result := append([]string(nil), args...)
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--" {
+			break
+		}
+		name, _, inline := strings.Cut(strings.TrimLeft(args[i], "-"), "=")
+		if !strings.HasPrefix(args[i], "-") || inline || !doctorValueOption(name) {
+			continue
+		}
+		if name == "mtr-replay" {
+			// Help/version needs no file. An explicit = preserves literal
+			// filenames such as --help instead of interpreting them as options.
+			if i+1 == len(args) {
+				result[i] += "="
+				continue
+			}
+			next, _, _ := strings.Cut(args[i+1], "=")
+			switch next {
+			case "--help", "-h", "--version", "-V":
+				result[i] += "="
+				continue
+			}
+		}
+		i++ // Preserve values belonging to other options or the replay path.
+	}
+	return result
+}
+
 func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) {
 	if !containsMTRReplayFlag(args) {
 		return false, 0
@@ -78,7 +107,7 @@ func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) 
 	}
 	fs.BoolVar(&o.showIPs, "show-ips", false, "Show PTR and IP together")
 	fs.StringVar(&o.columns, "mtr-columns", "", "Select text statistic columns")
-	ordered, err := doctorArgs(fs, args)
+	ordered, err := doctorArgs(fs, normalizeMTRReplayHelpArgs(args))
 	if err == nil {
 		err = fs.Parse(ordered)
 	}

--- a/cmd/mtr_replay.go
+++ b/cmd/mtr_replay.go
@@ -73,7 +73,9 @@ func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) 
 	for _, name := range []string{"y", "ipinfo"} {
 		fs.IntVar(&o.hostMode, name, 0, "Initial host display mode (0-4)")
 	}
-	fs.BoolVar(&o.json, "json", false, "Print the offline replay result as JSON")
+	for _, name := range []string{"j", "json"} {
+		fs.BoolVar(&o.json, name, false, "Print the offline replay result as JSON")
+	}
 	fs.BoolVar(&o.showIPs, "show-ips", false, "Show PTR and IP together")
 	fs.StringVar(&o.columns, "mtr-columns", "", "Select text statistic columns")
 	ordered, err := doctorArgs(fs, args)
@@ -81,31 +83,39 @@ func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) 
 		err = fs.Parse(ordered)
 	}
 	if err != nil {
-		fmt.Fprintln(stderr, "Invalid replay arguments; use --mtr-replay FILE --help.")
+		_, _ = fmt.Fprintln(stderr, "Invalid replay arguments; use --mtr-replay FILE --help.")
 		return true, 2
 	}
-	if help {
-		fmt.Fprintf(stdout, "Usage: %s --mtr-replay FILE [--report|--wide|--json]\nOffline only. J: time, Space: play, P: pause, R: rewind, Q: quit.\n", appBinName)
-		fs.SetOutput(stdout)
-		fs.PrintDefaults()
-		return true, 0
-	}
-	if version {
-		fmt.Fprintln(stdout, config.Version, config.CommitID)
-		return true, 0
+	if help || version {
+		return true, runMTRCLIWithSignals(func(context.Context) int {
+			output := &mtrReplayOutput{w: stdout}
+			// The sink retains errors, including writes hidden by PrintDefaults.
+			if help {
+				_, _ = fmt.Fprintf(output, "Usage: %s --mtr-replay FILE [--report|--wide|--json]\nOffline only. J: time, Space: play, P: pause, R: rewind, Q: quit.\n", appBinName)
+				fs.SetOutput(output)
+				fs.PrintDefaults()
+			} else {
+				_, _ = fmt.Fprintln(output, config.Version, config.CommitID)
+			}
+			if output.err != nil {
+				_, _ = fmt.Fprintln(stderr, output.err)
+				return 1
+			}
+			return 0
+		})
 	}
 	fs.Visit(func(f *flag.Flag) { o.explicit[f.Name] = true })
 	if fs.NArg() != 0 || strings.TrimSpace(o.file) == "" || o.file == "-" {
-		fmt.Fprintln(stderr, "Replay requires one --mtr-replay file and no target")
+		_, _ = fmt.Fprintln(stderr, "Replay requires one --mtr-replay file and no target")
 		return true, 2
 	}
 	if o.hostMode < 0 || o.hostMode > 4 || (o.language != "" && o.language != "cn" && o.language != "en") || (o.json && o.explicit["mtr-columns"]) {
-		fmt.Fprintln(stderr, "Invalid replay display options")
+		_, _ = fmt.Fprintln(stderr, "Invalid replay display options")
 		return true, 2
 	}
 	if o.explicit["mtr-columns"] {
 		if _, err = printer.ParseMTRColumns(o.columns, false); err != nil {
-			fmt.Fprintln(stderr, err)
+			_, _ = fmt.Fprintln(stderr, err)
 			return true, 2
 		}
 	}
@@ -122,8 +132,8 @@ func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) 
 			return 130
 		}
 		if err != nil {
-			if !errors.Is(err, errMTRReplayIncomplete) {
-				fmt.Fprintln(stderr, sanitizeMTRReplayText(err.Error()))
+			if err != errMTRReplayIncomplete {
+				_, _ = fmt.Fprintln(stderr, sanitizeMTRReplayText(err.Error()))
 			}
 			return 1
 		}
@@ -138,9 +148,13 @@ func runMTRReplay(ctx context.Context, opts mtrReplayOptions, stdout, stderr io.
 	if err != nil {
 		return err
 	}
-	defer r.Close()
+	defer func() {
+		if closeErr := r.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
 	if !opts.json && !opts.report && !opts.wide && stdout == os.Stdout && CheckTTY(int(os.Stdin.Fd()), int(os.Stdout.Fd())) {
-		fmt.Fprintln(stderr, "Loading recording...")
+		_, _ = fmt.Fprintln(stderr, "Loading recording...")
 	}
 	loaded, err := readMTRReplay(ctx, r, time.Duration(1<<63-1))
 	if err != nil {
@@ -154,7 +168,7 @@ func runMTRReplay(ctx context.Context, opts mtrReplayOptions, stdout, stderr io.
 	}()
 	duration := loaded.cursor
 	if !complete {
-		fmt.Fprintln(stderr, "Incomplete recording: displaying all complete events.")
+		_, _ = fmt.Fprintln(stderr, "Incomplete recording: displaying all complete events.")
 	}
 	if opts.json {
 		snap := loaded.state.Snapshot()

--- a/cmd/mtr_replay.go
+++ b/cmd/mtr_replay.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/config"
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type mtrReplayOptions struct {
+	file                                 string
+	report, wide, json, noColor, showIPs bool
+	columns, language                    string
+	hostMode                             int
+	explicit                             map[string]bool
+}
+
+func containsMTRReplayFlag(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return false
+		}
+		name, _, inline := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+		if strings.HasPrefix(arg, "-") && name == "mtr-replay" {
+			return true
+		}
+		if strings.HasPrefix(arg, "-") && !inline && doctorValueOption(name) {
+			i++
+		}
+	}
+	return false
+}
+
+func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) {
+	if !containsMTRReplayFlag(args) {
+		return false, 0
+	}
+	fs := flag.NewFlagSet(appBinName+" --mtr-replay", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	o := mtrReplayOptions{explicit: make(map[string]bool)}
+	var help, version bool
+	fs.StringVar(&o.file, "mtr-replay", "", "Read an MTR session offline")
+	for _, name := range []string{"h", "help"} {
+		fs.BoolVar(&help, name, false, "Show replay help")
+	}
+	for _, name := range []string{"V", "version"} {
+		fs.BoolVar(&version, name, false, "Show version")
+	}
+	for _, name := range []string{"r", "report"} {
+		fs.BoolVar(&o.report, name, false, "Print the final statistics")
+	}
+	for _, name := range []string{"w", "wide"} {
+		fs.BoolVar(&o.wide, name, false, "Print a wide final report")
+	}
+	for _, name := range []string{"C", "no-color"} {
+		fs.BoolVar(&o.noColor, name, false, "Disable color")
+	}
+	for _, name := range []string{"g", "language"} {
+		fs.StringVar(&o.language, name, "", "Display language: cn or en")
+	}
+	for _, name := range []string{"y", "ipinfo"} {
+		fs.IntVar(&o.hostMode, name, 0, "Initial host display mode (0-4)")
+	}
+	fs.BoolVar(&o.json, "json", false, "Print the offline replay result as JSON")
+	fs.BoolVar(&o.showIPs, "show-ips", false, "Show PTR and IP together")
+	fs.StringVar(&o.columns, "mtr-columns", "", "Select text statistic columns")
+	ordered, err := doctorArgs(fs, args)
+	if err == nil {
+		err = fs.Parse(ordered)
+	}
+	if err != nil {
+		fmt.Fprintln(stderr, "Invalid replay arguments; use --mtr-replay FILE --help.")
+		return true, 2
+	}
+	if help {
+		fmt.Fprintf(stdout, "Usage: %s --mtr-replay FILE [--report|--wide|--json]\nOffline only. J: time, Space: play, P: pause, R: rewind, Q: quit.\n", appBinName)
+		fs.SetOutput(stdout)
+		fs.PrintDefaults()
+		return true, 0
+	}
+	if version {
+		fmt.Fprintln(stdout, config.Version, config.CommitID)
+		return true, 0
+	}
+	fs.Visit(func(f *flag.Flag) { o.explicit[f.Name] = true })
+	if fs.NArg() != 0 || strings.TrimSpace(o.file) == "" || o.file == "-" {
+		fmt.Fprintln(stderr, "Replay requires one --mtr-replay file and no target")
+		return true, 2
+	}
+	if o.hostMode < 0 || o.hostMode > 4 || (o.language != "" && o.language != "cn" && o.language != "en") || (o.json && o.explicit["mtr-columns"]) {
+		fmt.Fprintln(stderr, "Invalid replay display options")
+		return true, 2
+	}
+	if o.explicit["mtr-columns"] {
+		if _, err = printer.ParseMTRColumns(o.columns, false); err != nil {
+			fmt.Fprintln(stderr, err)
+			return true, 2
+		}
+	}
+	return true, runMTRCLIWithSignals(func(ctx context.Context) int {
+		err := runMTRReplay(ctx, o, stdout, stderr)
+		if cause := context.Cause(ctx); cause != nil {
+			err = cause
+		}
+		var interrupted *mtrJSONSignal
+		if errors.As(err, &interrupted) {
+			if interrupted.signal == syscall.SIGTERM {
+				return 143
+			}
+			return 130
+		}
+		if err != nil {
+			if !errors.Is(err, errMTRReplayIncomplete) {
+				fmt.Fprintln(stderr, sanitizeMTRReplayText(err.Error()))
+			}
+			return 1
+		}
+		return 0
+	})
+}
+
+var errMTRReplayIncomplete = errors.New("incomplete MTR recording")
+
+func runMTRReplay(ctx context.Context, opts mtrReplayOptions, stdout, stderr io.Writer) (err error) {
+	r, err := mtrsession.OpenReader(opts.file)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	if !opts.json && !opts.report && !opts.wide && stdout == os.Stdout && CheckTTY(int(os.Stdin.Fd()), int(os.Stdout.Fd())) {
+		fmt.Fprintln(stderr, "Loading recording...")
+	}
+	loaded, err := readMTRReplay(ctx, r, time.Duration(1<<63-1))
+	if err != nil {
+		return err
+	}
+	complete := !r.Incomplete()
+	defer func() {
+		if err == nil && !complete {
+			err = errMTRReplayIncomplete
+		}
+	}()
+	duration := loaded.cursor
+	if !complete {
+		fmt.Fprintln(stderr, "Incomplete recording: displaying all complete events.")
+	}
+	if opts.json {
+		snap := loaded.state.Snapshot()
+		return json.NewEncoder(&mtrReplayOutput{w: stdout}).Encode(struct {
+			SchemaVersion  int                 `json:"schema_version"`
+			Type           string              `json:"type"`
+			Session        *mtrsession.Session `json:"session"`
+			Complete       bool                `json:"complete"`
+			CursorNS       int64               `json:"cursor_ns"`
+			DurationNS     int64               `json:"duration_ns"`
+			Generation     uint64              `json:"generation"`
+			RecordedPaused bool                `json:"recorded_paused"`
+			PathEnd        *trace.StopReason   `json:"path_end"`
+			Stats          []trace.MTRHopStat  `json:"stats"`
+			End            *mtrsession.End     `json:"end,omitempty"`
+		}{1, "mtr_replay", loaded.session, complete, int64(duration), int64(duration), loaded.state.Generation(), loaded.state.Paused(), loaded.state.PathEnd(), snap.Stats, loaded.end})
+	}
+	header, err := mtrReplayHeader(loaded.session, opts)
+	if err != nil {
+		return err
+	}
+	if opts.report || opts.wide || stdout != os.Stdout || !CheckTTY(int(os.Stdin.Fd()), int(os.Stdout.Fd())) {
+		wide := opts.wide || (!opts.report && loaded.session.Display.Wide)
+		return printer.WriteMTRReplayReport(stdout, sanitizeMTRReplayStats(loaded.state.Snapshot().Stats), printer.MTRReportOptions{Columns: header.Columns, StartTime: header.StartTime, SrcHost: header.SrcHost, Wide: wide, ShowIPs: header.ShowIPs, Lang: header.Lang})
+	}
+	applyColorMode(opts.noColor)
+	return runMTRReplayTUI(ctx, r, loaded, header, duration, complete, stdout)
+}
+
+func mtrReplayHeader(session *mtrsession.Session, opts mtrReplayOptions) (printer.MTRTUIHeader, error) {
+	header := printer.MTRTUIHeader{Target: session.Target, Domain: session.Target, TargetIP: session.ResolvedIP, Version: session.Version, StartTime: session.StartedAt, SrcHost: session.SourceHost, DisplayMode: session.Display.HostMode, NameMode: session.Display.HostNameMode, ShowIPs: session.Display.ShowIPs, DisableMPLS: !session.Display.ShowMPLS}
+	if p := session.EffectiveParameters; p != nil {
+		header.Lang = p.Language
+		header.SrcIP = p.SourceAddress
+	}
+	if session.SourceIP != "" {
+		header.SrcIP = session.SourceIP
+	}
+	if opts.explicit["language"] || opts.explicit["g"] {
+		header.Lang = opts.language
+	}
+	if opts.explicit["ipinfo"] || opts.explicit["y"] {
+		header.DisplayMode = opts.hostMode
+	}
+	if opts.explicit["show-ips"] {
+		header.ShowIPs = opts.showIPs
+	}
+	columns := session.Display.Columns
+	if opts.explicit["mtr-columns"] {
+		columns = opts.columns
+	}
+	if columns != "" {
+		var err error
+		header.Columns, err = printer.ParseMTRColumns(columns, false)
+		if err != nil {
+			return header, err
+		}
+	}
+	for _, field := range []*string{&header.Target, &header.Domain, &header.TargetIP, &header.Version, &header.SrcHost, &header.SrcIP} {
+		*field = sanitizeMTRReplayText(*field)
+	}
+	return header, nil
+}

--- a/cmd/mtr_replay.go
+++ b/cmd/mtr_replay.go
@@ -43,7 +43,7 @@ func containsMTRReplayFlag(args []string) bool {
 	return false
 }
 
-func normalizeMTRReplayHelpArgs(args []string) []string {
+func normalizeMTRReplayArgs(fs *flag.FlagSet, args []string) []string {
 	result := append([]string(nil), args...)
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--" {
@@ -54,15 +54,14 @@ func normalizeMTRReplayHelpArgs(args []string) []string {
 			continue
 		}
 		if name == "mtr-replay" {
-			// Help/version needs no file. An explicit = preserves literal
-			// filenames such as --help instead of interpreting them as options.
+			// Do not consume a recognized option as a missing filename.
+			// Explicit = or ./ still permits option-like filenames.
 			if i+1 == len(args) {
 				result[i] += "="
 				continue
 			}
-			next, _, _ := strings.Cut(args[i+1], "=")
-			switch next {
-			case "--help", "-h", "--version", "-V":
+			next, _, _ := strings.Cut(strings.TrimLeft(args[i+1], "-"), "=")
+			if strings.HasPrefix(args[i+1], "-") && (args[i+1] == "--" || fs.Lookup(next) != nil) {
 				result[i] += "="
 				continue
 			}
@@ -107,7 +106,7 @@ func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) 
 	}
 	fs.BoolVar(&o.showIPs, "show-ips", false, "Show PTR and IP together")
 	fs.StringVar(&o.columns, "mtr-columns", "", "Select text statistic columns")
-	ordered, err := doctorArgs(fs, normalizeMTRReplayHelpArgs(args))
+	ordered, err := doctorArgs(fs, normalizeMTRReplayArgs(fs, args))
 	if err == nil {
 		err = fs.Parse(ordered)
 	}

--- a/cmd/mtr_replay_clock_test.go
+++ b/cmd/mtr_replay_clock_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+)
+
+func TestMTRReplayHistorySurvivesWallClockJump(t *testing.T) {
+	for _, jump := range []time.Duration{-10 * time.Minute, 10 * time.Minute} {
+		t.Run(jump.String(), func(t *testing.T) {
+			start := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+			file := replayFixture(t, start, true)
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+				var record mtrsession.Record
+				if err := json.Unmarshal(line, &record); err != nil {
+					t.Fatal(err)
+				}
+				if record.Probe != nil {
+					age := int64(20 * time.Millisecond)
+					record.ProbeAgeNS = &age
+					record.Timestamp = record.Timestamp.Add(jump)
+				}
+				if err := json.NewEncoder(&output).Encode(record); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(file, output.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			r, err := mtrsession.OpenReader(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = r.Close() }()
+			final, err := readMTRReplay(t.Context(), r, time.Duration(1<<63-1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			history := final.history.Snapshot(start.Add(final.cursor))
+			want := start.Add(4*time.Second - 20*time.Millisecond)
+			if len(history) != 1 || len(history[0].Samples) != 1 || !history[0].Samples[0].At.Equal(want) {
+				t.Fatalf("history after wall clock jump %s: %+v; want one sample at %s", jump, history, want)
+			}
+		})
+	}
+}

--- a/cmd/mtr_replay_input.go
+++ b/cmd/mtr_replay_input.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/printer"
+)
+
+type mtrReplayCommand struct {
+	kind      string
+	at        time.Duration
+	playAfter bool
+}
+
+type mtrReplayControls struct {
+	commands chan mtrReplayCommand
+	cursor   atomic.Int64
+	duration time.Duration
+}
+
+func (r *mtrReplayControls) send(command mtrReplayCommand) {
+	// Keep a pending seek when a play/pause key immediately follows Enter.
+	select {
+	case r.commands <- command:
+		return
+	default:
+	}
+	select {
+	case previous := <-r.commands:
+		if previous.kind == "seek" && command.kind != "seek" {
+			previous.playAfter = command.kind == "play"
+			command = previous
+		}
+	default:
+	}
+	select {
+	case r.commands <- command:
+	default:
+	}
+}
+
+func (u *mtrUI) isMTREditing() bool {
+	u.columnsMu.Lock()
+	defer u.columnsMu.Unlock()
+	return u.columnEditor.Active || u.replayEditor.Active
+}
+
+func (u *mtrUI) editMTRInput(b byte, paste bool) {
+	u.columnsMu.Lock()
+	replay := u.replayEditor.Active
+	u.columnsMu.Unlock()
+	if replay {
+		u.editReplayTime(b, paste)
+	} else {
+		u.editColumn(b, paste)
+	}
+}
+
+func (u *mtrUI) applyReplayAction(action mtrInputAction) bool {
+	switch action {
+	case mtrActionPause:
+		u.paused.Store(true)
+		u.replay.send(mtrReplayCommand{kind: "pause"})
+	case mtrActionResume:
+		u.paused.Store(false)
+		u.replay.send(mtrReplayCommand{kind: "play"})
+	case mtrActionRestart:
+		u.paused.Store(true)
+		u.replay.send(mtrReplayCommand{kind: "seek"})
+	case mtrActionReplayJump:
+		u.paused.Store(true)
+		u.replay.send(mtrReplayCommand{kind: "pause"})
+		u.columnsMu.Lock()
+		u.replayEditor = printer.MTRReplayEditor{Active: true, Draft: printer.FormatMTRReplayTime(time.Duration(u.replay.cursor.Load()))}
+		u.columnsMu.Unlock()
+	default:
+		return false
+	}
+	return true
+}
+
+func (u *mtrUI) editReplayTime(b byte, paste bool) {
+	u.columnsMu.Lock()
+	defer u.columnsMu.Unlock()
+	e := &u.replayEditor
+	if !e.Active {
+		return
+	}
+	if !paste {
+		switch b {
+		case 27:
+			e.Active = false
+			return
+		case 8, 127:
+			if len(e.Draft) > 0 {
+				e.Draft = e.Draft[:len(e.Draft)-1]
+			}
+			e.Error = ""
+			return
+		case 21:
+			e.Draft = ""
+			e.Error = ""
+			return
+		case '\r', '\n':
+			at, err := parseMTRReplayTime(e.Draft)
+			if err != nil {
+				e.Error = err.Error()
+				return
+			}
+			if at > u.replay.duration {
+				e.Error = "Time exceeds recording duration"
+				return
+			}
+			e.Active = false
+			e.Error = ""
+			u.replay.send(mtrReplayCommand{kind: "seek", at: at})
+			return
+		}
+	}
+	if b >= 32 && b <= 126 {
+		if len(e.Draft) >= 32 {
+			e.Error = "Maximum 32 characters"
+			return
+		}
+		e.Draft += string(b)
+		e.Error = ""
+	}
+}
+
+func parseMTRReplayTime(value string) (time.Duration, error) {
+	invalid := errors.New("Use HH:MM:SS[.mmm]")
+	parts := strings.Split(strings.TrimSpace(value), ":")
+	if len(parts) != 3 || len(parts[0]) < 2 || len(parts[1]) != 2 {
+		return 0, invalid
+	}
+	seconds := strings.Split(parts[2], ".")
+	if len(seconds) > 2 || len(seconds[0]) != 2 {
+		return 0, invalid
+	}
+	if len(seconds) == 2 && (len(seconds[1]) == 0 || len(seconds[1]) > 3) {
+		return 0, invalid
+	}
+	for _, p := range []string{parts[0], parts[1], strings.Join(seconds, "")} {
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return 0, invalid
+			}
+		}
+	}
+	h, e1 := strconv.ParseUint(parts[0], 10, 64)
+	m, e2 := strconv.ParseUint(parts[1], 10, 64)
+	s, e3 := strconv.ParseUint(seconds[0], 10, 64)
+	if e1 != nil || e2 != nil || e3 != nil || m >= 60 || s >= 60 || h > uint64((1<<63-1)/int64(time.Hour)) {
+		return 0, invalid
+	}
+	ms := uint64(0)
+	if len(seconds) == 2 {
+		ms, _ = strconv.ParseUint(seconds[1]+strings.Repeat("0", 3-len(seconds[1])), 10, 64)
+	}
+	ns := h*uint64(time.Hour) + m*uint64(time.Minute) + s*uint64(time.Second) + ms*uint64(time.Millisecond)
+	if ns > 1<<63-1 {
+		return 0, invalid
+	}
+	return time.Duration(ns), nil
+}

--- a/cmd/mtr_replay_input.go
+++ b/cmd/mtr_replay_input.go
@@ -112,7 +112,7 @@ func (u *mtrUI) editReplayTime(b byte, paste bool) {
 				return
 			}
 			if at > u.replay.duration {
-				e.Error = "Time exceeds recording duration"
+				e.Error = "time exceeds recording duration"
 				return
 			}
 			e.Active = false
@@ -123,7 +123,7 @@ func (u *mtrUI) editReplayTime(b byte, paste bool) {
 	}
 	if b >= 32 && b <= 126 {
 		if len(e.Draft) >= 32 {
-			e.Error = "Maximum 32 characters"
+			e.Error = "maximum 32 characters"
 			return
 		}
 		e.Draft += string(b)
@@ -132,7 +132,7 @@ func (u *mtrUI) editReplayTime(b byte, paste bool) {
 }
 
 func parseMTRReplayTime(value string) (time.Duration, error) {
-	invalid := errors.New("Use HH:MM:SS[.mmm]")
+	invalid := errors.New("use HH:MM:SS[.mmm]")
 	parts := strings.Split(strings.TrimSpace(value), ":")
 	if len(parts) != 3 || len(parts[0]) < 2 || len(parts[1]) != 2 {
 		return 0, invalid

--- a/cmd/mtr_replay_read.go
+++ b/cmd/mtr_replay_read.go
@@ -97,6 +97,9 @@ func (c *mtrReplayCursor) apply(record mtrsession.Record) error {
 	if p := record.Probe; p != nil {
 		now := c.session.StartedAt.Add(time.Duration(record.ElapsedNS))
 		age := max(time.Duration(0), record.Timestamp.Sub(p.CompletedAt))
+		if record.ProbeAgeNS != nil {
+			age = time.Duration(*record.ProbeAgeNS)
+		}
 		c.history.AddProbeEventAt(trace.MTRProbeEvent{TTL: p.TTL, Success: p.Success, RTT: p.RTT, Timestamp: now.Add(-age)}, now)
 	}
 	return nil

--- a/cmd/mtr_replay_read.go
+++ b/cmd/mtr_replay_read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/internal/mtrsession"
@@ -82,6 +83,15 @@ func (c *mtrReplayCursor) apply(record mtrsession.Record) error {
 		c.state = trace.NewMTRReplayState(bounded, maxHops)
 		return nil
 	case mtrsession.EndEvent:
+		recorded, rebuilt := record.End.PathEnd, c.state.PathEnd()
+		matched := recorded == nil && rebuilt == nil
+		if recorded != nil && rebuilt != nil {
+			matched = recorded.Hop == rebuilt.Hop && recorded.Reason == rebuilt.Reason &&
+				slices.Equal(recorded.Responses, rebuilt.Responses) && slices.Equal(recorded.Markers, rebuilt.Markers)
+		}
+		if !matched {
+			return errors.New("recording footer path does not match replay state")
+		}
 		c.end = record.End
 		return nil
 	}

--- a/cmd/mtr_replay_read.go
+++ b/cmd/mtr_replay_read.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type mtrReplayCursor struct {
+	session *mtrsession.Session
+	state   *trace.MTRReplayState
+	history *printer.MTRHistoryStore
+	pending *mtrsession.Record
+	end     *mtrsession.End
+	cursor  time.Duration
+	eof     bool
+}
+
+func readMTRReplay(ctx context.Context, r *mtrsession.Reader, at time.Duration) (*mtrReplayCursor, error) {
+	if err := r.Rewind(); err != nil {
+		return nil, err
+	}
+	c := &mtrReplayCursor{history: printer.NewMTRHistoryStore(printer.MTRHistoryWindow)}
+	if err := c.advance(ctx, r, at); err != nil {
+		return nil, err
+	}
+	if c.session == nil {
+		return nil, errors.New("recording has no session header")
+	}
+	return c, nil
+}
+
+func (c *mtrReplayCursor) advance(ctx context.Context, r *mtrsession.Reader, at time.Duration) error {
+	for !c.eof {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var record mtrsession.Record
+		if c.pending != nil {
+			record = *c.pending
+			c.pending = nil
+		} else {
+			var err error
+			record, err = r.Next()
+			if errors.Is(err, io.EOF) {
+				c.eof = true
+				break
+			}
+			if err != nil {
+				return err
+			}
+		}
+		if time.Duration(record.ElapsedNS) > at {
+			c.pending = &record
+			break
+		}
+		c.cursor = time.Duration(record.ElapsedNS)
+		if err := c.apply(record); err != nil {
+			return err
+		}
+	}
+	if at != time.Duration(1<<63-1) {
+		c.cursor = at
+	}
+	return nil
+}
+
+func (c *mtrReplayCursor) apply(record mtrsession.Record) error {
+	switch record.Type {
+	case mtrsession.StartEvent:
+		c.session = record.Session
+		maxHops, bounded := 30, false
+		if p := c.session.EffectiveParameters; p != nil {
+			maxHops = p.MaxHops
+			bounded = p.MaxPerHop > 0
+		}
+		c.state = trace.NewMTRReplayState(bounded, maxHops)
+		return nil
+	case mtrsession.EndEvent:
+		c.end = record.End
+		return nil
+	}
+	if c.state == nil {
+		return errors.New("recording event precedes session header")
+	}
+	if err := c.state.Apply(record.MTRSessionEvent); err != nil {
+		return err
+	}
+	if record.Type == trace.MTRSessionResetEvent {
+		c.history.Reset()
+	}
+	if p := record.Probe; p != nil {
+		now := c.session.StartedAt.Add(time.Duration(record.ElapsedNS))
+		age := max(time.Duration(0), record.Timestamp.Sub(p.CompletedAt))
+		c.history.AddProbeEventAt(trace.MTRProbeEvent{TTL: p.TTL, Success: p.Success, RTT: p.RTT, Timestamp: now.Add(-age)}, now)
+	}
+	return nil
+}

--- a/cmd/mtr_replay_test.go
+++ b/cmd/mtr_replay_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -65,7 +66,7 @@ func TestMTRReplaySeekRebuildAndVirtualHistory(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer r.Close()
+			defer func() { _ = r.Close() }()
 			final, err := readMTRReplay(t.Context(), r, time.Duration(1<<63-1))
 			if err != nil {
 				t.Fatal(err)
@@ -143,6 +144,13 @@ func TestMTRReplayOfflineCLIAndPartialResult(t *testing.T) {
 		if strings.Contains(diag.String(), "Incomplete") == complete {
 			t.Fatalf("diag=%s", diag.String())
 		}
+		canonicalJSON := append([]byte(nil), out.Bytes()...)
+		out.Reset()
+		diag.Reset()
+		_, code = maybeRunMTRReplayMode([]string{"--mtr-replay", path, "-j"}, &out, &diag)
+		if code != wantCode || !bytes.Equal(canonicalJSON, out.Bytes()) {
+			t.Fatalf("JSON alias differs: code=%d out=%s diag=%s", code, out.String(), diag.String())
+		}
 		out.Reset()
 		diag.Reset()
 		_, code = maybeRunMTRReplayMode([]string{"--mtr-replay", path, "-w", "--mtr-columns", "received,avg"}, &out, &diag)
@@ -169,11 +177,40 @@ func TestMTRReplayArgumentsAndCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if _, err := readMTRReplay(ctx, r, time.Second); !errors.Is(err, context.Canceled) {
 		t.Fatalf("cancel err=%v", err)
+	}
+}
+
+type replayDelayedWriteFailure struct{ calls int }
+
+func (w *replayDelayedWriteFailure) Write(data []byte) (int, error) {
+	w.calls++
+	if w.calls == 1 {
+		return len(data), nil
+	}
+	return 0, io.ErrClosedPipe
+}
+
+func TestMTRReplayHelpVersionWriteFailures(t *testing.T) {
+	for _, flag := range []string{"--help", "--version"} {
+		for _, short := range []bool{false, true} {
+			var diag bytes.Buffer
+			writer := &failingMTRWriter{short: short}
+			handled, code := maybeRunMTRReplayMode([]string{"--mtr-replay", "unused", flag}, writer, &diag)
+			if !handled || code != 1 || writer.calls != 1 || diag.Len() == 0 {
+				t.Fatalf("flag=%s short=%v handled=%v code=%d writes=%d diag=%s", flag, short, handled, code, writer.calls, diag.String())
+			}
+		}
+	}
+	var diag bytes.Buffer
+	writer := &replayDelayedWriteFailure{}
+	_, code := maybeRunMTRReplayMode([]string{"--mtr-replay", "unused", "--help"}, writer, &diag)
+	if code != 1 || writer.calls != 2 || diag.Len() == 0 {
+		t.Fatalf("PrintDefaults error lost: code=%d writes=%d diag=%s", code, writer.calls, diag.String())
 	}
 }
 
@@ -301,7 +338,7 @@ func TestMTRReplayLongSessionStreamingSeek(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	started = time.Now()
 	final, err := readMTRReplay(t.Context(), r, time.Duration(1<<63-1))
 	if err != nil {

--- a/cmd/mtr_replay_test.go
+++ b/cmd/mtr_replay_test.go
@@ -58,6 +58,53 @@ func replayFixture(t *testing.T, start time.Time, complete bool) string {
 	return path
 }
 
+func TestMTRReplayEmptyStatsArray(t *testing.T) {
+	for _, mode := range []string{"empty", "initialize-failed", "reset", "incomplete"} {
+		t.Run(mode, func(t *testing.T) {
+			start := time.Now()
+			path := filepath.Join(t.TempDir(), "empty.jsonl")
+			w, err := mtrsession.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = w.Close() }()
+			session := mtrsession.Session{Version: "test", StartedAt: start}
+			if err := w.Start(session); err != nil {
+				t.Fatal(err)
+			}
+			if mode == "reset" {
+				if err := w.Event(trace.MTRSessionEvent{Type: trace.MTRSessionResetEvent, Generation: 1, At: start.Add(time.Second)}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			end := mtrsession.End{EndedAt: start.Add(2 * time.Second), EndReason: "completed"}
+			if mode == "initialize-failed" {
+				end.EndReason, end.Error = "error", &mtrsession.Error{Stage: "initialize", Message: "test failure"}
+			}
+			if mode != "incomplete" {
+				if err := w.Finish(end); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			var output, diagnostic bytes.Buffer
+			_, code := maybeRunMTRReplayMode([]string{"--mtr-replay", path, "--json"}, &output, &diagnostic)
+			var report map[string]json.RawMessage
+			if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+				t.Fatalf("invalid replay JSON: %v: %s", err, diagnostic.String())
+			}
+			expectedCode := 0
+			if mode == "incomplete" {
+				expectedCode = 1
+			}
+			if code != expectedCode || string(report["stats"]) != "[]" {
+				t.Fatalf("code=%d stats=%s", code, report["stats"])
+			}
+		})
+	}
+}
+
 func TestMTRReplaySeekRebuildAndVirtualHistory(t *testing.T) {
 	for _, year := range []int{2000, 2100} {
 		t.Run(time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006"), func(t *testing.T) {

--- a/cmd/mtr_replay_test.go
+++ b/cmd/mtr_replay_test.go
@@ -1,0 +1,332 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func replayFixture(t *testing.T, start time.Time, complete bool) string {
+	t.Helper()
+	session := &mtrsession.Session{Version: "test", Target: "offline.invalid", ResolvedIP: "192.0.2.1", Protocol: "icmp", StartedAt: start, SourceHost: "recorded-host", SourceIP: "192.0.2.10", EffectiveParameters: &mtrsession.Parameters{MaxHops: 3, BeginHop: 1, MaxPerHop: 3, HopIntervalMs: 1000, TimeoutMs: 1000, ParallelRequests: 2}, Display: mtrsession.DisplayParameters{ShowMPLS: true}}
+	probe := func(gen uint64, at time.Duration, host string) trace.MTRSessionEvent {
+		return trace.MTRSessionEvent{Type: trace.MTRSessionProbeEvent, Generation: gen, Iteration: 1, Probe: &trace.MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Host: host, Success: true, RTT: 1234567, CompletedAt: start.Add(at)}}
+	}
+	records := []mtrsession.Record{
+		{MTRSessionEvent: trace.MTRSessionEvent{Type: mtrsession.StartEvent}, Session: session},
+		{ElapsedNS: int64(time.Second), MTRSessionEvent: probe(0, time.Second, "before.invalid")},
+		{ElapsedNS: int64(2 * time.Second), MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionPauseEvent}},
+		{ElapsedNS: int64(3 * time.Second), MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionResetEvent, Generation: 1}},
+		{ElapsedNS: int64(4 * time.Second), MTRSessionEvent: probe(1, 4*time.Second, "")},
+		{ElapsedNS: int64(5 * time.Second), MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionMetadataEvent, Generation: 1, Metadata: &trace.MTRSessionMetadata{IP: "192.0.2.1", Host: "patched.invalid", Geo: &ipgeo.IPGeoData{Country: "测试"}}}},
+		{ElapsedNS: int64(6 * time.Second), MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionResumeEvent, Generation: 1}},
+	}
+	if complete {
+		records = append(records, mtrsession.Record{ElapsedNS: int64(7 * time.Second), MTRSessionEvent: trace.MTRSessionEvent{Type: mtrsession.EndEvent, Generation: 1}, End: &mtrsession.End{EndedAt: start.Add(7 * time.Second), EndReason: "completed"}})
+	}
+	var b bytes.Buffer
+	for i := range records {
+		r := &records[i]
+		r.Format = mtrsession.FormatName
+		r.SchemaVersion = mtrsession.SchemaVersion
+		r.Seq = uint64(i + 1)
+		r.Timestamp = start.Add(time.Duration(r.ElapsedNS))
+		if err := json.NewEncoder(&b).Encode(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !complete {
+		b.WriteString(`{"type":"end"`)
+	}
+	path := filepath.Join(t.TempDir(), "recording.ndjson")
+	if err := os.WriteFile(path, b.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestMTRReplaySeekRebuildAndVirtualHistory(t *testing.T) {
+	for _, year := range []int{2000, 2100} {
+		t.Run(time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006"), func(t *testing.T) {
+			start := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+			r, err := mtrsession.OpenReader(replayFixture(t, start, true))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer r.Close()
+			final, err := readMTRReplay(t.Context(), r, time.Duration(1<<63-1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			stats := final.state.Snapshot().Stats
+			if r.Incomplete() || final.cursor != 7*time.Second || len(stats) != 1 || stats[0].Snt != 1 || stats[0].Host != "patched.invalid" || stats[0].Geo.Country != "测试" || final.state.Generation() != 1 || final.state.Paused() {
+				t.Fatalf("final=%+v stats=%+v", final, stats)
+			}
+			history := final.history.Snapshot(start.Add(final.cursor))
+			if len(history) != 1 || len(history[0].Samples) != 1 || !history[0].Samples[0].At.Equal(start.Add(4*time.Second)) {
+				t.Fatalf("history=%+v", history)
+			}
+			before, err := readMTRReplay(t.Context(), r, 2500*time.Millisecond)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if before.cursor != 2500*time.Millisecond || !before.state.Paused() || before.state.Generation() != 0 || before.state.Snapshot().Stats[0].Host != "before.invalid" {
+				t.Fatalf("seek=%+v", before)
+			}
+			if err := before.advance(t.Context(), r, 7*time.Second); err != nil {
+				t.Fatal(err)
+			}
+			if got := before.state.Snapshot().Stats; len(got) != 1 || got[0].Snt != 1 || got[0].Host != "patched.invalid" {
+				t.Fatalf("forward=%+v", got)
+			}
+			atReset, err := readMTRReplay(t.Context(), r, 3*time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(atReset.state.Snapshot().Stats) != 0 || len(atReset.history.Snapshot(start.Add(3*time.Second))) != 0 {
+				t.Fatal("reset retained data")
+			}
+		})
+	}
+}
+
+func TestMTRReplayOfflineCLIAndPartialResult(t *testing.T) {
+	oldLookup, oldReport, oldRaw := domainLookupFn, runMTRReportFn, runMTRJSONRawFn
+	t.Cleanup(func() { domainLookupFn, runMTRReportFn, runMTRJSONRawFn = oldLookup, oldReport, oldRaw })
+	domainLookupFn = func(context.Context, string, string, string, bool) (net.IP, error) {
+		t.Fatal("offline replay called DNS")
+		return nil, nil
+	}
+	runMTRReportFn = func(context.Context, trace.Method, trace.Config, trace.MTROptions, trace.MTROnSnapshot) error {
+		t.Fatal("offline replay called MTR")
+		return nil
+	}
+	runMTRJSONRawFn = func(context.Context, trace.Method, trace.Config, trace.MTRRawOptions, trace.MTRRawOnRecord) error {
+		t.Fatal("offline replay called RAW")
+		return nil
+	}
+	for _, complete := range []bool{false, true} {
+		wantCode := 0
+		if !complete {
+			wantCode = 1
+		}
+		path := replayFixture(t, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), complete)
+		var out, diag bytes.Buffer
+		handled, code := maybeRunMTRReplayMode([]string{"--mtr-replay", path, "--json"}, &out, &diag)
+		if !handled || code != wantCode {
+			t.Fatalf("handled=%v code=%d diag=%s", handled, code, diag.String())
+		}
+		var result struct {
+			Complete bool               `json:"complete"`
+			Cursor   int64              `json:"cursor_ns"`
+			Stats    []trace.MTRHopStat `json:"stats"`
+			Type     string             `json:"type"`
+		}
+		if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+			t.Fatal(err)
+		}
+		if result.Complete != complete || result.Type != "mtr_replay" || len(result.Stats) != 1 || result.Stats[0].Snt != 1 || result.Cursor <= 0 {
+			t.Fatalf("result=%s", out.String())
+		}
+		if strings.Contains(diag.String(), "Incomplete") == complete {
+			t.Fatalf("diag=%s", diag.String())
+		}
+		out.Reset()
+		diag.Reset()
+		_, code = maybeRunMTRReplayMode([]string{"--mtr-replay", path, "-w", "--mtr-columns", "received,avg"}, &out, &diag)
+		if code != wantCode || strings.Contains(out.String(), "\x1b") || !strings.Contains(out.String(), "Rcv") || !strings.Contains(out.String(), "patched.invalid") {
+			t.Fatalf("report code=%d out=%s diag=%s", code, out.String(), diag.String())
+		}
+	}
+}
+
+func TestMTRReplayArgumentsAndCancellation(t *testing.T) {
+	for _, args := range [][]string{{"--", "--mtr-replay"}, {"--mtr-record", "--mtr-replay"}, {"--file", "--mtr-replay"}, {"--source=--mtr-replay"}} {
+		if containsMTRReplayFlag(args) {
+			t.Fatalf("stole argument %v", args)
+		}
+	}
+	for _, args := range [][]string{{"--mtr-replay=x", "--tcp"}, {"--mtr-replay=x", "--doctor"}, {"--mtr-replay=x", "--no-rdns"}, {"--mtr-replay=x", "--disable-mpls"}, {"--mtr-replay=x", "target"}, {"--mtr-replay=x", "--ipinfo=9"}, {"--mtr-replay=x", "--json", "--mtr-columns=avg"}} {
+		var out, diag bytes.Buffer
+		handled, code := maybeRunMTRReplayMode(args, &out, &diag)
+		if !handled || code != 2 || out.Len() != 0 {
+			t.Fatalf("args=%v handled=%v code=%d out=%s", args, handled, code, out.String())
+		}
+	}
+	r, err := mtrsession.OpenReader(replayFixture(t, time.Now(), true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := readMTRReplay(ctx, r, time.Second); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel err=%v", err)
+	}
+}
+
+func TestMTRReplayTimeEditor(t *testing.T) {
+	for value, want := range map[string]time.Duration{"00:00:00": 0, "00:01:02.3": 62300 * time.Millisecond, "100:59:59.999": 100*time.Hour + 59*time.Minute + 59999*time.Millisecond} {
+		got, err := parseMTRReplayTime(value)
+		if err != nil || got != want {
+			t.Fatalf("%q: %s %v", value, got, err)
+		}
+	}
+	for _, value := range []string{"1:02:03", "00:60:00", "00:00:60", "00:01:00.", "00:00:00.0000", "-01:00:00", "99999999999999:00:00", "00:00:0x"} {
+		if _, err := parseMTRReplayTime(value); err == nil {
+			t.Fatalf("accepted %q", value)
+		}
+	}
+	u := newMTRUI(nil, 0)
+	u.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1), duration: time.Hour}
+	u.replay.cursor.Store(int64(5 * time.Second))
+	var keys mtrKeyInput
+	keys.feed(u, 'j', time.Now())
+	if !u.IsPaused() || !u.replayEditor.Active || u.replayEditor.Draft != "00:00:05.000" {
+		t.Fatalf("editor=%+v", u.replayEditor)
+	}
+	keys.feed(u, 21, time.Now())
+	for _, b := range []byte("\x1b[200~00:00:12.500\n\x1b[201~") {
+		keys.feed(u, b, time.Now())
+	}
+	if !u.replayEditor.Active {
+		t.Fatal("paste submitted editor")
+	}
+	keys.feed(u, '\r', time.Now())
+	if u.replayEditor.Active {
+		t.Fatalf("submit error=%s", u.replayEditor.Error)
+	}
+	command := <-u.replay.commands
+	if command.kind != "seek" || command.at != 12500*time.Millisecond {
+		t.Fatalf("command=%+v", command)
+	}
+	u.applyReplayAction(mtrActionReplayJump)
+	u.editReplayTime(21, false)
+	for _, b := range []byte("02:00:00") {
+		u.editReplayTime(b, false)
+	}
+	u.editReplayTime('\r', false)
+	if !u.replayEditor.Active || u.replayEditor.Error == "" {
+		t.Fatal("out of range accepted")
+	}
+	u.editReplayTime(27, false)
+	if u.replayEditor.Active || !u.IsPaused() {
+		t.Fatal("cancel changed playback")
+	}
+}
+
+func TestMTRReplayPendingSeekKeepsImmediatePlay(t *testing.T) {
+	r := &mtrReplayControls{commands: make(chan mtrReplayCommand, 1)}
+	r.send(mtrReplayCommand{kind: "seek", at: 12 * time.Second})
+	r.send(mtrReplayCommand{kind: "play"})
+	got := <-r.commands
+	if got.kind != "seek" || got.at != 12*time.Second || !got.playAfter {
+		t.Fatalf("seek lost: %+v", got)
+	}
+	r.send(got)
+	r.send(mtrReplayCommand{kind: "pause"})
+	got = <-r.commands
+	if got.kind != "seek" || got.at != 12*time.Second || got.playAfter {
+		t.Fatalf("pause lost: %+v", got)
+	}
+}
+
+func TestMTRReplayDisplaySanitization(t *testing.T) {
+	original := []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1", Host: "bad\x1b[2Jhost", Geo: &ipgeo.IPGeoData{Owner: "evil\u009b[2J"}, MPLS: []string{"label\nnext"}, Response: &trace.MTRProbeResponse{Marker: "!\x1b[2J"}}}
+	clean := sanitizeMTRReplayStats(original)
+	if strings.ContainsAny(clean[0].Host, "\x1b\n") || strings.ContainsAny(clean[0].Geo.Owner, "\u009b") || strings.Contains(clean[0].MPLS[0], "\n") {
+		t.Fatalf("unsafe=%+v", clean)
+	}
+	if original[0].Host == clean[0].Host || original[0].Geo.Owner == clean[0].Geo.Owner || original[0].MPLS[0] == clean[0].MPLS[0] {
+		t.Fatal("modified original")
+	}
+	h, err := mtrReplayHeader(&mtrsession.Session{Target: "target\x1b[2J", SourceHost: "source\nnext", SourceIP: "192.0.2.9", Version: "v\x1b[2J"}, mtrReplayOptions{})
+	if err != nil || strings.Contains(h.Target, "\x1b") || strings.Contains(h.SrcHost, "\n") || h.SrcIP != "192.0.2.9" {
+		t.Fatalf("header=%+v err=%v", h, err)
+	}
+}
+
+func TestMTRReplayLongSessionStreamingSeek(t *testing.T) {
+	started := time.Now()
+	path := filepath.Join(t.TempDir(), "long.ndjson")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buffer := bufio.NewWriter(file)
+	encoder := json.NewEncoder(buffer)
+	start := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	seq := uint64(0)
+	write := func(record mtrsession.Record) {
+		t.Helper()
+		seq++
+		record.Format, record.SchemaVersion, record.Seq = mtrsession.FormatName, mtrsession.SchemaVersion, seq
+		record.Timestamp = start.Add(time.Duration(record.ElapsedNS))
+		if err := encoder.Encode(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(mtrsession.Record{MTRSessionEvent: trace.MTRSessionEvent{Type: mtrsession.StartEvent}, Session: &mtrsession.Session{
+		StartedAt: start, Target: "192.0.2.1", ResolvedIP: "192.0.2.1", Protocol: "icmp",
+		EffectiveParameters: &mtrsession.Parameters{BeginHop: 1, MaxHops: 1, HopIntervalMs: 100, TimeoutMs: 1000, ParallelRequests: 1},
+	}})
+	for i := 1; i <= 4000; i++ {
+		elapsed := time.Duration(i) * 100 * time.Millisecond
+		write(mtrsession.Record{ElapsedNS: int64(elapsed), MTRSessionEvent: trace.MTRSessionEvent{
+			Type: trace.MTRSessionProbeEvent, Iteration: i,
+			Probe: &trace.MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Success: true, RTT: time.Millisecond, CompletedAt: start.Add(elapsed)},
+		}})
+	}
+	write(mtrsession.Record{ElapsedNS: int64(400 * time.Second), MTRSessionEvent: trace.MTRSessionEvent{Type: mtrsession.EndEvent}, End: &mtrsession.End{EndedAt: start.Add(400 * time.Second), EndReason: "completed"}})
+	if err := buffer.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	generated := time.Since(started)
+	r, err := mtrsession.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	started = time.Now()
+	final, err := readMTRReplay(t.Context(), r, time.Duration(1<<63-1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded := time.Since(started)
+	history := final.history.Snapshot(start.Add(400 * time.Second))
+	if len(history) != 1 || len(history[0].Samples) != 1801 || !history[0].Samples[0].At.Equal(start.Add(220*time.Second)) {
+		t.Fatalf("final history retained the wrong window: %+v", history)
+	}
+	if stats := final.state.Snapshot().Stats; len(stats) != 1 || stats[0].Snt != 4000 {
+		t.Fatalf("final stats=%+v", stats)
+	}
+	started = time.Now()
+	early, err := readMTRReplay(t.Context(), r, 10*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sought := time.Since(started)
+	history = early.history.Snapshot(start.Add(10 * time.Second))
+	if len(history) != 1 || len(history[0].Samples) != 100 || !history[0].Samples[0].At.Equal(start.Add(100*time.Millisecond)) {
+		t.Fatalf("seek did not recover the discarded early window: %+v", history)
+	}
+	if stats := early.state.Snapshot().Stats; len(stats) != 1 || stats[0].Snt != 100 {
+		t.Fatalf("early stats=%+v", stats)
+	}
+	t.Logf("400s / 4000 probes, bytes=%d generation=%s load=%s seek-to-10s=%s", r.Size(), generated, loaded, sought)
+}

--- a/cmd/mtr_replay_tui.go
+++ b/cmd/mtr_replay_tui.go
@@ -1,0 +1,221 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type mtrReplaySeekResult struct {
+	cursor *mtrReplayCursor
+	err    error
+}
+
+type mtrReplayOutput struct {
+	w   io.Writer
+	err error
+}
+
+func (w *mtrReplayOutput) Write(data []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	n, err := w.w.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	w.err = err
+	return n, err
+}
+
+func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current *mtrReplayCursor, header printer.MTRTUIHeader, duration time.Duration, complete bool, stdout io.Writer) error {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+	ui := newMTRUI(cancel, header.DisplayMode)
+	ui.columns = append([]printer.MTRColumn(nil), header.Columns...)
+	ui.nameMode.Store(int32(header.NameMode))
+	ui.disableMPLS.Store(header.DisableMPLS)
+	ui.paused.Store(true)
+	ui.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1), duration: duration}
+	ui.replay.cursor.Store(int64(current.cursor))
+	ui.Enter()
+	defer ui.Leave()
+	keysDone := make(chan struct{})
+	go func() { defer close(keysDone); ui.ReadKeysLoop(ctx) }()
+	defer func() { cancel(); <-keysDone }()
+	var seekDone chan mtrReplaySeekResult
+	var stopSeek context.CancelFunc
+	var queuedSeek *time.Duration
+	playing := false
+	output := &mtrReplayOutput{w: stdout}
+	baseCursor, baseTime := current.cursor, time.Now()
+	beginSeek := func(at time.Duration) {
+		seekCtx, stop := context.WithCancel(ctx)
+		stopSeek = stop
+		seekDone = make(chan mtrReplaySeekResult, 1)
+		result := seekDone
+		go func() { next, err := readMTRReplay(seekCtx, reader, at); result <- mtrReplaySeekResult{next, err} }()
+	}
+	defer func() {
+		if stopSeek != nil {
+			stopSeek()
+			<-seekDone
+		}
+	}()
+	render := func() error {
+		h := header
+		h.Now = header.StartTime.Add(current.cursor)
+		h.HistoryNow = h.Now
+		h.HistoryMode = ui.IsHistoryMode()
+		h.HistoryChartMode = ui.CurrentHistoryChartMode()
+		if h.HistoryMode {
+			h.History = current.history.Snapshot(h.Now)
+		}
+		h.DisplayMode = ui.CurrentDisplayMode()
+		h.NameMode = ui.CurrentNameMode()
+		h.DisableMPLS = ui.IsMPLSDisabled()
+		h.Status = printer.MTRTUIPaused
+		if playing && !ui.IsPaused() {
+			h.Status = printer.MTRTUIRunning
+		}
+		h.Replay = &printer.MTRReplayStatus{Cursor: current.cursor, Duration: duration, Complete: complete, Seeking: seekDone != nil, RecordedPaused: current.state.Paused()}
+		ui.columnsMu.Lock()
+		h.Columns = append([]printer.MTRColumn(nil), ui.columns...)
+		h.ColumnEditor = ui.columnEditor
+		h.ReplayEditor = ui.replayEditor
+		editing := h.ColumnEditor.Active || h.ReplayEditor.Active
+		ui.columnsMu.Unlock()
+		if editing {
+			fmt.Fprint(output, "\033[?2004h")
+		} else {
+			fmt.Fprint(output, "\033[?2004l")
+		}
+		snapshot := current.state.Snapshot()
+		h.Iteration = snapshot.Iteration
+		printer.MTRTUIRender(output, h, sanitizeMTRReplayStats(snapshot.Stats))
+		return output.err
+	}
+	if err := render(); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case command := <-ui.replay.commands:
+			switch command.kind {
+			case "pause":
+				playing = false
+			case "play":
+				playing = true
+				baseCursor, baseTime = current.cursor, time.Now()
+				if seekDone == nil && current.cursor >= duration {
+					beginSeek(0)
+				}
+			case "seek":
+				playing = command.playAfter
+				if seekDone != nil {
+					at := command.at
+					queuedSeek = &at
+					stopSeek()
+				} else {
+					beginSeek(command.at)
+				}
+			}
+			if err := render(); err != nil {
+				return err
+			}
+		case result := <-seekDone:
+			stopSeek()
+			stopSeek = nil
+			seekDone = nil
+			if queuedSeek != nil {
+				at := *queuedSeek
+				queuedSeek = nil
+				beginSeek(at)
+				if err := render(); err != nil {
+					return err
+				}
+				continue
+			}
+			if result.err != nil {
+				if errors.Is(result.err, context.Canceled) {
+					continue
+				}
+				return result.err
+			}
+			current = result.cursor
+			ui.replay.cursor.Store(int64(current.cursor))
+			baseCursor, baseTime = current.cursor, time.Now()
+			if err := render(); err != nil {
+				return err
+			}
+		case <-ui.redraw:
+			if err := render(); err != nil {
+				return err
+			}
+		case <-ticker.C:
+			if playing && !ui.IsPaused() && seekDone == nil {
+				at := min(duration, baseCursor+time.Since(baseTime))
+				if err := current.advance(ctx, reader, at); err != nil {
+					if errors.Is(err, context.Canceled) {
+						return nil
+					}
+					return err
+				}
+				ui.replay.cursor.Store(int64(current.cursor))
+				if current.cursor >= duration {
+					playing = false
+					ui.paused.Store(true)
+				}
+			}
+			if err := render(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func sanitizeMTRReplayText(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, value)
+}
+
+// Recordings may be shared by an untrusted sender. Clean only display copies;
+// the reducer and JSON export retain the recorded values.
+func sanitizeMTRReplayStats(stats []trace.MTRHopStat) []trace.MTRHopStat {
+	result := cloneMTRDisplayStats(stats)
+	for i := range result {
+		s := &result[i]
+		s.Host = sanitizeMTRReplayText(s.Host)
+		s.IP = sanitizeMTRReplayText(s.IP)
+		for j := range s.MPLS {
+			s.MPLS[j] = sanitizeMTRReplayText(s.MPLS[j])
+		}
+		if s.Response != nil {
+			s.Response.Kind = sanitizeMTRReplayText(s.Response.Kind)
+			s.Response.Marker = sanitizeMTRReplayText(s.Response.Marker)
+			s.Response.Description = sanitizeMTRReplayText(s.Response.Description)
+		}
+		if g := s.Geo; g != nil {
+			for _, field := range []*string{&g.IP, &g.Asnumber, &g.Country, &g.CountryEn, &g.Prov, &g.ProvEn, &g.City, &g.CityEn, &g.District, &g.Owner, &g.Isp, &g.Domain, &g.Whois, &g.Prefix, &g.Source} {
+				*field = sanitizeMTRReplayText(*field)
+			}
+		}
+	}
+	return result
+}

--- a/cmd/mtr_replay_tui.go
+++ b/cmd/mtr_replay_tui.go
@@ -93,10 +93,11 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 		h.ReplayEditor = ui.replayEditor
 		editing := h.ColumnEditor.Active || h.ReplayEditor.Active
 		ui.columnsMu.Unlock()
+		// The sink retains the first error; render returns it after the frame.
 		if editing {
-			fmt.Fprint(output, "\033[?2004h")
+			_, _ = fmt.Fprint(output, "\033[?2004h")
 		} else {
-			fmt.Fprint(output, "\033[?2004l")
+			_, _ = fmt.Fprint(output, "\033[?2004l")
 		}
 		snapshot := current.state.Snapshot()
 		h.Iteration = snapshot.Iteration

--- a/cmd/mtr_replay_validation_test.go
+++ b/cmd/mtr_replay_validation_test.go
@@ -75,6 +75,38 @@ func TestMTRReplayRejectsUnknownResponseKind(t *testing.T) {
 	}
 }
 
+func TestMTRReplayRejectsPathEndWithoutEvidence(t *testing.T) {
+	for _, reason := range []string{trace.StopReasonDestination, trace.StopReasonUnreachable} {
+		file := replayFixture(t, time.Now(), true)
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var rewritten bytes.Buffer
+		for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+			var record mtrsession.Record
+			if err := json.Unmarshal(line, &record); err != nil {
+				t.Fatal(err)
+			}
+			if record.Type == trace.MTRSessionMetadataEvent {
+				record.Type, record.Metadata = trace.MTRSessionPathEndEvent, nil
+				record.PathEnd = &trace.StopReason{Hop: 1, Reason: reason}
+			}
+			if err := json.NewEncoder(&rewritten).Encode(record); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(file, rewritten.Bytes(), 0600); err != nil {
+			t.Fatal(err)
+		}
+		var output, diagnostic bytes.Buffer
+		_, code := maybeRunMTRReplayMode([]string{"--mtr-replay", file, "--json"}, &output, &diagnostic)
+		if code != 1 || output.Len() != 0 || !strings.Contains(diagnostic.String(), "probe evidence") {
+			t.Fatalf("reason=%s code=%d output=%q diagnostic=%q", reason, code, output.String(), diagnostic.String())
+		}
+	}
+}
+
 func TestMTRReplayRejectsResponseWithoutSuccessfulPeer(t *testing.T) {
 	for _, kind := range []string{trace.MTRResponseTransit, trace.MTRResponseDestination, trace.MTRResponseUnreachable} {
 		for _, peer := range []struct {

--- a/cmd/mtr_replay_validation_test.go
+++ b/cmd/mtr_replay_validation_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestMTRReplayHelpWithoutFile(t *testing.T) {
+	for _, flag := range []string{"--help", "-h", "--version", "-V"} {
+		for _, args := range [][]string{{"--mtr-replay", flag}, {flag, "--mtr-replay"}, {"--no-color", "--mtr-replay", flag}} {
+			var output, diagnostic bytes.Buffer
+			handled, code := maybeRunMTRReplayMode(args, &output, &diagnostic)
+			if !handled || code != 0 || output.Len() == 0 || diagnostic.Len() != 0 {
+				t.Fatalf("args=%v handled=%v code=%d output=%q diagnostic=%q", args, handled, code, output.String(), diagnostic.String())
+			}
+		}
+	}
+}
+
+func TestMTRReplayHelpLikeFilename(t *testing.T) {
+	t.Chdir(t.TempDir())
+	data, err := os.ReadFile(replayFixture(t, time.Now(), true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, filename := range []string{"--help", "--version", "-h", "-V"} {
+		if err := os.WriteFile(filename, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{{"--mtr-replay=" + filename, "--json"}, {"--mtr-replay", "./" + filename, "--json"}} {
+			var output, diagnostic bytes.Buffer
+			handled, code := maybeRunMTRReplayMode(args, &output, &diagnostic)
+			if !handled || code != 0 || !strings.Contains(output.String(), `"type":"mtr_replay"`) || diagnostic.Len() != 0 {
+				t.Fatalf("args=%v code=%d output=%q diagnostic=%q", args, code, output.String(), diagnostic.String())
+			}
+		}
+	}
+}
+
+func TestMTRReplayRejectsUnknownResponseKind(t *testing.T) {
+	for _, kind := range []string{"", "future_response"} {
+		file := replayFixture(t, time.Now(), true)
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var rewritten bytes.Buffer
+		for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+			var record mtrsession.Record
+			if err := json.Unmarshal(line, &record); err != nil {
+				t.Fatal(err)
+			}
+			if record.Probe != nil {
+				record.Probe.Response = &trace.MTRProbeResponse{Kind: kind, Marker: "!H"}
+			}
+			if err := json.NewEncoder(&rewritten).Encode(record); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(file, rewritten.Bytes(), 0600); err != nil {
+			t.Fatal(err)
+		}
+		var output, diagnostic bytes.Buffer
+		handled, code := maybeRunMTRReplayMode([]string{"--mtr-replay", file, "--json"}, &output, &diagnostic)
+		if !handled || code != 1 || output.Len() != 0 || !strings.Contains(diagnostic.String(), "response kind") {
+			t.Fatalf("kind=%q code=%d output=%q diagnostic=%q", kind, code, output.String(), diagnostic.String())
+		}
+	}
+}

--- a/cmd/mtr_replay_validation_test.go
+++ b/cmd/mtr_replay_validation_test.go
@@ -74,3 +74,40 @@ func TestMTRReplayRejectsUnknownResponseKind(t *testing.T) {
 		}
 	}
 }
+
+func TestMTRReplayRejectsResponseWithoutSuccessfulPeer(t *testing.T) {
+	for _, kind := range []string{trace.MTRResponseTransit, trace.MTRResponseDestination, trace.MTRResponseUnreachable} {
+		for _, peer := range []struct {
+			success bool
+			ip      string
+		}{{false, ""}, {false, "192.0.2.1"}, {true, ""}, {true, "not-an-ip"}} {
+			file := replayFixture(t, time.Now(), true)
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var rewritten bytes.Buffer
+			for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+				var record mtrsession.Record
+				if err := json.Unmarshal(line, &record); err != nil {
+					t.Fatal(err)
+				}
+				if record.Probe != nil {
+					record.Probe.Success, record.Probe.IP = peer.success, peer.ip
+					record.Probe.Response = &trace.MTRProbeResponse{Kind: kind}
+				}
+				if err := json.NewEncoder(&rewritten).Encode(record); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(file, rewritten.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			var output, diagnostic bytes.Buffer
+			handled, code := maybeRunMTRReplayMode([]string{"--mtr-replay", file, "--json"}, &output, &diagnostic)
+			if !handled || code != 1 || output.Len() != 0 || diagnostic.Len() == 0 {
+				t.Fatalf("kind=%q peer=%+v code=%d output=%q diagnostic=%q", kind, peer, code, output.String(), diagnostic.String())
+			}
+		}
+	}
+}

--- a/cmd/mtr_replay_validation_test.go
+++ b/cmd/mtr_replay_validation_test.go
@@ -30,7 +30,7 @@ func TestMTRReplayHelpLikeFilename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, filename := range []string{"--help", "--version", "-h", "-V"} {
+	for _, filename := range []string{"--help", "--version", "-h", "-V", "--json", "--language", "-r"} {
 		if err := os.WriteFile(filename, data, 0600); err != nil {
 			t.Fatal(err)
 		}
@@ -107,6 +107,35 @@ func TestMTRReplayRejectsPathEndWithoutEvidence(t *testing.T) {
 	}
 }
 
+func TestMTRReplayRejectsContradictoryFooterPath(t *testing.T) {
+	file := replayFixture(t, time.Now(), true)
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rewritten bytes.Buffer
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+		var record mtrsession.Record
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatal(err)
+		}
+		if record.End != nil {
+			record.End.PathEnd = &trace.StopReason{Hop: 1, Reason: trace.StopReasonDestination}
+		}
+		if err := json.NewEncoder(&rewritten).Encode(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(file, rewritten.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var output, diagnostic bytes.Buffer
+	_, code := maybeRunMTRReplayMode([]string{"--mtr-replay", file, "--json"}, &output, &diagnostic)
+	if code != 1 || output.Len() != 0 || !strings.Contains(diagnostic.String(), "path") {
+		t.Fatalf("code=%d output=%q diagnostic=%q", code, output.String(), diagnostic.String())
+	}
+}
+
 func TestMTRReplayRejectsResponseWithoutSuccessfulPeer(t *testing.T) {
 	for _, kind := range []string{trace.MTRResponseTransit, trace.MTRResponseDestination, trace.MTRResponseUnreachable} {
 		for _, peer := range []struct {
@@ -140,6 +169,17 @@ func TestMTRReplayRejectsResponseWithoutSuccessfulPeer(t *testing.T) {
 			if !handled || code != 1 || output.Len() != 0 || diagnostic.Len() == 0 {
 				t.Fatalf("kind=%q peer=%+v code=%d output=%q diagnostic=%q", kind, peer, code, output.String(), diagnostic.String())
 			}
+		}
+	}
+}
+
+func TestMTRReplayMissingFileBeforeOptions(t *testing.T) {
+	for _, tail := range [][]string{{"--json"}, {"-j"}, {"--report"}, {"--language", "en"}, {"--ipinfo=2"}, {"--mtr-columns", "avg"}, {"--"}} {
+		args := append([]string{"--mtr-replay"}, tail...)
+		var output, diagnostic bytes.Buffer
+		handled, code := maybeRunMTRReplayMode(args, &output, &diagnostic)
+		if !handled || code != 2 || output.Len() != 0 || diagnostic.Len() == 0 {
+			t.Fatalf("args=%v code=%d output=%q diagnostic=%q", args, code, output.String(), diagnostic.String())
 		}
 	}
 }

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -22,6 +22,8 @@ type mtrUI struct {
 	columnsMu    sync.Mutex
 	columns      []printer.MTRColumn
 	columnEditor printer.MTRColumnEditor
+	replayEditor printer.MTRReplayEditor
+	replay       *mtrReplayControls
 	redraw       chan struct{}
 	isTTY        bool
 	oldState     *term.State // raw mode 之前的终端状态
@@ -230,6 +232,7 @@ const (
 	mtrActionHistoryToggle                       // d
 	mtrActionHistoryChart                        // g
 	mtrActionColumns
+	mtrActionReplayJump
 	mtrActionPasteStart
 )
 
@@ -383,6 +386,8 @@ func mapKeyToAction(b byte) mtrInputAction {
 		return mtrActionHistoryChart
 	case 'o', 'O':
 		return mtrActionColumns
+	case 'j', 'J':
+		return mtrActionReplayJump
 	default:
 		return mtrActionNone
 	}

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -52,6 +52,9 @@ Every record includes `type`, `seq`, `generation`, `elapsed_ns`, and `timestamp`
 | `path_end` | `path_end`: destination/unreachable/max-hops conclusion, or explicit `null` for reopening |
 | `end` | `end`: end time, reason, final path conclusion and optional error/signal |
 
+When present, a probe's `response.kind` must be `transit`, `destination`, or
+`unreachable`; empty or unknown kinds are invalid records.
+
 The session header only includes explicitly selected safe fields, not the
 runtime configuration or provider credentials. Source selection describes the
 recorded configuration/display, not proof of an operating-system route.
@@ -82,6 +85,9 @@ nexttrace --mtr-replay session.jsonl
 nexttrace --mtr-replay session.jsonl -w
 nexttrace --mtr-replay session.jsonl -r --json
 ```
+
+`--mtr-replay --help` and `--mtr-replay --version` need no file. For a file named
+`--help` or `--version`, use `--mtr-replay=--help` or a path such as `./--help`.
 
 Replay accepts presentation options, not a target or probe configuration. It
 does not initialize probing, resolve addresses, query metadata, or discover a

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -1,0 +1,130 @@
+# MTR session recording v1
+
+`--mtr-record FILE` explicitly records the current CLI MTR session in all three
+builds. TUI, non-TTY tables, report/wide, RAW and MTR JSON can be recorded. The
+file is independent of stdout and of the existing [MTR JSON v1](mtr-json.md)
+contract. Existing NDJSON streams and final JSON reports are not replay files.
+
+## Recording
+
+```sh
+nexttrace --mtr --mtr-record session.jsonl example.com
+nexttrace -w -q 10 --mtr-record report-session.jsonl example.com
+nexttrace --mtr --json -q 10 --mtr-record stream-session.jsonl example.com
+ntr --mtr-record session.jsonl example.com
+```
+
+Full and tiny require an explicit MTR mode; ntr defaults to MTR. Traditional
+traceroute, standalone modes and replay cannot be combined with recording.
+The file is exclusively created with Unix mode `0600`: existing files and
+symlinks are never overwritten or appended to. The parent directory must exist.
+Opening the recording precedes network initialization and probing.
+
+Each accepted event is written as a complete UTF-8 JSON line. A failed encode or
+write cancels probing. The file is synchronized and closed at the end, and
+sync/close errors are reported as failures. No events are silently dropped.
+There is no rotation, compression, append mode, or periodic durable checkpoint.
+Crash recovery is limited to complete records that remain readable from disk.
+
+## Event contract
+
+Records identify `format: "nexttrace-mtr-session"` and `schema_version: 1`.
+The maximum encoded record size is 1 MiB including its terminating newline.
+Every record includes `type`, `seq`, `generation`, `elapsed_ns`, and `timestamp`.
+
+- `seq` starts at 1 and increases by exactly one, including control events.
+- `generation` starts at 0; each reset increases it by one.
+- `elapsed_ns` is the nondecreasing playback clock from session start. Events
+  with equal elapsed time retain sequence order.
+- `timestamp` records event application time. Probe completion time is separate:
+  concurrent results must never be reordered by their completion timestamps.
+- `start` is first and `end` is last in a complete recording. Additional fields
+  may be introduced within v1; unsupported versions and event types are errors.
+
+| Type | Payload |
+| --- | --- |
+| `start` | `session`: software version, target, resolved IP, protocol, start time, effective parameters, source display information and initial display settings |
+| `probe` | `probe`: counted TTL, IP/Host, success, integer `rtt_ns`, `completed_at`, complete available Geo/MPLS and response details; `iteration` retains scheduler meaning |
+| `metadata` | `metadata`: IP and applied Host/Geo updates, without counting another probe |
+| `pause`, `resume` | Changes actually observed by the scheduler; pending probe results may still follow pause |
+| `reset` | New generation; clears current statistics, path evidence and history |
+| `path_end` | `path_end`: destination/unreachable/max-hops conclusion, or explicit `null` for reopening |
+| `end` | `end`: end time, reason, final path conclusion and optional error/signal |
+
+The session header only includes explicitly selected safe fields, not the
+runtime configuration or provider credentials. Source selection describes the
+recorded configuration/display, not proof of an operating-system route.
+Initialization failure can produce a complete empty session with undetermined
+parameters and an error end record.
+
+### Statistics and ordering
+
+Only probes actually accepted into the existing aggregator are recorded.
+The probe payload contains the final Hop used for aggregation, including
+synchronous metadata. Later metadata patches update existing rows without
+changing Snt, RTT statistics or responder order.
+
+Response identity, integer RTT precision, unknown-row merging and synthetic
+timeouts retain the live aggregator's semantics. Individual local send retries,
+unsent time during pause and in-flight probes discarded by cancellation are
+not converted into additional timeout records.
+
+The triggering probe precedes its `path_end` event. A confirmed destination
+clears statistics above its TTL. A provisional unreachable edge hides those
+rows; reopening can reveal their earlier statistics. Reset discards late results
+from the previous generation. It does not remove earlier events from the file.
+
+## Offline replay
+
+```sh
+nexttrace --mtr-replay session.jsonl
+nexttrace --mtr-replay session.jsonl -w
+nexttrace --mtr-replay session.jsonl -r --json
+```
+
+Replay accepts presentation options, not a target or probe configuration. It
+does not initialize probing, resolve addresses, query metadata, or discover a
+source interface. Recorded missing metadata stays missing. It can run without
+raw-socket privileges and without network connectivity.
+
+TTY opens paused at the last valid position. Space plays at original speed;
+at EOF it starts from the beginning. `p` pauses playback, `r` rewinds and pauses,
+`q` quits. Recorded probe pause and current playback pause are separate states.
+Host, MPLS, columns and the existing three history charts remain available.
+
+`j/J` opens elapsed-time input, prefilled with the current position, and pauses.
+Use `HH:MM:SS[.mmm]`, with hours allowed beyond 23. Enter seeks and stays paused;
+Esc cancels and stays paused; Backspace deletes and Ctrl-U clears. Invalid or
+out-of-range input leaves the current position unchanged. Bracketed-paste
+newlines cannot submit the input.
+
+The history chart shows the three minutes ending at the playback position.
+The whole file remains available for seeking. Initial loading and seeking scan
+records sequentially, using the existing aggregator; no full event array or
+checkpoint index is retained. Seeking is O(N) in the events before the requested
+position and can be canceled. Memory still depends on distinct responder state
+and probes inside the current history window. This version does not tail a file
+that continues growing after it is opened.
+
+Non-TTY or explicit `-r/-w` produces one final report. `--json` produces a
+separate offline document with session information, statistics, path state,
+playback position and recording completeness, rather than emitting live NDJSON.
+
+## Incomplete and invalid files
+
+A missing end record or an unfinished final JSON line recovers only the complete
+valid prefix. Text/TUI explicitly identify the recording as incomplete; offline
+JSON exposes the same state. Incomplete replay exits nonzero, even when some
+statistics could be recovered. An unsupported version, invalid middle record,
+oversized record or invalid sequence is an error; records are never skipped to
+fabricate a complete session.
+
+Normal replay of a complete file exits 0. A complete recording may describe an
+original session that ended with an error or signal; that historical outcome is
+retained separately from the current file-read result. Invalid arguments exit
+2; file/recording errors exit 1; handled SIGINT/SIGTERM exit 130/143. Diagnostics
+go to stderr. A completed probe session is not itself a reachability verdict.
+
+Recordings contain target, source and responder addresses and available
+metadata. Redact those fields before attaching files to a public issue when
+they identify private infrastructure.

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -56,7 +56,10 @@ The end time must equal its record timestamp, and the final path must match the
 reconstructed state. `completed` has no error or signal; `interrupted` has no
 error and optionally `SIGINT` or `SIGTERM`; `error` requires a nonempty error
 stage/message and no signal. Metadata events must actually update an existing
-responder. Contradictory or unapplied events are rejected.
+responder. Probe TTLs stay within the configured range, and bounded sessions
+may not exceed `max_per_hop` in any generation. A `max_hops` event requires
+all configured TTLs to have completed that count. Reset clears these counts.
+Contradictory or unapplied events are rejected.
 
 When present, a probe's `response.kind` must be `transit`, `destination`, or
 `unreachable`; empty or unknown kinds are invalid records. A response also

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -52,6 +52,12 @@ Every record includes `type`, `seq`, `generation`, `elapsed_ns`, and `timestamp`
 | `path_end` | `path_end`: destination/unreachable/max-hops conclusion, or explicit `null` for reopening |
 | `end` | `end`: end time, reason, final path conclusion and optional error/signal |
 
+The end time must equal its record timestamp, and the final path must match the
+reconstructed state. `completed` has no error or signal; `interrupted` has no
+error and optionally `SIGINT` or `SIGTERM`; `error` requires a nonempty error
+stage/message and no signal. Metadata events must actually update an existing
+responder. Contradictory or unapplied events are rejected.
+
 When present, a probe's `response.kind` must be `transit`, `destination`, or
 `unreachable`; empty or unknown kinds are invalid records. A response also
 requires `success: true` and a valid responder IP; timeouts cannot carry path

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -53,7 +53,9 @@ Every record includes `type`, `seq`, `generation`, `elapsed_ns`, and `timestamp`
 | `end` | `end`: end time, reason, final path conclusion and optional error/signal |
 
 When present, a probe's `response.kind` must be `transit`, `destination`, or
-`unreachable`; empty or unknown kinds are invalid records.
+`unreachable`; empty or unknown kinds are invalid records. A response also
+requires `success: true` and a valid responder IP; timeouts cannot carry path
+evidence.
 
 The session header only includes explicitly selected safe fields, not the
 runtime configuration or provider credentials. Source selection describes the

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -38,6 +38,7 @@ Every record includes `type`, `seq`, `generation`, `elapsed_ns`, and `timestamp`
   with equal elapsed time retain sequence order.
 - `timestamp` records event application time. Probe completion time is separate:
   concurrent results must never be reordered by their completion timestamps.
+- Probe records include optional `probe_age_ns`, computed from the monotonic clock before serialization; replay uses this nonnegative completion-to-application age for history positioning, falling back to the wall timestamps only for older records without this field.
 - `start` is first and `end` is last in a complete recording. Additional fields
   may be introduced within v1; unsupported versions and event types are errors.
 

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -57,6 +57,13 @@ When present, a probe's `response.kind` must be `transit`, `destination`, or
 requires `success: true` and a valid responder IP; timeouts cannot carry path
 evidence.
 
+Replay verifies destination, unreachable and reopening events against the
+accumulated probe evidence before applying a path boundary. A contradictory
+event is an error, not an instruction to discard statistics.
+
+Offline JSON always encodes `stats` as an array, including `[]` for empty
+sessions, initialization failures and the state immediately after a reset.
+
 The session header only includes explicitly selected safe fields, not the
 runtime configuration or provider credentials. Source selection describes the
 recorded configuration/display, not proof of an operating-system route.

--- a/internal/mtrsession/reader.go
+++ b/internal/mtrsession/reader.go
@@ -1,0 +1,143 @@
+package mtrsession
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Reader holds an open regular file and a fixed byte limit. New data appended
+// while replaying is not followed, including after Rewind.
+type Reader struct {
+	file       *os.File
+	scanner    *bufio.Scanner
+	size       int64
+	offset     int64
+	state      recordState
+	incomplete bool
+	done       bool
+	closed     bool
+	err        error
+}
+
+func OpenReader(path string) (*Reader, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("MTR session replay requires a regular file")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err = f.Stat()
+	if err == nil && !info.Mode().IsRegular() {
+		err = errors.New("MTR session replay requires a regular file")
+	}
+	if err != nil {
+		return nil, errors.Join(err, f.Close())
+	}
+	r := &Reader{file: f, size: info.Size()}
+	r.reset()
+	return r, nil
+}
+
+// Next returns io.EOF at the fixed end, including a recoverable partial tail.
+// Call Incomplete after EOF to distinguish a complete session from a prefix.
+// Invalid complete records are errors and are never silently skipped.
+func (r *Reader) Next() (Record, error) {
+	if r.closed {
+		return Record{}, ErrClosed
+	}
+	if r.err != nil {
+		return Record{}, r.err
+	}
+	if r.done {
+		return Record{}, io.EOF
+	}
+	if !r.scanner.Scan() {
+		return r.eof(r.scanner.Err())
+	}
+	line := r.scanner.Bytes()
+	r.offset += int64(len(line))
+	terminated := len(line) > 0 && line[len(line)-1] == '\n'
+	var record Record
+	if err := json.Unmarshal(line, &record); err != nil {
+		if !terminated && r.state.seq > 0 && !r.state.ended {
+			return r.eof(nil)
+		}
+		r.err = fmt.Errorf("invalid MTR session record %d: %w", r.state.seq+1, err)
+		return Record{}, r.err
+	}
+	if err := r.state.accept(record); err != nil {
+		r.err = fmt.Errorf("MTR session record %d: %w", r.state.seq+1, err)
+		return Record{}, r.err
+	}
+	record.At = record.Timestamp
+	return record, nil
+}
+
+func (r *Reader) eof(err error) (Record, error) {
+	r.done = true
+	if err == nil && r.state.seq == 0 {
+		err = errors.New("MTR session has no complete start record")
+	}
+	if err != nil {
+		r.err = err
+		return Record{}, err
+	}
+	r.incomplete = !r.state.ended
+	return Record{}, io.EOF
+}
+
+// Rewind starts a new pass over the same original file extent.
+func (r *Reader) Rewind() error {
+	if r.closed {
+		return ErrClosed
+	}
+	r.reset()
+	return nil
+}
+
+func (r *Reader) reset() {
+	r.scanner = bufio.NewScanner(io.NewSectionReader(r.file, 0, r.size))
+	r.scanner.Buffer(make([]byte, 64*1024), MaxLineBytes+1)
+	r.scanner.Split(splitLine)
+	r.offset, r.state = 0, recordState{}
+	r.incomplete, r.done, r.err = true, false, nil
+}
+
+func splitLine(data []byte, atEOF bool) (int, []byte, error) {
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		if i+1 > MaxLineBytes {
+			return 0, nil, ErrLineTooLarge
+		}
+		return i + 1, data[:i+1], nil
+	}
+	// A record without its optional final newline obeys the same payload bound.
+	if len(data)+1 > MaxLineBytes {
+		return 0, nil, ErrLineTooLarge
+	}
+	if atEOF && len(data) > 0 {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
+func (r *Reader) Incomplete() bool { return r.incomplete }
+func (r *Reader) Size() int64      { return r.size }
+func (r *Reader) Offset() int64    { return r.offset }
+
+func (r *Reader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	return r.file.Close()
+}

--- a/internal/mtrsession/session_test.go
+++ b/internal/mtrsession/session_test.go
@@ -653,3 +653,80 @@ func TestRejectContradictoryFooter(t *testing.T) {
 		})
 	}
 }
+
+func TestPerHopRecordingBounds(t *testing.T) {
+	for _, scenario := range []string{"overflow", "below_begin", "premature_max", "other_ttl_unfinished", "complete", "reset", "unbounded_max"} {
+		t.Run(scenario, func(t *testing.T) {
+			session := testSession()
+			session.EffectiveParameters.BeginHop = 2
+			session.EffectiveParameters.MaxHops = 3
+			session.EffectiveParameters.MaxPerHop = 2
+			if scenario == "unbounded_max" {
+				session.EffectiveParameters.MaxPerHop = 0
+			}
+			records := []Record{{MTRSessionEvent: trace.MTRSessionEvent{Type: StartEvent}, Session: &session}}
+			generation := uint64(0)
+			probe := func(ttl int) {
+				event := testProbe(session.StartedAt)
+				event.Generation, event.Probe.TTL = generation, ttl
+				records = append(records, Record{MTRSessionEvent: event})
+			}
+			probe(2)
+			probe(3)
+			switch scenario {
+			case "overflow":
+				probe(2)
+				probe(2)
+			case "below_begin":
+				probe(1)
+			case "other_ttl_unfinished":
+				probe(3)
+			case "complete", "reset":
+				probe(2)
+				probe(3)
+				if scenario == "reset" {
+					generation++
+					records = append(records, Record{MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionResetEvent, Generation: generation}})
+					probe(2)
+					probe(2)
+					probe(3)
+					probe(3)
+				}
+			}
+			if scenario != "overflow" && scenario != "below_begin" {
+				records = append(records, Record{MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionPathEndEvent, Generation: generation, PathEnd: &trace.StopReason{Hop: 3, Reason: trace.StopReasonMaxHops}}})
+			}
+			var data bytes.Buffer
+			writer, err := Open(filepath.Join(t.TempDir(), "writer.jsonl"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = writer.Close() }()
+			var writeErr error
+			for i := range records {
+				r := &records[i]
+				r.Format, r.SchemaVersion, r.Seq = FormatName, SchemaVersion, uint64(i+1)
+				r.Timestamp = session.StartedAt
+				if err := json.NewEncoder(&data).Encode(r); err != nil {
+					t.Fatal(err)
+				}
+				if writeErr == nil {
+					if i == 0 {
+						writeErr = writer.Start(session)
+					} else {
+						writeErr = writer.Event(r.MTRSessionEvent)
+					}
+				}
+			}
+			path := filepath.Join(t.TempDir(), "reader.jsonl")
+			if err := os.WriteFile(path, data.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, _, readErr := readRecords(t, path)
+			valid := scenario == "complete" || scenario == "reset"
+			if (writeErr == nil) != valid || (readErr == nil) != valid {
+				t.Fatalf("valid=%v write=%v read=%v", valid, writeErr, readErr)
+			}
+		})
+	}
+}

--- a/internal/mtrsession/session_test.go
+++ b/internal/mtrsession/session_test.go
@@ -187,6 +187,9 @@ func TestRejectInvalidRecordContract(t *testing.T) {
 		{"missing-probe", 1, func(r *Record) { r.Probe = nil }},
 		{"bad-generation", 1, func(r *Record) { r.Generation = 1 }},
 		{"missing-timestamp", 1, func(r *Record) { r.Timestamp = time.Time{} }},
+		{"negative-probe-age", 1, func(r *Record) { age := int64(-1); r.ProbeAgeNS = &age }},
+		{"probe-age-on-start", 0, func(r *Record) { age := int64(0); r.ProbeAgeNS = &age }},
+		{"probe-age-on-end", 2, func(r *Record) { age := int64(0); r.ProbeAgeNS = &age }},
 		{"unexpected-header", 1, func(r *Record) { r.Session = original[0].Session }},
 		{"missing-end-payload", 2, func(r *Record) { r.End = nil }},
 	}
@@ -443,5 +446,85 @@ func TestReaderRejectsDirectory(t *testing.T) {
 	if r, err := OpenReader(t.TempDir()); err == nil {
 		_ = r.Close()
 		t.Fatal("accepted directory")
+	}
+}
+
+func TestWriterProbeAgePreservesMonotonicTime(t *testing.T) {
+	for _, fallback := range []bool{false, true} {
+		t.Run(map[bool]string{false: "event-time", true: "fallback-time"}[fallback], func(t *testing.T) {
+			f := &failingFile{}
+			w := &Writer{file: f}
+			completed := time.Now().Add(-time.Second)
+			applied := time.Now()
+			s := testSession()
+			s.StartedAt = completed.Add(-time.Second)
+			if err := w.Start(s); err != nil {
+				t.Fatal(err)
+			}
+			event := testProbe(completed)
+			event.At = applied
+			if fallback {
+				event.At = time.Time{}
+			}
+			if err := w.Event(event); err != nil {
+				t.Fatal(err)
+			}
+			after := time.Now()
+			lines := bytes.Split(f.Bytes(), []byte{'\n'})
+			var record Record
+			if err := json.Unmarshal(lines[1], &record); err != nil {
+				t.Fatal(err)
+			}
+			if record.ProbeAgeNS == nil {
+				t.Fatal("probe age was omitted")
+			}
+			want := int64(applied.Sub(completed))
+			if fallback {
+				if *record.ProbeAgeNS < want || *record.ProbeAgeNS > int64(after.Sub(completed)) {
+					t.Fatalf("fallback age out of bounds: %d", *record.ProbeAgeNS)
+				}
+			} else if *record.ProbeAgeNS != want {
+				t.Fatalf("age = %d, want %d", *record.ProbeAgeNS, want)
+			}
+		})
+	}
+}
+
+func TestReaderProbeAgeIndependentOfWallClock(t *testing.T) {
+	original, _, err := readRecords(t, writeFixture(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, shift := range []time.Duration{-24 * time.Hour, 24 * time.Hour} {
+		for _, legacy := range []bool{false, true} {
+			records := append([]Record(nil), original...)
+			records[1].Timestamp = records[1].Probe.CompletedAt.Add(shift)
+			age := int64(50 * time.Millisecond)
+			records[1].ProbeAgeNS = &age
+			if legacy {
+				records[1].ProbeAgeNS = nil
+			}
+			var data bytes.Buffer
+			for _, record := range records {
+				if err := json.NewEncoder(&data).Encode(record); err != nil {
+					t.Fatal(err)
+				}
+			}
+			path := filepath.Join(t.TempDir(), "wall-clock.session")
+			if err := os.WriteFile(path, data.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			got, incomplete, err := readRecords(t, path)
+			if err != nil || incomplete || len(got) != 3 {
+				t.Fatalf("shift=%v legacy=%v err=%v", shift, legacy, err)
+			}
+			if legacy {
+				if got[1].ProbeAgeNS != nil {
+					t.Fatal("invented an age for an older record")
+				}
+			} else if got[1].ProbeAgeNS == nil || *got[1].ProbeAgeNS != age {
+				t.Fatal("stored probe age was changed by wall-clock timestamps")
+			}
+		}
 	}
 }

--- a/internal/mtrsession/session_test.go
+++ b/internal/mtrsession/session_test.go
@@ -98,6 +98,42 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestProbeResponseKinds(t *testing.T) {
+	for _, kind := range []string{trace.MTRResponseTransit, trace.MTRResponseDestination, trace.MTRResponseUnreachable, "", "future_response"} {
+		t.Run(kind, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "recording.jsonl")
+			w, err := Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = w.Close() }()
+			session := testSession()
+			if err := w.Start(session); err != nil {
+				t.Fatal(err)
+			}
+			probe := testProbe(session.StartedAt.Add(time.Second))
+			probe.Probe.Response = &trace.MTRProbeResponse{Kind: kind}
+			err = w.Event(probe)
+			if kind == "" || kind == "future_response" {
+				if err == nil || !strings.Contains(err.Error(), "response kind") {
+					t.Fatalf("invalid kind %q: %v", kind, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Finish(End{EndedAt: session.StartedAt.Add(2 * time.Second), EndReason: "completed"}); err != nil {
+				t.Fatal(err)
+			}
+			records, incomplete, err := readRecords(t, path)
+			if err != nil || incomplete || len(records) != 3 || records[1].Probe.Response.Kind != kind {
+				t.Fatalf("kind=%q records=%v incomplete=%v err=%v", kind, records, incomplete, err)
+			}
+		})
+	}
+}
+
 func TestExclusivePrivateFile(t *testing.T) {
 	path := writeFixture(t, true)
 	original, err := os.ReadFile(path)

--- a/internal/mtrsession/session_test.go
+++ b/internal/mtrsession/session_test.go
@@ -134,6 +134,29 @@ func TestProbeResponseKinds(t *testing.T) {
 	}
 }
 
+func TestWriterRejectsResponseWithoutSuccessfulPeer(t *testing.T) {
+	for _, peer := range []struct {
+		success bool
+		ip      string
+	}{{false, ""}, {false, "192.0.2.1"}, {true, ""}, {true, "not-an-ip"}} {
+		w, err := Open(filepath.Join(t.TempDir(), "recording.jsonl"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = w.Close() })
+		session := testSession()
+		if err := w.Start(session); err != nil {
+			t.Fatal(err)
+		}
+		probe := testProbe(session.StartedAt.Add(time.Second))
+		probe.Probe.Success, probe.Probe.IP = peer.success, peer.ip
+		probe.Probe.Response = &trace.MTRProbeResponse{Kind: trace.MTRResponseDestination}
+		if err := w.Event(probe); err == nil {
+			t.Fatalf("writer accepted response without a successful peer: %+v", peer)
+		}
+	}
+}
+
 func TestExclusivePrivateFile(t *testing.T) {
 	path := writeFixture(t, true)
 	original, err := os.ReadFile(path)

--- a/internal/mtrsession/session_test.go
+++ b/internal/mtrsession/session_test.go
@@ -587,3 +587,69 @@ func TestReaderProbeAgeIndependentOfWallClock(t *testing.T) {
 		}
 	}
 }
+
+func TestRejectContradictoryFooter(t *testing.T) {
+	for _, scenario := range []string{"timestamp", "unknown_reason", "completed_error", "completed_signal", "interrupted_error", "interrupted_signal", "error_missing", "error_stage", "error_message", "error_signal"} {
+		t.Run(scenario, func(t *testing.T) {
+			path := writeFixture(t, true)
+			records, _, err := readRecords(t, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			record := &records[len(records)-1]
+			switch scenario {
+			case "timestamp":
+				record.End.EndedAt = record.End.EndedAt.Add(time.Second)
+			case "unknown_reason":
+				record.End.EndReason = "future_reason"
+			case "completed_error":
+				record.End.Error = &Error{Stage: "run", Message: "failed"}
+			case "completed_signal":
+				record.End.Signal = "SIGINT"
+			case "interrupted_error":
+				record.End.EndReason = "interrupted"
+				record.End.Error = &Error{Stage: "run", Message: "failed"}
+			case "interrupted_signal":
+				record.End.EndReason = "interrupted"
+				record.End.Signal = "SIGKILL"
+			case "error_missing":
+				record.End.EndReason = "error"
+			case "error_stage":
+				record.End.EndReason = "error"
+				record.End.Error = &Error{Message: "failed"}
+			case "error_message":
+				record.End.EndReason = "error"
+				record.End.Error = &Error{Stage: "run"}
+			case "error_signal":
+				record.End.EndReason = "error"
+				record.End.Error = &Error{Stage: "run", Message: "failed"}
+				record.End.Signal = "SIGINT"
+			}
+			var data bytes.Buffer
+			for _, r := range records {
+				if err := json.NewEncoder(&data).Encode(r); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(path, data.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := readRecords(t, path); err == nil {
+				t.Fatal("reader accepted contradictory footer")
+			}
+			if scenario != "timestamp" { // Finish supplies one timestamp for both fields.
+				writer, err := Open(filepath.Join(t.TempDir(), "invalid.jsonl"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = writer.Close() }()
+				if err := writer.Start(testSession()); err != nil {
+					t.Fatal(err)
+				}
+				if err := writer.Finish(*record.End); err == nil {
+					t.Fatal("writer accepted contradictory footer")
+				}
+			}
+		})
+	}
+}

--- a/internal/mtrsession/session_test.go
+++ b/internal/mtrsession/session_test.go
@@ -1,0 +1,447 @@
+package mtrsession
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func testSession() Session {
+	return Session{
+		Version: "test", Target: "example.invalid", ResolvedIP: "192.0.2.1", Protocol: "icmp",
+		StartedAt: time.Date(2026, 9, 8, 1, 2, 3, 0, time.UTC), SourceHost: "test-host",
+		EffectiveParameters: &Parameters{BeginHop: 1, MaxHops: 30, HopIntervalMs: 1000, TimeoutMs: 2000, ParallelRequests: 8},
+	}
+}
+
+func testProbe(at time.Time) trace.MTRSessionEvent {
+	return trace.MTRSessionEvent{Type: trace.MTRSessionProbeEvent, At: at, Probe: &trace.MTRSessionProbe{
+		TTL: 1, IP: "192.0.2.1", Host: "example.invalid", Success: true, RTT: 1234567,
+		CompletedAt: at, MPLS: []string{"test-label"}, Geo: &ipgeo.IPGeoData{Country: "测试", Owner: "Example"},
+	}}
+}
+
+func writeFixture(t *testing.T, finish bool) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.ndjson")
+	w, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	s := testSession()
+	if err = w.Start(s); err != nil {
+		t.Fatal(err)
+	}
+	if err = w.Event(testProbe(s.StartedAt.Add(time.Second))); err != nil {
+		t.Fatal(err)
+	}
+	if finish {
+		err = w.Finish(End{EndedAt: s.StartedAt.Add(2 * time.Second), EndReason: "completed"})
+	} else {
+		err = w.Close()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readRecords(t *testing.T, path string) ([]Record, bool, error) {
+	t.Helper()
+	r, err := OpenReader(path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = r.Close() }()
+	var records []Record
+	for {
+		record, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			return records, r.Incomplete(), nil
+		}
+		if err != nil {
+			return records, r.Incomplete(), err
+		}
+		records = append(records, record)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	path := writeFixture(t, true)
+	records, incomplete, err := readRecords(t, path)
+	if err != nil || incomplete || len(records) != 3 {
+		t.Fatalf("records=%d incomplete=%v err=%v", len(records), incomplete, err)
+	}
+	for i, r := range records {
+		if r.Format != FormatName || r.SchemaVersion != SchemaVersion || r.Seq != uint64(i+1) || r.ElapsedNS != int64(i)*int64(time.Second) || !r.At.Equal(r.Timestamp) {
+			t.Fatalf("record %d: %+v", i, r)
+		}
+	}
+	p := records[1].Probe
+	if p.RTT != 1234567 || p.Geo.Country != "测试" || p.MPLS[0] != "test-label" || !p.CompletedAt.Equal(records[1].At) {
+		t.Fatalf("probe not preserved: %+v", p)
+	}
+	if records[0].Session.EffectiveParameters.MaxHops != 30 || records[2].End.EndReason != "completed" {
+		t.Fatal("header or footer lost")
+	}
+}
+
+func TestExclusivePrivateFile(t *testing.T) {
+	path := writeFixture(t, true)
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w, err := Open(path); !errors.Is(err, os.ErrExist) || w != nil {
+		t.Fatalf("existing file: writer=%v err=%v", w, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(original, after) {
+		t.Fatal("existing file changed")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
+		t.Fatalf("permissions = %o", info.Mode().Perm())
+	}
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(path, link); err == nil {
+		if w, err := Open(link); !errors.Is(err, os.ErrExist) || w != nil {
+			t.Fatalf("symlink: writer=%v err=%v", w, err)
+		}
+	}
+}
+
+func TestTruncatedTail(t *testing.T) {
+	original, err := os.ReadFile(writeFixture(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.SplitAfter(original, []byte{'\n'})
+	tests := []struct {
+		name       string
+		data       []byte
+		count      int
+		incomplete bool
+		invalid    bool
+	}{
+		{"complete", original, 3, false, false},
+		{"no-final-newline", bytes.TrimSuffix(original, []byte{'\n'}), 3, false, false},
+		{"missing-end", bytes.Join(lines[:2], nil), 2, true, false},
+		{"partial-end", append(bytes.Join(lines[:2], nil), lines[2][:len(lines[2])/2]...), 2, true, false},
+		{"partial-probe", append(append([]byte{}, lines[0]...), lines[1][:len(lines[1])/2]...), 1, true, false},
+		{"header-only", lines[0], 1, true, false},
+		{"empty", nil, 0, true, true},
+		{"partial-header", lines[0][:len(lines[0])/2], 0, true, true},
+		{"broken-middle", bytes.Join([][]byte{lines[0], []byte("{broken}\n"), lines[2]}, nil), 1, true, true},
+		{"broken-complete-last-line", append(append([]byte{}, lines[0]...), []byte("{broken}\n")...), 1, true, true},
+		{"partial-after-end", append(append([]byte{}, original...), []byte("{broken")...), 3, true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "input")
+			if err := os.WriteFile(path, tc.data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			records, incomplete, err := readRecords(t, path)
+			if (err != nil) != tc.invalid || len(records) != tc.count || incomplete != tc.incomplete {
+				t.Fatalf("count=%d incomplete=%v error=%v", len(records), incomplete, err)
+			}
+		})
+	}
+}
+
+func TestRejectInvalidRecordContract(t *testing.T) {
+	path := writeFixture(t, true)
+	original, _, err := readRecords(t, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		index  int
+		mutate func(*Record)
+	}{
+		{"format", 0, func(r *Record) { r.Format = "" }},
+		{"version", 0, func(r *Record) { r.SchemaVersion++ }},
+		{"version-midstream", 1, func(r *Record) { r.SchemaVersion++ }},
+		{"missing-sequence", 1, func(r *Record) { r.Seq = 0 }},
+		{"duplicate-sequence", 1, func(r *Record) { r.Seq = 1 }},
+		{"sequence-gap", 1, func(r *Record) { r.Seq++ }},
+		{"decreasing-elapsed", 2, func(r *Record) { r.ElapsedNS = 0 }},
+		{"unknown-event", 1, func(r *Record) { r.Type = "future_event" }},
+		{"missing-probe", 1, func(r *Record) { r.Probe = nil }},
+		{"bad-generation", 1, func(r *Record) { r.Generation = 1 }},
+		{"missing-timestamp", 1, func(r *Record) { r.Timestamp = time.Time{} }},
+		{"unexpected-header", 1, func(r *Record) { r.Session = original[0].Session }},
+		{"missing-end-payload", 2, func(r *Record) { r.End = nil }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			records := append([]Record(nil), original...)
+			tc.mutate(&records[tc.index])
+			var data bytes.Buffer
+			for _, record := range records {
+				if err := json.NewEncoder(&data).Encode(record); err != nil {
+					t.Fatal(err)
+				}
+			}
+			p := filepath.Join(t.TempDir(), "input")
+			if err := os.WriteFile(p, data.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := readRecords(t, p); err == nil {
+				t.Fatal("accepted malformed recording")
+			}
+		})
+	}
+}
+
+func TestReaderDoesNotFollowGrowthAndRewinds(t *testing.T) {
+	path := writeFixture(t, false)
+	r, err := OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	size := r.Size()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("not part of the original file\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for pass := 0; pass < 2; pass++ {
+		count := 0
+		for {
+			_, err := r.Next()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			count++
+		}
+		if count != 2 || !r.Incomplete() || r.Offset() != size {
+			t.Fatalf("pass=%d count=%d incomplete=%v offset=%d size=%d", pass, count, r.Incomplete(), r.Offset(), size)
+		}
+		if err := r.Rewind(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Next(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("closed Next: %v", err)
+	}
+	if err := r.Rewind(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("closed Rewind: %v", err)
+	}
+}
+
+type failingFile struct {
+	bytes.Buffer
+	writeErr, syncErr, closeErr error
+	short                       bool
+	writes, syncs, closes       int
+}
+
+func (f *failingFile) Write(data []byte) (int, error) {
+	f.writes++
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	if f.short {
+		return len(data) - 1, nil
+	}
+	return f.Buffer.Write(data)
+}
+func (f *failingFile) Sync() error  { f.syncs++; return f.syncErr }
+func (f *failingFile) Close() error { f.closes++; return f.closeErr }
+
+func TestWriterFailuresAreStickyAndClose(t *testing.T) {
+	diskFull, syncFail, closeFail := errors.New("disk full"), errors.New("sync failure"), errors.New("close failure")
+	for _, tc := range []struct {
+		name string
+		file *failingFile
+		want error
+	}{
+		{"write", &failingFile{writeErr: diskFull}, diskFull},
+		{"short-write", &failingFile{short: true}, io.ErrShortWrite},
+		{"sync", &failingFile{syncErr: syncFail}, syncFail},
+		{"close", &failingFile{closeErr: closeFail}, closeFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &Writer{file: tc.file}
+			_ = w.Start(testSession())
+			err := w.Finish(End{EndReason: "completed"})
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("got %v want %v", err, tc.want)
+			}
+			writes := tc.file.writes
+			if err := w.Finish(End{}); !errors.Is(err, tc.want) {
+				t.Fatal(err)
+			}
+			if err := w.Close(); !errors.Is(err, tc.want) {
+				t.Fatal(err)
+			}
+			if tc.file.writes != writes || tc.file.syncs != 1 || tc.file.closes != 1 {
+				t.Fatalf("writes=%d syncs=%d closes=%d", tc.file.writes, tc.file.syncs, tc.file.closes)
+			}
+			if tc.file.writeErr != nil || tc.file.short {
+				if writes != 1 {
+					t.Fatalf("retried failed write: %d", writes)
+				}
+			}
+		})
+	}
+}
+
+func TestWriterMarshalFailure(t *testing.T) {
+	f := &failingFile{}
+	w := &Writer{file: f}
+	s := testSession()
+	if err := w.Start(s); err != nil {
+		t.Fatal(err)
+	}
+	event := testProbe(s.StartedAt)
+	event.Probe.Geo.Lat = math.NaN()
+	if err := w.Event(event); err == nil {
+		t.Fatal("accepted NaN")
+	}
+	if err := w.Finish(End{EndReason: "error"}); err == nil {
+		t.Fatal("forgot marshal failure")
+	}
+	if f.writes != 1 || f.syncs != 1 || f.closes != 1 {
+		t.Fatalf("file: %+v", f)
+	}
+}
+
+func TestLineLimit(t *testing.T) {
+	f := &failingFile{}
+	w := &Writer{file: f}
+	s := testSession()
+	if err := w.Start(s); err != nil {
+		t.Fatal(err)
+	}
+	event := trace.MTRSessionEvent{Type: trace.MTRSessionMetadataEvent, At: s.StartedAt, Metadata: &trace.MTRSessionMetadata{IP: "192.0.2.1"}}
+	record := Record{Format: FormatName, SchemaVersion: SchemaVersion, Seq: 2, Timestamp: s.StartedAt, MTRSessionEvent: event}
+	// Host is omitted when empty, so account for the added field and quotes.
+	event.Metadata.Host = "x"
+	record.Metadata = event.Metadata
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event.Metadata.Host = strings.Repeat("x", MaxLineBytes-len(encoded))
+	if err := w.Event(event); err != nil {
+		t.Fatalf("exact-limit record rejected: %v", err)
+	}
+	lines := bytes.SplitAfter(f.Bytes(), []byte{'\n'})
+	if len(lines[1]) != MaxLineBytes {
+		t.Fatalf("line=%d", len(lines[1]))
+	}
+	p := filepath.Join(t.TempDir(), "exact")
+	if err := os.WriteFile(p, f.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if records, incomplete, err := readRecords(t, p); err != nil || len(records) != 2 || !incomplete {
+		t.Fatalf("reader exact limit: %d %v %v", len(records), incomplete, err)
+	}
+	event.Metadata.Host += "x"
+	if err := w.Event(event); !errors.Is(err, ErrLineTooLarge) {
+		t.Fatalf("oversized writer: %v", err)
+	}
+	for _, terminated := range []bool{false, true} {
+		over := append([]byte{}, lines[0]...)
+		over = append(over, bytes.Repeat([]byte{'x'}, MaxLineBytes+1)...)
+		if terminated {
+			over = append(over, '\n')
+		}
+		if err := os.WriteFile(p, over, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := readRecords(t, p); !errors.Is(err, ErrLineTooLarge) {
+			t.Fatalf("oversized reader terminated=%v: %v", terminated, err)
+		}
+	}
+}
+
+func TestControlEventsAndClockRegression(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session")
+	w, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := testSession()
+	if err := w.Start(s); err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range []trace.MTRSessionEvent{
+		{Type: trace.MTRSessionPauseEvent, At: s.StartedAt.Add(time.Second)},
+		{Type: trace.MTRSessionResetEvent, Generation: 1, At: s.StartedAt.Add(-time.Second)},
+		{Type: trace.MTRSessionResumeEvent, Generation: 1, At: s.StartedAt.Add(2 * time.Second)},
+		{Type: trace.MTRSessionPathEndEvent, Generation: 1, At: s.StartedAt.Add(3 * time.Second)},
+	} {
+		if err := w.Event(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Finish(End{EndedAt: s.StartedAt.Add(4 * time.Second), EndReason: "interrupted", Signal: "SIGINT"}); err != nil {
+		t.Fatal(err)
+	}
+	records, incomplete, err := readRecords(t, path)
+	if err != nil || incomplete || len(records) != 6 {
+		t.Fatalf("%d %v %v", len(records), incomplete, err)
+	}
+	if records[2].ElapsedNS != int64(time.Second) || !records[2].Timestamp.Equal(s.StartedAt.Add(-time.Second)) || records[5].Generation != 1 {
+		t.Fatal("clock or generation not preserved")
+	}
+}
+
+func TestInitializationFailureSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session")
+	w, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := testSession()
+	s.ResolvedIP, s.EffectiveParameters = "", nil
+	if err := w.Start(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Finish(End{EndReason: "error", Error: &Error{Stage: "initialize", Message: "backend unavailable"}}); err != nil {
+		t.Fatal(err)
+	}
+	records, incomplete, err := readRecords(t, path)
+	if err != nil || incomplete || len(records) != 2 || records[1].End.Error.Stage != "initialize" {
+		t.Fatalf("%+v %v %v", records, incomplete, err)
+	}
+}
+
+func TestReaderRejectsDirectory(t *testing.T) {
+	if r, err := OpenReader(t.TempDir()); err == nil {
+		_ = r.Close()
+		t.Fatal("accepted directory")
+	}
+}

--- a/internal/mtrsession/types.go
+++ b/internal/mtrsession/types.go
@@ -1,0 +1,90 @@
+// Package mtrsession stores explicitly recorded MTR sessions for offline replay.
+package mtrsession
+
+import (
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+const (
+	FormatName    = "nexttrace-mtr-session"
+	SchemaVersion = 1
+	// MaxLineBytes includes the terminating newline written by Writer.
+	MaxLineBytes = 1 << 20
+	StartEvent   = "start"
+	EndEvent     = "end"
+)
+
+// Parameters contains effective probe settings, never provider credentials.
+type Parameters struct {
+	FWMark           *uint32 `json:"fwmark,omitempty"`
+	MaxPerHop        int     `json:"max_per_hop"`
+	HopIntervalMs    int     `json:"hop_interval_ms"`
+	TimeoutMs        int64   `json:"timeout_ms"`
+	BeginHop         int     `json:"begin_hop"`
+	MaxHops          int     `json:"max_hops"`
+	ParallelRequests int     `json:"parallel_requests"`
+	SourceAddress    string  `json:"source_address"`
+	SourceDevice     string  `json:"source_device,omitempty"`
+	SourcePort       *int    `json:"source_port,omitempty"`
+	Port             *int    `json:"port,omitempty"`
+	PacketSize       int     `json:"packet_size"`
+	RandomPacketSize bool    `json:"random_packet_size"`
+	TOS              int     `json:"tos"`
+	ICMPMode         *int    `json:"icmp_mode,omitempty"`
+	DataProvider     string  `json:"data_provider"`
+	Language         string  `json:"language"`
+	DotServer        string  `json:"dot_server,omitempty"`
+	RDNS             bool    `json:"rdns"`
+	AlwaysWaitRDNS   bool    `json:"always_wait_rdns"`
+	DisableMPLS      bool    `json:"disable_mpls"`
+	DN42             bool    `json:"dn42"`
+}
+
+type DisplayParameters struct {
+	HostMode     int    `json:"host_mode"`
+	HostNameMode int    `json:"host_name_mode"`
+	ShowIPs      bool   `json:"show_ips"`
+	ShowMPLS     bool   `json:"show_mpls"`
+	Wide         bool   `json:"wide"`
+	Columns      string `json:"columns,omitempty"`
+}
+
+type Session struct {
+	Version             string            `json:"version"`
+	Target              string            `json:"target"`
+	ResolvedIP          string            `json:"resolved_ip"`
+	Protocol            string            `json:"protocol"`
+	StartedAt           time.Time         `json:"started_at"`
+	EffectiveParameters *Parameters       `json:"effective_parameters"`
+	SourceHost          string            `json:"source_host"`
+	SourceIP            string            `json:"source_ip,omitempty"`
+	Display             DisplayParameters `json:"display"`
+}
+
+type Error struct {
+	Stage   string `json:"stage"`
+	Message string `json:"message"`
+}
+
+type End struct {
+	EndedAt   time.Time         `json:"ended_at"`
+	EndReason string            `json:"end_reason"`
+	PathEnd   *trace.StopReason `json:"path_end"`
+	Error     *Error            `json:"error,omitempty"`
+	Signal    string            `json:"signal,omitempty"`
+}
+
+// Record keeps event occurrence time separate from the ordered playback clock.
+// Sequence and ElapsedNS are monotonic, even if the wall clock moves backwards.
+type Record struct {
+	Format        string    `json:"format"`
+	SchemaVersion int       `json:"schema_version"`
+	Seq           uint64    `json:"seq"`
+	ElapsedNS     int64     `json:"elapsed_ns"`
+	Timestamp     time.Time `json:"timestamp"`
+	trace.MTRSessionEvent
+	Session *Session `json:"session,omitempty"`
+	End     *End     `json:"end,omitempty"`
+}

--- a/internal/mtrsession/types.go
+++ b/internal/mtrsession/types.go
@@ -84,6 +84,7 @@ type Record struct {
 	Seq           uint64    `json:"seq"`
 	ElapsedNS     int64     `json:"elapsed_ns"`
 	Timestamp     time.Time `json:"timestamp"`
+	ProbeAgeNS    *int64    `json:"probe_age_ns,omitempty"`
 	trace.MTRSessionEvent
 	Session *Session `json:"session,omitempty"`
 	End     *End     `json:"end,omitempty"`

--- a/internal/mtrsession/validate.go
+++ b/internal/mtrsession/validate.go
@@ -79,7 +79,7 @@ func (s *recordState) acceptEvent(r Record) error {
 		return errors.New("invalid MTR session generation")
 	}
 	if r.Type == EndEvent {
-		if r.End == nil || r.Probe != nil || r.Metadata != nil || r.PathEnd != nil || r.End.EndedAt.IsZero() || r.End.EndReason == "" {
+		if r.End == nil || r.Probe != nil || r.Metadata != nil || r.PathEnd != nil || !r.End.EndedAt.Equal(r.Timestamp) || !validEndReason(r.End) {
 			return errors.New("invalid MTR session end")
 		}
 		s.ended = true
@@ -119,4 +119,18 @@ func (s *recordState) acceptEvent(r Record) error {
 		return fmt.Errorf("unknown MTR session event %q", r.Type)
 	}
 	return nil
+}
+
+// validEndReason accepts only combinations emitted by the recording lifecycle.
+func validEndReason(end *End) bool {
+	switch end.EndReason {
+	case "completed":
+		return end.Error == nil && end.Signal == ""
+	case "interrupted":
+		return end.Error == nil && (end.Signal == "" || end.Signal == "SIGINT" || end.Signal == "SIGTERM")
+	case "error":
+		return end.Signal == "" && end.Error != nil && end.Error.Stage != "" && end.Error.Message != ""
+	default:
+		return false
+	}
 }

--- a/internal/mtrsession/validate.go
+++ b/internal/mtrsession/validate.go
@@ -92,6 +92,13 @@ func (s *recordState) acceptEvent(r Record) error {
 		if r.Probe == nil || r.Metadata != nil || r.PathEnd != nil || r.Probe.TTL < 1 || r.Probe.TTL > s.maxHops || r.Probe.RTT < 0 || r.Probe.CompletedAt.IsZero() {
 			return errors.New("invalid MTR session probe")
 		}
+		if response := r.Probe.Response; response != nil {
+			switch response.Kind {
+			case trace.MTRResponseTransit, trace.MTRResponseDestination, trace.MTRResponseUnreachable:
+			default:
+				return fmt.Errorf("invalid MTR session response kind %q", response.Kind)
+			}
+		}
 	case trace.MTRSessionMetadataEvent:
 		if r.Metadata == nil || r.Metadata.IP == "" || r.Probe != nil || r.PathEnd != nil {
 			return errors.New("invalid MTR session metadata")

--- a/internal/mtrsession/validate.go
+++ b/internal/mtrsession/validate.go
@@ -1,0 +1,108 @@
+package mtrsession
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+var (
+	ErrLineTooLarge = errors.New("MTR session record exceeds 1 MiB")
+	ErrClosed       = errors.New("MTR session file is closed")
+)
+
+type recordState struct {
+	seq        uint64
+	elapsed    int64
+	generation uint64
+	maxHops    int
+	ended      bool
+}
+
+func (s *recordState) accept(r Record) error {
+	if r.Format != FormatName {
+		return errors.New("not a NextTrace MTR session file")
+	}
+	if r.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported MTR session schema version %d", r.SchemaVersion)
+	}
+	if s.ended {
+		return errors.New("record follows MTR session end")
+	}
+	if r.Seq != s.seq+1 {
+		return fmt.Errorf("MTR session sequence: got %d, expected %d", r.Seq, s.seq+1)
+	}
+	if r.ElapsedNS < s.elapsed || r.Timestamp.IsZero() {
+		return errors.New("invalid MTR session timestamp")
+	}
+	if s.seq == 0 {
+		if err := s.acceptStart(r); err != nil {
+			return err
+		}
+	} else if err := s.acceptEvent(r); err != nil {
+		return err
+	}
+	s.seq, s.elapsed, s.generation = r.Seq, r.ElapsedNS, r.Generation
+	return nil
+}
+
+func (s *recordState) acceptStart(r Record) error {
+	if r.Type != StartEvent || r.Session == nil || r.End != nil || r.Probe != nil || r.Metadata != nil || r.PathEnd != nil || r.Generation != 0 || r.ElapsedNS != 0 {
+		return errors.New("MTR session must begin with a start record")
+	}
+	if !r.Timestamp.Equal(r.Session.StartedAt) {
+		return errors.New("MTR session start timestamp does not match header")
+	}
+	if p := r.Session.EffectiveParameters; p != nil {
+		if p.MaxHops < 1 || p.MaxHops > 255 || p.BeginHop < 1 || p.BeginHop > p.MaxHops || p.MaxPerHop < 0 || p.HopIntervalMs <= 0 || p.TimeoutMs <= 0 || p.ParallelRequests <= 0 || p.TOS < 0 || p.TOS > 255 {
+			return errors.New("invalid effective MTR session parameters")
+		}
+		s.maxHops = p.MaxHops
+	}
+	return nil
+}
+
+func (s *recordState) acceptEvent(r Record) error {
+	if r.Session != nil {
+		return errors.New("unexpected MTR session header")
+	}
+	expectedGeneration := s.generation
+	if r.Type == trace.MTRSessionResetEvent {
+		expectedGeneration++
+	}
+	if r.Generation != expectedGeneration {
+		return errors.New("invalid MTR session generation")
+	}
+	if r.Type == EndEvent {
+		if r.End == nil || r.Probe != nil || r.Metadata != nil || r.PathEnd != nil || r.End.EndedAt.IsZero() || r.End.EndReason == "" {
+			return errors.New("invalid MTR session end")
+		}
+		s.ended = true
+		return nil
+	}
+	if r.End != nil {
+		return errors.New("unexpected MTR session end payload")
+	}
+	switch r.Type {
+	case trace.MTRSessionProbeEvent:
+		if r.Probe == nil || r.Metadata != nil || r.PathEnd != nil || r.Probe.TTL < 1 || r.Probe.TTL > s.maxHops || r.Probe.RTT < 0 || r.Probe.CompletedAt.IsZero() {
+			return errors.New("invalid MTR session probe")
+		}
+	case trace.MTRSessionMetadataEvent:
+		if r.Metadata == nil || r.Metadata.IP == "" || r.Probe != nil || r.PathEnd != nil {
+			return errors.New("invalid MTR session metadata")
+		}
+	case trace.MTRSessionPathEndEvent:
+		if r.Probe != nil || r.Metadata != nil {
+			return errors.New("invalid MTR session path end")
+		}
+	case trace.MTRSessionPauseEvent, trace.MTRSessionResumeEvent, trace.MTRSessionResetEvent:
+		if r.Probe != nil || r.Metadata != nil || r.PathEnd != nil {
+			return errors.New("unexpected MTR session control payload")
+		}
+	default:
+		return fmt.Errorf("unknown MTR session event %q", r.Type)
+	}
+	return nil
+}

--- a/internal/mtrsession/validate.go
+++ b/internal/mtrsession/validate.go
@@ -36,6 +36,9 @@ func (s *recordState) accept(r Record) error {
 	if r.ElapsedNS < s.elapsed || r.Timestamp.IsZero() {
 		return errors.New("invalid MTR session timestamp")
 	}
+	if r.ProbeAgeNS != nil && (r.Type != trace.MTRSessionProbeEvent || *r.ProbeAgeNS < 0) {
+		return errors.New("invalid MTR session probe age")
+	}
 	if s.seq == 0 {
 		if err := s.acceptStart(r); err != nil {
 			return err

--- a/internal/mtrsession/validate.go
+++ b/internal/mtrsession/validate.go
@@ -18,6 +18,9 @@ type recordState struct {
 	elapsed    int64
 	generation uint64
 	maxHops    int
+	beginHop   int
+	maxPerHop  int
+	probes     [256]int
 	ended      bool
 }
 
@@ -62,7 +65,7 @@ func (s *recordState) acceptStart(r Record) error {
 		if p.MaxHops < 1 || p.MaxHops > 255 || p.BeginHop < 1 || p.BeginHop > p.MaxHops || p.MaxPerHop < 0 || p.HopIntervalMs <= 0 || p.TimeoutMs <= 0 || p.ParallelRequests <= 0 || p.TOS < 0 || p.TOS > 255 {
 			return errors.New("invalid effective MTR session parameters")
 		}
-		s.maxHops = p.MaxHops
+		s.maxHops, s.beginHop, s.maxPerHop = p.MaxHops, p.BeginHop, p.MaxPerHop
 	}
 	return nil
 }
@@ -90,7 +93,7 @@ func (s *recordState) acceptEvent(r Record) error {
 	}
 	switch r.Type {
 	case trace.MTRSessionProbeEvent:
-		if r.Probe == nil || r.Metadata != nil || r.PathEnd != nil || r.Probe.TTL < 1 || r.Probe.TTL > s.maxHops || r.Probe.RTT < 0 || r.Probe.CompletedAt.IsZero() {
+		if r.Probe == nil || r.Metadata != nil || r.PathEnd != nil || r.Probe.TTL < s.beginHop || r.Probe.TTL > s.maxHops || r.Probe.RTT < 0 || r.Probe.CompletedAt.IsZero() {
 			return errors.New("invalid MTR session probe")
 		}
 		if response := r.Probe.Response; response != nil {
@@ -103,6 +106,12 @@ func (s *recordState) acceptEvent(r Record) error {
 				return fmt.Errorf("invalid MTR session response kind %q", response.Kind)
 			}
 		}
+		if s.maxPerHop > 0 {
+			if s.probes[r.Probe.TTL] >= s.maxPerHop {
+				return errors.New("MTR session probe exceeds max_per_hop")
+			}
+			s.probes[r.Probe.TTL]++
+		}
 	case trace.MTRSessionMetadataEvent:
 		if r.Metadata == nil || r.Metadata.IP == "" || r.Probe != nil || r.PathEnd != nil {
 			return errors.New("invalid MTR session metadata")
@@ -111,9 +120,22 @@ func (s *recordState) acceptEvent(r Record) error {
 		if r.Probe != nil || r.Metadata != nil {
 			return errors.New("invalid MTR session path end")
 		}
+		if r.PathEnd != nil && r.PathEnd.Reason == trace.StopReasonMaxHops {
+			if s.maxPerHop <= 0 || r.PathEnd.Hop != s.maxHops {
+				return errors.New("MTR session max_hops requires bounded completion")
+			}
+			for ttl := s.beginHop; ttl <= s.maxHops; ttl++ {
+				if s.probes[ttl] != s.maxPerHop {
+					return errors.New("MTR session max_hops precedes per-hop completion")
+				}
+			}
+		}
 	case trace.MTRSessionPauseEvent, trace.MTRSessionResumeEvent, trace.MTRSessionResetEvent:
 		if r.Probe != nil || r.Metadata != nil || r.PathEnd != nil {
 			return errors.New("unexpected MTR session control payload")
+		}
+		if r.Type == trace.MTRSessionResetEvent {
+			s.probes = [256]int{}
 		}
 	default:
 		return fmt.Errorf("unknown MTR session event %q", r.Type)

--- a/internal/mtrsession/validate.go
+++ b/internal/mtrsession/validate.go
@@ -3,6 +3,7 @@ package mtrsession
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/nxtrace/NTrace-core/trace"
 )
@@ -93,6 +94,9 @@ func (s *recordState) acceptEvent(r Record) error {
 			return errors.New("invalid MTR session probe")
 		}
 		if response := r.Probe.Response; response != nil {
+			if !r.Probe.Success || net.ParseIP(r.Probe.IP) == nil {
+				return errors.New("MTR session response requires a successful probe with a valid address")
+			}
 			switch response.Kind {
 			case trace.MTRResponseTransit, trace.MTRResponseDestination, trace.MTRResponseUnreachable:
 			default:

--- a/internal/mtrsession/writer.go
+++ b/internal/mtrsession/writer.go
@@ -1,0 +1,138 @@
+package mtrsession
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type writeSyncCloser interface {
+	io.Writer
+	Sync() error
+	Close() error
+}
+
+// Writer writes each complete event before returning. Finish syncs and closes
+// the file. A failed write is sticky: later calls never append to a bad tail.
+type Writer struct {
+	mu     sync.Mutex
+	file   writeSyncCloser
+	start  time.Time
+	state  recordState
+	err    error
+	closed bool
+}
+
+// Open exclusively creates a private file. Existing files, including symlinks,
+// are never overwritten or appended to.
+func Open(path string) (*Writer, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{file: f}, nil
+}
+
+func (w *Writer) Start(session Session) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if session.StartedAt.IsZero() {
+		session.StartedAt = time.Now()
+	}
+	w.start = session.StartedAt
+	session.StartedAt = session.StartedAt.UTC()
+	return w.writeLocked(Record{
+		MTRSessionEvent: trace.MTRSessionEvent{Type: StartEvent},
+		Timestamp:       session.StartedAt.UTC(), Session: &session,
+	})
+}
+
+func (w *Writer) Event(event trace.MTRSessionEvent) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if event.At.IsZero() {
+		event.At = time.Now()
+	}
+	return w.writeLocked(Record{MTRSessionEvent: event, Timestamp: event.At.UTC(), ElapsedNS: w.elapsed(event.At)})
+}
+
+func (w *Writer) elapsed(at time.Time) int64 {
+	value := int64(at.Sub(w.start))
+	if value < w.state.elapsed {
+		value = w.state.elapsed
+	}
+	return value
+}
+
+func (w *Writer) writeLocked(record Record) error {
+	if w.closed {
+		return ErrClosed
+	}
+	if w.err != nil {
+		return w.err
+	}
+	record.Format, record.SchemaVersion, record.Seq = FormatName, SchemaVersion, w.state.seq+1
+	state := w.state
+	if w.err = state.accept(record); w.err != nil {
+		return w.err
+	}
+	var data []byte
+	data, w.err = json.Marshal(record)
+	if w.err != nil {
+		return w.err
+	}
+	if len(data)+1 > MaxLineBytes {
+		w.err = ErrLineTooLarge
+		return w.err
+	}
+	data = append(data, '\n')
+	var n int
+	n, w.err = w.file.Write(data)
+	if w.err == nil && n != len(data) {
+		w.err = io.ErrShortWrite
+	}
+	if w.err == nil {
+		w.state = state
+	}
+	return w.err
+}
+
+// Finish is idempotent and checks both Sync and Close, including after a write
+// failure. The first failed record is never retried.
+func (w *Writer) Finish(end End) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return w.err
+	}
+	if end.EndedAt.IsZero() {
+		end.EndedAt = time.Now()
+	}
+	elapsed := w.elapsed(end.EndedAt)
+	end.EndedAt = end.EndedAt.UTC()
+	_ = w.writeLocked(Record{
+		MTRSessionEvent: trace.MTRSessionEvent{Type: EndEvent, Generation: w.state.generation},
+		Timestamp:       end.EndedAt, ElapsedNS: elapsed, End: &end,
+	})
+	return w.closeLocked()
+}
+
+// Close preserves an unfinished file for recovery without inventing an end.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closeLocked()
+}
+
+func (w *Writer) closeLocked() error {
+	if !w.closed {
+		w.closed = true
+		w.err = errors.Join(w.err, w.file.Sync(), w.file.Close())
+	}
+	return w.err
+}

--- a/internal/mtrsession/writer.go
+++ b/internal/mtrsession/writer.go
@@ -58,7 +58,15 @@ func (w *Writer) Event(event trace.MTRSessionEvent) error {
 	if event.At.IsZero() {
 		event.At = time.Now()
 	}
-	return w.writeLocked(Record{MTRSessionEvent: event, Timestamp: event.At.UTC(), ElapsedNS: w.elapsed(event.At)})
+	record := Record{MTRSessionEvent: event, ElapsedNS: w.elapsed(event.At)}
+	if event.Probe != nil {
+		// Sub retains the monotonic clock here; the two serialized wall times
+		// cannot recover this age if the clock steps while a result is queued.
+		age := int64(max(time.Duration(0), event.At.Sub(event.Probe.CompletedAt)))
+		record.ProbeAgeNS = &age
+	}
+	record.Timestamp = event.At.UTC()
+	return w.writeLocked(record)
 }
 
 func (w *Writer) elapsed(at time.Time) int64 {

--- a/printer/mtr_columns_layout.go
+++ b/printer/mtr_columns_layout.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/nxtrace/NTrace-core/trace"
@@ -134,7 +133,11 @@ func renderMTRSelectedHeader(b *strings.Builder, header MTRTUIHeader, width int)
 	if width < 40 {
 		tuiLine(b, "%s", truncateByDisplayWidth(buildMTRTUIRouteText(header), width))
 	} else {
-		tuiLine(b, "%s", buildMTRTUIRouteLine(header, width, time.Now()))
+		tuiLine(b, "%s", buildMTRTUIRouteLine(header, width, mtrTUIClock(header)))
+	}
+	if header.Replay != nil {
+		tuiLine(b, "%s", buildMTRReplayControls(header, width))
+		return
 	}
 	if width >= 160 {
 		tuiLine(b, "%s", buildMTRTUIControlsLine(header, width))

--- a/printer/mtr_history.go
+++ b/printer/mtr_history.go
@@ -46,10 +46,15 @@ func NewMTRHistoryStore(window time.Duration) *MTRHistoryStore {
 }
 
 func (s *MTRHistoryStore) AddProbeEvent(event trace.MTRProbeEvent) {
+	s.AddProbeEventAt(event, time.Now())
+}
+
+// AddProbeEventAt uses the caller's clock, allowing offline history to retain
+// samples from the recording instead of pruning them against wall time.
+func (s *MTRHistoryStore) AddProbeEventAt(event trace.MTRProbeEvent, now time.Time) {
 	if s == nil || event.TTL <= 0 {
 		return
 	}
-	now := time.Now()
 	at := event.Timestamp
 	if at.IsZero() || at.After(now) {
 		at = now

--- a/printer/mtr_replay.go
+++ b/printer/mtr_replay.go
@@ -1,0 +1,92 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type MTRReplayStatus struct {
+	Cursor, Duration  time.Duration
+	Complete, Seeking bool
+	RecordedPaused    bool
+}
+
+type MTRReplayEditor struct {
+	Active       bool
+	Draft, Error string
+}
+
+func FormatMTRReplayTime(d time.Duration) string {
+	ms := max(int64(0), d.Milliseconds())
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", ms/3600000, ms/60000%60, ms/1000%60, ms%1000)
+}
+
+func mtrTUIClock(header MTRTUIHeader) time.Time {
+	if !header.Now.IsZero() {
+		return header.Now
+	}
+	return time.Now()
+}
+
+func buildMTRReplayControls(header MTRTUIHeader, width int) string {
+	r := header.Replay
+	state := "Playing"
+	if header.Status == MTRTUIPaused {
+		state = "Paused"
+	}
+	if r.Seeking {
+		state = "Seeking"
+	}
+	status := fmt.Sprintf("%s %s/%s", state, FormatMTRReplayTime(r.Cursor), FormatMTRReplayTime(r.Duration))
+	if !r.Complete {
+		status += " Incomplete"
+	}
+	if r.RecordedPaused {
+		status += " Probe-paused"
+	}
+	return truncateByDisplayWidth(status+"  Q:quit J:time Space:play P:pause R:rewind D:history G:chart O:cols Y:display N:host E:mpls", width)
+}
+
+func renderMTRReplayEditor(b *strings.Builder, editor MTRReplayEditor, width int) {
+	for _, line := range []string{"Go to HH:MM:SS[.mmm]", "Enter: apply Esc: cancel", "Backspace: delete Ctrl-U: clear"} {
+		tuiLine(b, "%s", truncateByDisplayWidth(line, width))
+	}
+	prefix := "Time: "
+	draft := editor.Draft
+	available := max(1, width-len(prefix)-1)
+	if len(draft) > available {
+		draft = draft[len(draft)-available:]
+	}
+	tuiLine(b, "%s", truncateByDisplayWidth(prefix+draft+"_", width))
+	if editor.Error != "" {
+		tuiLine(b, "%s", truncateByDisplayWidth(editor.Error, width))
+	}
+}
+
+// WriteMTRReplayReport shares the live report's host and metric formatting,
+// while writing to an explicit sink without terminal escapes.
+func WriteMTRReplayReport(w io.Writer, stats []trace.MTRHopStat, opts MTRReportOptions) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Start: %s\n", opts.StartTime.Format("2006-01-02T15:04:05-0700"))
+	hosts, hostWidth := prepareMTRReportHosts(stats, opts, normalizeMTRReportLang(opts.Lang))
+	columns := opts.Columns
+	if columns == nil {
+		columns = DefaultMTRColumns()
+	}
+	widths := mtrColumnWidths(columns, stats)
+	fmt.Fprintf(&b, "HOST: %s %s\n", reportPadRight(opts.SrcHost, hostWidth), mtrSelectedMetrics(columns, widths, nil, false))
+	previous := 0
+	for i, stat := range stats {
+		fmt.Fprintf(&b, "%s%s %s\n", mtrReportPrefix(stat.TTL, previous), reportPadRight(hosts[i], hostWidth), mtrSelectedMetrics(columns, widths, &stat, false))
+		previous = stat.TTL
+	}
+	n, err := io.WriteString(w, b.String())
+	if err == nil && n != b.Len() {
+		err = io.ErrShortWrite
+	}
+	return err
+}

--- a/printer/mtr_replay_test.go
+++ b/printer/mtr_replay_test.go
@@ -1,0 +1,56 @@
+package printer
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestMTRReplayExplicitClockInAllHeaders(t *testing.T) {
+	clock := time.Date(2000, 2, 3, 4, 5, 6, 0, time.UTC)
+	for _, columns := range [][]MTRColumn{nil, {MTRColumnAvg}} {
+		header := MTRTUIHeader{Target: "192.0.2.1", Version: "test", Now: clock, Columns: columns, Replay: &MTRReplayStatus{Cursor: 5 * time.Second, Duration: time.Minute, Complete: true}, Status: MTRTUIPaused}
+		frame := mtrTUIRenderStringWithWidth(header, nil, 160)
+		for _, want := range []string{"Replay", "2000-02-03T04:05:06+0000", "Paused 00:00:05.000/00:01:00.000", "J:time"} {
+			if !strings.Contains(frame, want) {
+				t.Fatalf("missing %q in %q", want, frame)
+			}
+		}
+	}
+}
+
+func TestMTRReplayHistoryUsesRecordingClock(t *testing.T) {
+	for _, year := range []int{2000, 2100} {
+		clock := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+		store := NewMTRHistoryStore(MTRHistoryWindow)
+		store.AddProbeEventAt(trace.MTRProbeEvent{TTL: 1, Success: true, Timestamp: clock.Add(-time.Second), RTT: time.Millisecond}, clock)
+		store.AddProbeEventAt(trace.MTRProbeEvent{TTL: 1, Success: false, Timestamp: clock.Add(-4 * time.Minute)}, clock)
+		history := store.Snapshot(clock)
+		if len(history) != 1 || len(history[0].Samples) != 1 || !history[0].Samples[0].At.Equal(clock.Add(-time.Second)) {
+			t.Fatalf("year=%d history=%+v", year, history)
+		}
+	}
+}
+
+type replayFailedWriter struct{}
+
+func (replayFailedWriter) Write([]byte) (int, error) { return 0, errors.New("closed") }
+
+func TestMTRReplayReportPlainSink(t *testing.T) {
+	var b bytes.Buffer
+	stats := []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1", Snt: 2, Received: 1, Loss: 50, Avg: 1.25}}
+	opts := MTRReportOptions{Columns: []MTRColumn{MTRColumnReceived, MTRColumnAvg}, Wide: true, SrcHost: "recorded-host"}
+	if err := WriteMTRReplayReport(&b, stats, opts); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(b.String(), "\x1b") || !strings.Contains(b.String(), "Rcv") || !strings.Contains(b.String(), "Avg") || strings.Contains(b.String(), "Loss%") {
+		t.Fatalf("report=%s", b.String())
+	}
+	if err := WriteMTRReplayReport(replayFailedWriter{}, stats, opts); err == nil {
+		t.Fatal("ignored write error")
+	}
+}

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -52,6 +52,9 @@ type MTRTUIHeader struct {
 	HistoryChartMode int
 	History          []MTRHistoryTTL
 	HistoryNow       time.Time
+	Now              time.Time // zero uses the live clock
+	Replay           *MTRReplayStatus
+	ReplayEditor     MTRReplayEditor
 }
 
 // ---------------------------------------------------------------------------
@@ -375,6 +378,12 @@ func mtrTUIRenderWithWidth(w io.Writer, header MTRTUIHeader, stats []trace.MTRHo
 	var b strings.Builder
 
 	writeMTRTUIFramePrefix(&b)
+	if header.ReplayEditor.Active {
+		tuiLine(&b, "%s", buildMTRTUITitleLine(header, lo.termWidth))
+		renderMTRReplayEditor(&b, header.ReplayEditor, lo.termWidth)
+		_, _ = fmt.Fprint(w, b.String())
+		return
+	}
 	if header.ColumnEditor.Active {
 		tuiLine(&b, "%s", buildMTRTUITitleLine(header, lo.termWidth))
 		tuiLine(&b, "%s", mtrTUIStatusText(header.Status))
@@ -427,7 +436,7 @@ func writeMTRTUIFramePrefix(b *strings.Builder) {
 
 func renderMTRTUIHeader(b *strings.Builder, header MTRTUIHeader, termWidth int) {
 	tuiLine(b, "%s", buildMTRTUITitleLine(header, termWidth))
-	tuiLine(b, "%s", buildMTRTUIRouteLine(header, termWidth, time.Now()))
+	tuiLine(b, "%s", buildMTRTUIRouteLine(header, termWidth, mtrTUIClock(header)))
 	tuiLine(b, "%s", buildMTRTUIControlsLine(header, termWidth))
 }
 
@@ -459,6 +468,9 @@ func resolveMTRTUITitleParts(header MTRTUIHeader) (string, string) {
 		ver = "dev"
 	}
 	titlePart := fmt.Sprintf("NextTrace [%s]", ver)
+	if header.Replay != nil {
+		titlePart += " Replay"
+	}
 	if header.APIInfo == "" {
 		return titlePart, ""
 	}
@@ -515,6 +527,9 @@ func resolveMTRTUIDestinationLabel(header MTRTUIHeader) string {
 }
 
 func buildMTRTUIControlsLine(header MTRTUIHeader, termWidth int) string {
+	if header.Replay != nil {
+		return buildMTRReplayControls(header, termWidth)
+	}
 	const keysPrefix = "Keys:  "
 	items := buildMTRTUIKeyItems(header, mtrTUIKeyHiColor)
 	plainItems := buildMTRTUIKeyItems(header, fmt.Sprint)

--- a/scripts/test_mtr_session_pty.py
+++ b/scripts/test_mtr_session_pty.py
@@ -11,6 +11,7 @@ import os
 import platform
 import re
 import select
+import signal
 import struct
 import subprocess
 import sys
@@ -131,6 +132,43 @@ def verify_recording(binary, path):
     return records[-1]["elapsed_ns"]
 
 
+def verify_recording_signals(binary, directory, mode, log):
+    # Unix delivers actual OS signals; ConPTY key input is a separate contract.
+    for output_mode, flags in (("tui", mode), ("report", ["-r"]), ("raw", mode + ["--raw"])):
+        for sig, expected_code in ((signal.SIGINT, 130), (signal.SIGTERM, 143)):
+            path = os.path.join(directory, f"{output_mode}-{sig.name}.jsonl")
+            terminal = Terminal([binary] + flags + [
+                "--mtr-record", path, "-q", "1000", "-i", "40", "--timeout", "100",
+                "-d", "disable-geoip", "-n", "-s", "127.0.0.1", "-m", "1", "127.0.0.1",
+            ], log)
+            try:
+                deadline = time.monotonic() + 5
+                ready = False
+                while time.monotonic() < deadline:
+                    terminal.read(0.05)
+                    try:
+                        with open(path, encoding="utf-8") as source:
+                            ready = any('"type":"probe"' in line for line in source)
+                    except FileNotFoundError:
+                        pass
+                    if ready:
+                        break
+                assert ready, f"{output_mode} did not record a probe before {sig.name}"
+                terminal.process.send_signal(sig)
+                deadline = time.monotonic() + 5
+                while terminal.process.poll() is None and time.monotonic() < deadline:
+                    terminal.read(0.05)
+                assert terminal.process.poll() == expected_code, (output_mode, sig.name, terminal.process.poll())
+                assert termios.tcgetattr(terminal.slave) == terminal.original, "Signal exit did not restore terminal"
+                with open(path, encoding="utf-8") as source:
+                    records = [json.loads(line) for line in source]
+                assert records[-1]["type"] == "end", (output_mode, sig.name)
+                assert records[-1]["end"]["end_reason"] == "interrupted", records[-1]
+                assert records[-1]["end"]["signal"] == sig.name, records[-1]
+            finally:
+                terminal.close()
+
+
 def main(binary):
     binary = os.path.abspath(binary)
     log = bytearray()
@@ -190,11 +228,14 @@ def main(binary):
                 offline.quit()
             finally:
                 offline.close()
+            if os.name != "nt":
+                verify_recording_signals(binary, directory, mode, log)
         print(json.dumps({
             "platform": platform.system(), "binary": os.path.basename(binary), "session_pty": "PASS",
             "checks": ["loopback recording", "pause/resume", "reset generation", "ordered file",
                        "offline count/RTT parity", "final snapshot", "time seek", "history", "column editor",
-                       "play/pause", "rewind", "EOF pause", "terminal restore"],
+                       "play/pause", "rewind", "EOF pause", "terminal restore"]
+                      + (["recorded SIGINT/SIGTERM"] if os.name != "nt" else []),
         }, indent=2))
     finally:
         with open(os.path.join(tempfile.gettempdir(), "mtr-session-pty.log"), "wb") as output:

--- a/scripts/test_mtr_session_pty.py
+++ b/scripts/test_mtr_session_pty.py
@@ -178,6 +178,9 @@ def main(binary):
         result = subprocess.run([binary, "--mtr-replay", flag], capture_output=True,
                                 text=True, timeout=5, check=True)
         assert result.stdout.strip(), f"Replay {flag} produced no output"
+        if flag == "--help":
+            assert "--mtr-replay FILE" in result.stdout
+            assert "Offline only." in result.stdout
     # ntr selects MTR by default and deliberately omits the mode flag.
     explicit_mtr = bool(re.search(r"^\s+-t\s+--mtr\s", help_result.stdout, re.M))
     mode = ["--mtr"] if explicit_mtr else []

--- a/scripts/test_mtr_session_pty.py
+++ b/scripts/test_mtr_session_pty.py
@@ -174,6 +174,10 @@ def main(binary):
     log = bytearray()
     help_result = subprocess.run([binary, "--help"], capture_output=True,
                                  text=True, timeout=5, check=True)
+    for flag in ("--help", "--version"):
+        result = subprocess.run([binary, "--mtr-replay", flag], capture_output=True,
+                                text=True, timeout=5, check=True)
+        assert result.stdout.strip(), f"Replay {flag} produced no output"
     # ntr selects MTR by default and deliberately omits the mode flag.
     explicit_mtr = bool(re.search(r"^\s+-t\s+--mtr\s", help_result.stdout, re.M))
     mode = ["--mtr"] if explicit_mtr else []
@@ -232,7 +236,7 @@ def main(binary):
                 verify_recording_signals(binary, directory, mode, log)
         print(json.dumps({
             "platform": platform.system(), "binary": os.path.basename(binary), "session_pty": "PASS",
-            "checks": ["loopback recording", "pause/resume", "reset generation", "ordered file",
+            "checks": ["replay help/version", "loopback recording", "pause/resume", "reset generation", "ordered file",
                        "offline count/RTT parity", "final snapshot", "time seek", "history", "column editor",
                        "play/pause", "rewind", "EOF pause", "terminal restore"]
                       + (["recorded SIGINT/SIGTERM"] if os.name != "nt" else []),

--- a/scripts/test_mtr_session_pty.py
+++ b/scripts/test_mtr_session_pty.py
@@ -1,0 +1,205 @@
+"""Record loopback MTR and exercise offline replay on a real PTY.
+
+Usage: python3 scripts/test_mtr_session_pty.py /path/to/nexttrace
+The same command accepts full, tiny and ntr builds. Windows requires
+pywinpty==3.0.5; Linux CI runs under sudo for ICMP socket access.
+"""
+
+import json
+import math
+import os
+import platform
+import re
+import select
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+if os.name != "nt":
+    import fcntl
+    import pty
+    import termios
+
+
+class Terminal:
+    def __init__(self, command, log):
+        self.log = log
+        self.windows = os.name == "nt"
+        if self.windows:
+            from winpty import PtyProcess
+            self.process = PtyProcess.spawn(command, dimensions=(32, 150))
+        else:
+            self.master, self.slave = pty.openpty()
+            self.original = termios.tcgetattr(self.slave)
+            fcntl.ioctl(self.slave, termios.TIOCSWINSZ,
+                        struct.pack("HHHH", 32, 150, 0, 0))
+            self.process = subprocess.Popen(
+                command, stdin=self.slave, stdout=self.slave, stderr=self.slave)
+
+    def read(self, seconds=0.2):
+        end = time.monotonic() + seconds
+        data = bytearray()
+        while time.monotonic() < end:
+            source = self.process.fileobj if self.windows else self.master
+            if select.select([source], [], [], max(0, end - time.monotonic()))[0]:
+                try:
+                    chunk = (self.process.read(65536).encode() if self.windows
+                             else os.read(self.master, 65536))
+                    if not chunk:
+                        break
+                    data.extend(chunk)
+                except (OSError, EOFError):
+                    break
+        self.log.extend(data)
+        return data.decode(errors="replace")
+
+    def expect(self, *needles, timeout=5):
+        text = ""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text += self.read()
+            if all(needle in text for needle in needles):
+                return text
+        raise AssertionError(f"Missing {needles!r}: {text[-12000:]!r}")
+
+    def send(self, keys):
+        if self.windows:
+            self.process.write(keys)
+        else:
+            os.write(self.master, keys.encode())
+
+    def quit(self):
+        self.send("q")
+        self.expect("\x1b[?1049l", "\x1b[?25h")
+        if self.windows:
+            deadline = time.monotonic() + 3
+            while self.process.isalive() and time.monotonic() < deadline:
+                self.read(0.1)
+            assert not self.process.isalive(), "Process did not exit"
+            assert self.process.exitstatus == 0, self.process.exitstatus
+        else:
+            self.process.wait(timeout=3)
+            assert self.process.returncode == 0, self.process.returncode
+            assert termios.tcgetattr(self.slave) == self.original, "Terminal attributes not restored"
+
+    def close(self):
+        if self.windows:
+            self.process.close(force=True)
+        else:
+            if self.process.poll() is None:
+                self.process.kill()
+                self.process.wait()
+            os.close(self.master)
+            os.close(self.slave)
+
+
+def replay_time(nanoseconds):
+    ms = nanoseconds // 1000000
+    return f"{ms // 3600000:02d}:{ms // 60000 % 60:02d}:{ms // 1000 % 60:02d}.{ms % 1000:03d}"
+
+
+def verify_recording(binary, path):
+    with open(path, encoding="utf-8") as source:
+        records = [json.loads(line) for line in source]
+    assert records[0]["type"] == "start", records[0]
+    assert records[-1]["type"] == "end", records[-1]
+    kinds = [record["type"] for record in records]
+    assert all(kind in kinds for kind in ("probe", "pause", "resume", "reset", "path_end")), kinds
+    assert [r["seq"] for r in records] == list(range(1, len(records) + 1)), "Non-contiguous sequence"
+    assert all(a["elapsed_ns"] <= b["elapsed_ns"] for a, b in zip(records, records[1:])), "Playback clock moved backwards"
+    reset = next(r for r in records if r["type"] == "reset")
+    probes = [r["probe"] for r in records if r["type"] == "probe" and r["generation"] == reset["generation"]]
+    assert probes, "No probes recorded after reset"
+    result = subprocess.run([binary, "--mtr-replay", path, "--json"],
+                            capture_output=True, text=True, timeout=10, check=True)
+    summary = json.loads(result.stdout)
+    assert summary["complete"] is True, summary
+    assert summary["generation"] == reset["generation"], summary
+    assert len(summary["stats"]) == 1, summary
+    stat = summary["stats"][0]
+    successful = [p["rtt_ns"] / 1000000 for p in probes if p["success"]]
+    assert stat["snt"] == len(probes), summary
+    assert stat["received"] == len(successful), summary
+    assert stat["ip"] == "127.0.0.1", summary
+    if successful:
+        expected = {"last_ms": successful[-1], "avg_ms": sum(successful) / len(successful),
+                    "best_ms": min(successful), "wrst_ms": max(successful)}
+        for key, value in expected.items():
+            assert math.isclose(stat[key], value, rel_tol=1e-12, abs_tol=1e-9), (key, stat[key], value)
+    return records[-1]["elapsed_ns"]
+
+
+def main(binary):
+    binary = os.path.abspath(binary)
+    log = bytearray()
+    help_result = subprocess.run([binary, "--help"], capture_output=True,
+                                 text=True, timeout=5, check=True)
+    # ntr selects MTR by default and deliberately omits the mode flag.
+    explicit_mtr = bool(re.search(r"^\s+-t\s+--mtr\s", help_result.stdout, re.M))
+    mode = ["--mtr"] if explicit_mtr else []
+    try:
+        with tempfile.TemporaryDirectory(prefix="mtr-session-pty-") as directory:
+            path = os.path.join(directory, "loopback.ndjson")
+            online = Terminal([binary] + mode + [
+                "--mtr-record", path,
+                "--mtr-columns", "loss,snt,received,avg", "-d", "disable-geoip", "-n",
+                "-s", "127.0.0.1", "-m", "1", "-i", "100", "--timeout", "100",
+                "--no-color", "127.0.0.1",
+            ], log)
+            try:
+                online.expect("Rcv", "127.0.0.1")
+                online.read(1.2)
+                online.send("p")
+                online.expect("Paused")
+                online.read(0.4)  # Let probes already in flight finish.
+                online.send(" ")
+                online.expect("127.0.0.1")
+                online.read(0.4)
+                online.send("r")
+                online.read(0.5)
+                online.expect("127.0.0.1")
+                online.quit()
+            finally:
+                online.close()
+            duration = verify_recording(binary, path)
+            assert duration >= 1000000000, "Recording too short to seek"
+            offline = Terminal([binary, "--mtr-replay", path, "--no-color"], log)
+            try:
+                offline.expect("Replay", "Paused " + replay_time(duration), "Rcv")
+                offline.send("J")
+                offline.expect("Go to HH:MM:SS[.mmm]", "Time:")
+                offline.send("\x1500:00:01.000\r")
+                offline.expect("Paused 00:00:01.000/", "127.0.0.1")
+                offline.send("d")
+                offline.expect("History")
+                offline.send("o")
+                offline.expect("Columns:")
+                offline.send("\x15la\r")
+                offline.expect("Loss%", "Avg", "Paused")
+                offline.send(" ")
+                offline.expect("Playing")
+                offline.send("p")
+                offline.expect("Paused")
+                offline.send("r")
+                offline.expect("Paused 00:00:00.000/")
+                offline.send(" ")
+                offline.expect("Playing")
+                offline.expect("Paused " + replay_time(duration) + "/", timeout=duration / 1000000000 + 5)
+                offline.quit()
+            finally:
+                offline.close()
+        print(json.dumps({
+            "platform": platform.system(), "binary": os.path.basename(binary), "session_pty": "PASS",
+            "checks": ["loopback recording", "pause/resume", "reset generation", "ordered file",
+                       "offline count/RTT parity", "final snapshot", "time seek", "history", "column editor",
+                       "play/pause", "rewind", "EOF pause", "terminal restore"],
+        }, indent=2))
+    finally:
+        with open(os.path.join(tempfile.gettempdir(), "mtr-session-pty.log"), "wb") as output:
+            output.write(log)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/trace/mtr_raw.go
+++ b/trace/mtr_raw.go
@@ -36,6 +36,8 @@ type MTRRawOptions struct {
 	RunRound func(method Method, cfg Config) (*Result, error)
 	// OnPathEnd is called when the semantic path edge changes. nil reopens it.
 	OnPathEnd func(*StopReason)
+	// OnEvent records applied per-hop session changes. An error stops probing.
+	OnEvent func(MTRSessionEvent) error
 }
 
 // MTRRawRecord is one stream record emitted by MTR raw mode.
@@ -71,6 +73,9 @@ var mtrRawTracerouteFn = Traceroute
 func RunMTRRaw(ctx context.Context, method Method, cfg Config, opts MTRRawOptions, onRecord MTRRawOnRecord) error {
 	if opts.HopInterval > 0 {
 		return runMTRRawPerHop(ctx, method, cfg, opts, onRecord)
+	}
+	if opts.OnEvent != nil {
+		return fmt.Errorf("mtr raw: session recording requires per-hop scheduling")
 	}
 	return runMTRRawRoundBased(ctx, method, cfg, opts, onRecord)
 }
@@ -125,6 +130,7 @@ func runMTRRawPerHop(ctx context.Context, method Method, cfg Config, opts MTRRaw
 		FillGeo:          true,
 		BaseConfig:       roundCfg,
 		OnPathEnd:        opts.OnPathEnd,
+		OnEvent:          opts.OnEvent,
 		StartErrorPrefix: "mtr raw",
 	}, nil, func(result mtrProbeResult, iteration int, _ time.Time) {
 		if onRecord == nil {

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -49,6 +49,8 @@ type MTROptions struct {
 	// OnPathEnd is called whenever the semantic path edge changes. A nil value
 	// means that a provisional unreachable edge was reopened or reset.
 	OnPathEnd func(*StopReason)
+	// OnEvent records applied per-hop session changes. An error stops probing.
+	OnEvent func(MTRSessionEvent) error
 }
 
 // MTROnSnapshot 每轮完成后的回调，用于刷新 CLI 表格。
@@ -107,6 +109,9 @@ func RunMTR(ctx context.Context, method Method, baseConfig Config, opts MTROptio
 	if opts.HopInterval > 0 {
 		return runMTRPerHop(ctx, method, baseConfig, opts, onSnapshot)
 	}
+	if opts.OnEvent != nil {
+		return fmt.Errorf("mtr: session recording requires per-hop scheduling")
+	}
 	return runMTRRoundBased(ctx, method, baseConfig, opts, onSnapshot)
 }
 
@@ -164,6 +169,7 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		IsPaused:         opts.IsPaused,
 		IsResetRequested: opts.IsResetRequested,
 		OnPathEnd:        opts.OnPathEnd,
+		OnEvent:          opts.OnEvent,
 		StartErrorPrefix: "mtr",
 	}, onSnapshot, mtrProbeCallbackFromOptions(opts))
 }

--- a/trace/mtr_scheduler.go
+++ b/trace/mtr_scheduler.go
@@ -50,6 +50,7 @@ type mtrSchedulerConfig struct {
 	AsyncMetadata     bool
 	BaseConfig        Config // used for geo/RDNS lookup
 	OnPathEnd         func(*StopReason)
+	OnEvent           func(MTRSessionEvent) error
 	StartErrorPrefix  string
 
 	IsPaused         func() bool

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -68,6 +68,9 @@ type mtrSchedulerRuntime struct {
 	metadataGeoRetryAt   map[string]time.Time
 	metadataHostRetryAt  map[string]time.Time
 	lastSnapshot         time.Time
+	sessionPaused        bool
+	sessionPathChanged   bool
+	sessionPathEnd       *StopReason
 }
 
 type mtrMetadataResult struct {
@@ -179,7 +182,15 @@ func newMTRSchedulerRuntimeWithSession(
 		metadataHostRetryAt:  make(map[string]time.Time),
 	}
 	rt.knownFinalTTL.Store(-1)
-	rt.pathTracker = newMTRPathTracker(cfg.MaxPerHop > 0, maxHops, cfg.OnPathEnd)
+	rt.pathTracker = newMTRPathTracker(cfg.MaxPerHop > 0, maxHops, func(reason *StopReason) {
+		if cfg.OnEvent != nil {
+			rt.sessionPathChanged = true
+			rt.sessionPathEnd = cloneStopReason(reason)
+		}
+		if cfg.OnPathEnd != nil {
+			cfg.OnPathEnd(reason)
+		}
+	})
 	return rt, nil
 }
 
@@ -190,6 +201,9 @@ func (rt *mtrSchedulerRuntime) run() error {
 	defer tick.Stop()
 
 	for {
+		if rt.ctx.Err() != nil {
+			return rt.handleCancel()
+		}
 		select {
 		case <-rt.ctx.Done():
 			return rt.handleCancel()
@@ -200,21 +214,24 @@ func (rt *mtrSchedulerRuntime) run() error {
 			}
 			if rt.isDone() {
 				rt.finishRun()
-				return nil
+				return context.Cause(rt.ctx)
 			}
 			rt.scheduleReady()
 		case mr := <-rt.metadataCh:
 			rt.processMetadataResult(mr)
+			if rt.ctx.Err() != nil {
+				return rt.handleCancel()
+			}
 			if rt.isDone() {
 				rt.finishRun()
-				return nil
+				return context.Cause(rt.ctx)
 			}
 		case <-tick.C:
 			rt.handleReset()
 			rt.scheduleReady()
 			if rt.isDone() {
 				rt.finishRun()
-				return nil
+				return context.Cause(rt.ctx)
 			}
 		}
 	}
@@ -336,7 +353,11 @@ func (rt *mtrSchedulerRuntime) processProbeError(ttl int, err error, doneAt time
 }
 
 func (rt *mtrSchedulerRuntime) recordSyntheticTimeout(ttl int, doneAt time.Time) {
-	rt.agg.Update(rt.timeoutProbeResult(ttl), 1)
+	res := rt.timeoutProbeResult(ttl)
+	rt.agg.Update(res, 1)
+	if !rt.emitSessionProbe(res.Hops[ttl-1][0], nil, doneAt) {
+		return
+	}
 	if rt.onProbe != nil {
 		rt.onProbe(mtrProbeResult{TTL: ttl}, rt.computeIteration(), doneAt)
 	}
@@ -392,6 +413,12 @@ func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResul
 	}
 
 	rt.agg.Update(singleRes, 1)
+	if !rt.emitSessionProbe(singleRes.Hops[ttl-1][0], result.Response, doneAt) {
+		return
+	}
+	if !rt.flushSessionPath() {
+		return
+	}
 	if rt.onProbe != nil {
 		rt.onProbe(result, rt.computeIteration(), doneAt)
 	}
@@ -581,6 +608,9 @@ func (rt *mtrSchedulerRuntime) processMetadataResult(result mtrMetadataResult) {
 	if !rt.agg.PatchMetadataByIP(ip, result.patch.host, result.patch.geo) {
 		return
 	}
+	if !rt.emitSessionMetadata(ip, result.patch) {
+		return
+	}
 	rt.maybeSnapshot(false)
 }
 
@@ -767,7 +797,21 @@ func (rt *mtrSchedulerRuntime) singleProbeResult(ttl int, result mtrProbeResult)
 }
 
 func (rt *mtrSchedulerRuntime) scheduleReady() {
-	if rt.cfg.IsPaused != nil && rt.cfg.IsPaused() {
+	if rt.ctx.Err() != nil {
+		return
+	}
+	paused := rt.cfg.IsPaused != nil && rt.cfg.IsPaused()
+	if paused != rt.sessionPaused {
+		rt.sessionPaused = paused
+		eventType := MTRSessionResumeEvent
+		if paused {
+			eventType = MTRSessionPauseEvent
+		}
+		if !rt.emitSessionEvent(MTRSessionEvent{Type: eventType}) {
+			return
+		}
+	}
+	if paused {
 		return
 	}
 
@@ -820,6 +864,7 @@ func (rt *mtrSchedulerRuntime) isDone() bool {
 
 func (rt *mtrSchedulerRuntime) finishRun() {
 	rt.pathTracker.completeAtMaxHops()
+	rt.flushSessionPath()
 	rt.maybeSnapshot(true)
 }
 
@@ -848,6 +893,9 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	rt.agg.Reset()
 	_ = rt.prober.Reset()
 	rt.generationCtx, rt.generationCancel = context.WithCancel(rt.ctx)
+	if rt.emitSessionEvent(MTRSessionEvent{Type: MTRSessionResetEvent}) {
+		rt.flushSessionPath()
+	}
 }
 
 func (rt *mtrSchedulerRuntime) handleCancel() error {

--- a/trace/mtr_session_events.go
+++ b/trace/mtr_session_events.go
@@ -1,0 +1,175 @@
+package trace
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+const (
+	MTRSessionProbeEvent    = "probe"
+	MTRSessionMetadataEvent = "metadata"
+	MTRSessionPauseEvent    = "pause"
+	MTRSessionResumeEvent   = "resume"
+	MTRSessionResetEvent    = "reset"
+	MTRSessionPathEndEvent  = "path_end"
+)
+
+// MTRSessionEvent describes an applied change to a per-hop MTR session.
+// OnEvent observers run serially in scheduler order. At is the application time;
+// a probe's CompletedAt may precede At and is not an event ordering key.
+// File formats supply their own version, sequence and relative time envelope.
+type MTRSessionEvent struct {
+	Type       string              `json:"type"`
+	Generation uint64              `json:"generation"`
+	At         time.Time           `json:"-"`
+	Iteration  int                 `json:"iteration,omitempty"`
+	Probe      *MTRSessionProbe    `json:"probe,omitempty"`
+	Metadata   *MTRSessionMetadata `json:"metadata,omitempty"`
+	PathEnd    *StopReason         `json:"path_end"`
+}
+
+// MTRSessionProbe contains exactly the hop passed to MTRAggregator.Update.
+// RTT is serialized as integer nanoseconds to preserve the original arithmetic.
+type MTRSessionProbe struct {
+	TTL         int               `json:"ttl"`
+	IP          string            `json:"ip,omitempty"`
+	Host        string            `json:"host,omitempty"`
+	Success     bool              `json:"success"`
+	RTT         time.Duration     `json:"rtt_ns"`
+	CompletedAt time.Time         `json:"completed_at"`
+	Geo         *ipgeo.IPGeoData  `json:"geo,omitempty"`
+	MPLS        []string          `json:"mpls,omitempty"`
+	Response    *MTRProbeResponse `json:"response,omitempty"`
+}
+
+// MTRSessionMetadata patches all existing rows for an address without counting
+// another probe. Empty fields retain their existing values.
+type MTRSessionMetadata struct {
+	IP   string           `json:"ip"`
+	Host string           `json:"host,omitempty"`
+	Geo  *ipgeo.IPGeoData `json:"geo,omitempty"`
+}
+
+// MTRReplayState rebuilds statistics without creating probes or looking up
+// metadata. Apply must be called in recorded sequence order, not timestamp order.
+type MTRReplayState struct {
+	agg        *MTRAggregator
+	tracker    *mtrPathTracker
+	maxHops    int
+	generation uint64
+	iteration  int
+	paused     bool
+}
+
+func NewMTRReplayState(bounded bool, maxHops int) *MTRReplayState {
+	if maxHops <= 0 {
+		maxHops = 30
+	}
+	maxHops = min(maxHops, maxMTRHopCount)
+	return &MTRReplayState{
+		agg:     NewMTRAggregator(),
+		tracker: newMTRPathTracker(bounded, maxHops, nil),
+		maxHops: maxHops,
+	}
+}
+
+func (s *MTRReplayState) Apply(event MTRSessionEvent) error {
+	if event.Type == MTRSessionResetEvent {
+		if event.Generation != s.generation+1 {
+			return fmt.Errorf("mtr replay: invalid reset generation %d", event.Generation)
+		}
+		s.generation = event.Generation
+		s.agg.Reset()
+		s.tracker.reset()
+		s.iteration = 0
+		return nil
+	}
+	if event.Generation != s.generation {
+		return fmt.Errorf("mtr replay: event generation %d does not match %d", event.Generation, s.generation)
+	}
+	switch event.Type {
+	case MTRSessionProbeEvent:
+		return s.applyProbe(event)
+	case MTRSessionMetadataEvent:
+		if event.Metadata == nil || net.ParseIP(event.Metadata.IP) == nil {
+			return fmt.Errorf("mtr replay: invalid metadata address")
+		}
+		patch := event.Metadata
+		s.agg.PatchMetadataByIP(patch.IP, patch.Host, patch.Geo)
+	case MTRSessionPauseEvent:
+		s.paused = true
+	case MTRSessionResumeEvent:
+		s.paused = false
+	case MTRSessionPathEndEvent:
+		if reason := event.PathEnd; reason != nil {
+			if reason.Hop <= 0 || reason.Hop > s.maxHops {
+				return fmt.Errorf("mtr replay: invalid path end hop %d", reason.Hop)
+			}
+			switch reason.Reason {
+			case StopReasonDestination, StopReasonUnreachable, StopReasonMaxHops:
+			default:
+				return fmt.Errorf("mtr replay: invalid path end reason %q", reason.Reason)
+			}
+			if reason.Reason == StopReasonDestination {
+				s.agg.ClearAbove(reason.Hop)
+			}
+		}
+		s.tracker.current = cloneStopReason(event.PathEnd)
+	default:
+		return fmt.Errorf("mtr replay: unsupported event type %q", event.Type)
+	}
+	return nil
+}
+
+func (s *MTRReplayState) applyProbe(event MTRSessionEvent) error {
+	probe := event.Probe
+	if probe == nil || probe.TTL <= 0 || probe.TTL > s.maxHops {
+		return fmt.Errorf("mtr replay: invalid probe TTL")
+	}
+	if probe.RTT < 0 || event.Iteration < 0 {
+		return fmt.Errorf("mtr replay: invalid probe timing or iteration")
+	}
+	var addr net.Addr
+	if probe.IP != "" {
+		ip := net.ParseIP(probe.IP)
+		if ip == nil {
+			return fmt.Errorf("mtr replay: invalid probe address %q", probe.IP)
+		}
+		addr = &net.IPAddr{IP: ip}
+	}
+	if probe.Success && addr == nil {
+		return fmt.Errorf("mtr replay: successful probe has no address")
+	}
+	response := mtrProbeResponseWithPeer(probe.Response, addr)
+	if s.tracker.observe(probe.TTL, response) {
+		if reason := s.tracker.pathEnd(); reason != nil && reason.Reason == StopReasonDestination {
+			s.agg.ClearAbove(reason.Hop)
+		}
+	}
+	hops := make([][]Hop, probe.TTL)
+	hops[probe.TTL-1] = []Hop{{
+		TTL: probe.TTL, Address: addr, Hostname: probe.Host,
+		Success: probe.Success, RTT: probe.RTT, Geo: probe.Geo, MPLS: probe.MPLS,
+	}}
+	s.agg.Update(&Result{Hops: hops}, 1)
+	s.iteration = event.Iteration
+	return nil
+}
+
+func (s *MTRReplayState) Snapshot() MTRSnapshot {
+	stats := s.agg.Snapshot()
+	if pathEnd := s.tracker.pathEnd(); pathEnd != nil {
+		stats = filterMTRStatsAtPathEnd(stats, pathEnd.Hop)
+	}
+	for i := range stats {
+		stats[i].Response = mtrProbeResponseForStat(s.tracker, stats[i])
+	}
+	return MTRSnapshot{Iteration: s.iteration, Stats: stats}
+}
+
+func (s *MTRReplayState) PathEnd() *StopReason { return s.tracker.pathEnd() }
+func (s *MTRReplayState) Paused() bool         { return s.paused }
+func (s *MTRReplayState) Generation() uint64   { return s.generation }

--- a/trace/mtr_session_events.go
+++ b/trace/mtr_session_events.go
@@ -146,6 +146,13 @@ func (s *MTRReplayState) applyProbe(event MTRSessionEvent) error {
 	if probe.Response != nil && !probe.Success {
 		return fmt.Errorf("mtr replay: failed probe cannot carry a response")
 	}
+	if response := probe.Response; response != nil {
+		switch response.Kind {
+		case MTRResponseTransit, MTRResponseDestination, MTRResponseUnreachable:
+		default:
+			return fmt.Errorf("mtr replay: invalid response kind %q", response.Kind)
+		}
+	}
 	response := mtrProbeResponseWithPeer(probe.Response, addr)
 	if s.tracker.observe(probe.TTL, response) {
 		if reason := s.tracker.pathEnd(); reason != nil && reason.Reason == StopReasonDestination {

--- a/trace/mtr_session_events.go
+++ b/trace/mtr_session_events.go
@@ -143,6 +143,9 @@ func (s *MTRReplayState) applyProbe(event MTRSessionEvent) error {
 	if probe.Success && addr == nil {
 		return fmt.Errorf("mtr replay: successful probe has no address")
 	}
+	if probe.Response != nil && !probe.Success {
+		return fmt.Errorf("mtr replay: failed probe cannot carry a response")
+	}
 	response := mtrProbeResponseWithPeer(probe.Response, addr)
 	if s.tracker.observe(probe.TTL, response) {
 		if reason := s.tracker.pathEnd(); reason != nil && reason.Reason == StopReasonDestination {

--- a/trace/mtr_session_events.go
+++ b/trace/mtr_session_events.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
@@ -104,23 +105,26 @@ func (s *MTRReplayState) Apply(event MTRSessionEvent) error {
 	case MTRSessionResumeEvent:
 		s.paused = false
 	case MTRSessionPathEndEvent:
-		if reason := event.PathEnd; reason != nil {
-			if reason.Hop <= 0 || reason.Hop > s.maxHops {
-				return fmt.Errorf("mtr replay: invalid path end hop %d", reason.Hop)
-			}
-			switch reason.Reason {
-			case StopReasonDestination, StopReasonUnreachable, StopReasonMaxHops:
-			default:
-				return fmt.Errorf("mtr replay: invalid path end reason %q", reason.Reason)
-			}
-			if reason.Reason == StopReasonDestination {
-				s.agg.ClearAbove(reason.Hop)
-			}
-		}
-		s.tracker.current = cloneStopReason(event.PathEnd)
+		return s.applyPathEnd(event.PathEnd)
 	default:
 		return fmt.Errorf("mtr replay: unsupported event type %q", event.Type)
 	}
+	return nil
+}
+
+func (s *MTRReplayState) applyPathEnd(reason *StopReason) error {
+	expected := s.tracker.pathEnd()
+	if expected == nil && s.tracker.bounded && reason != nil && reason.Reason == StopReasonMaxHops {
+		// Bounded completion is the only conclusion without response evidence.
+		expected = &StopReason{Hop: s.maxHops, Reason: StopReasonMaxHops}
+	}
+	if !reflect.DeepEqual(expected, cloneStopReason(reason)) {
+		return fmt.Errorf("mtr replay: path end does not match probe evidence")
+	}
+	if reason != nil && reason.Reason == StopReasonDestination {
+		s.agg.ClearAbove(reason.Hop)
+	}
+	s.tracker.current = cloneStopReason(reason)
 	return nil
 }
 

--- a/trace/mtr_session_events.go
+++ b/trace/mtr_session_events.go
@@ -99,7 +99,9 @@ func (s *MTRReplayState) Apply(event MTRSessionEvent) error {
 			return fmt.Errorf("mtr replay: invalid metadata address")
 		}
 		patch := event.Metadata
-		s.agg.PatchMetadataByIP(patch.IP, patch.Host, patch.Geo)
+		if !s.agg.PatchMetadataByIP(patch.IP, patch.Host, patch.Geo) {
+			return fmt.Errorf("mtr replay: metadata does not update an existing responder")
+		}
 	case MTRSessionPauseEvent:
 		s.paused = true
 	case MTRSessionResumeEvent:
@@ -115,8 +117,13 @@ func (s *MTRReplayState) Apply(event MTRSessionEvent) error {
 func (s *MTRReplayState) applyPathEnd(reason *StopReason) error {
 	expected := s.tracker.pathEnd()
 	if expected == nil && s.tracker.bounded && reason != nil && reason.Reason == StopReasonMaxHops {
-		// Bounded completion is the only conclusion without response evidence.
-		expected = &StopReason{Hop: s.maxHops, Reason: StopReasonMaxHops}
+		// Max-hops needs an accepted probe at that TTL, but no reply is required.
+		for _, stat := range s.agg.Snapshot() {
+			if stat.TTL == s.maxHops && stat.Snt > 0 {
+				expected = &StopReason{Hop: s.maxHops, Reason: StopReasonMaxHops}
+				break
+			}
+		}
 	}
 	if !reflect.DeepEqual(expected, cloneStopReason(reason)) {
 		return fmt.Errorf("mtr replay: path end does not match probe evidence")

--- a/trace/mtr_session_events_test.go
+++ b/trace/mtr_session_events_test.go
@@ -1,0 +1,385 @@
+package trace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+func TestMTRSessionReplayMatchesScheduler(t *testing.T) {
+	state := NewMTRReplayState(false, 5)
+	var events []MTRSessionEvent
+	resetRequested := false
+	rt, err := newMTRSchedulerRuntime(t.Context(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 5, ParallelRequests: 1,
+		IsResetRequested: func() bool { v := resetRequested; resetRequested = false; return v },
+		OnEvent: func(event MTRSessionEvent) error {
+			if event.At.IsZero() {
+				t.Error("session event has no application timestamp")
+			}
+			// Exercise the actual serialized representation, including private
+			// response peer attribution and integer RTT round trips.
+			encoded, err := json.Marshal(event)
+			if err != nil {
+				return err
+			}
+			var decoded MTRSessionEvent
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				return err
+			}
+			events = append(events, decoded)
+			return state.Apply(decoded)
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.workers.shutdown(nil)
+	compare := func() {
+		t.Helper()
+		got := state.Snapshot()
+		if want := rt.snapshotStats(); !reflect.DeepEqual(got.Stats, want) {
+			t.Fatalf("replay stats differ:\n got %#v\nwant %#v", got.Stats, want)
+		}
+		if got.Iteration != rt.computeIteration() || !reflect.DeepEqual(state.PathEnd(), rt.pathTracker.pathEnd()) {
+			t.Fatalf("replay boundary/iteration differ: got %+v, %v", got, state.PathEnd())
+		}
+	}
+	probe := func(ttl int, ip string, rtt time.Duration, kind string) {
+		t.Helper()
+		result := mtrProbeResult{TTL: ttl, RTT: rtt}
+		if ip != "" {
+			result.Success = true
+			result.Addr = &net.IPAddr{IP: net.ParseIP(ip)}
+			result.MPLS = []string{"label 20", "label 10"}
+			result.Response = &MTRProbeResponse{Kind: kind, Description: kind}
+		}
+		rt.processProbeSuccess(ttl, result, time.Now().Add(-time.Second))
+		if err := context.Cause(rt.ctx); err != nil {
+			t.Fatal(err)
+		}
+		compare()
+	}
+	probe(5, "2001:db8::5", time.Nanosecond, MTRResponseTransit)
+	probe(2, "", 0, "")
+	probe(2, "192.0.2.2", 0, MTRResponseTransit)
+	probe(2, "192.0.2.2", 13234567*time.Nanosecond, MTRResponseTransit)
+	probe(2, "192.0.2.20", 2*time.Millisecond, MTRResponseTransit)
+	probe(2, "", 0, "")
+	rt.processMetadataResult(mtrMetadataResult{gen: 0, kind: mtrMetadataKindGeo, patch: mtrMetadataPatch{
+		ip: "192.0.2.2", geo: &ipgeo.IPGeoData{Country: "中国", CountryEn: "China", City: "北京", CityEn: "Beijing", Router: map[string][]string{"64500": {"route"}}},
+	}})
+	rt.processMetadataResult(mtrMetadataResult{gen: 0, kind: mtrMetadataKindHost, patch: mtrMetadataPatch{ip: "192.0.2.2", host: "router.example"}})
+	compare()
+	probe(2, "192.0.2.20", 3*time.Millisecond, MTRResponseUnreachable)
+	if len(state.Snapshot().Stats) != 3 {
+		t.Fatalf("unreachable should hide high TTL: %+v", state.Snapshot())
+	}
+	probe(2, "192.0.2.20", 4*time.Millisecond, MTRResponseTransit)
+	if len(state.Snapshot().Stats) != 4 {
+		t.Fatalf("reopen should retain high TTL: %+v", state.Snapshot())
+	}
+	probe(3, "192.0.2.3", 5*time.Millisecond, MTRResponseDestination)
+	if len(state.agg.Snapshot()) != 4 {
+		t.Fatal("destination did not clear TTL 5")
+	}
+	probe(1, "192.0.2.1", 6*time.Millisecond, MTRResponseDestination)
+	if len(state.agg.Snapshot()) != 1 {
+		t.Fatal("lower destination retained old rows")
+	}
+	resetRequested = true
+	rt.handleReset()
+	compare()
+	before := len(events)
+	rt.inFlight = 1
+	rt.processResult(mtrCompletedProbe{ttl: 1, gen: 0, result: mtrProbeResult{TTL: 1}})
+	rt.processMetadataResult(mtrMetadataResult{gen: 0, kind: mtrMetadataKindHost, patch: mtrMetadataPatch{ip: "192.0.2.1", host: "stale.example"}})
+	if len(events) != before {
+		t.Fatal("old generation produced session events")
+	}
+	probe(1, "2001:db8::1", 7*time.Millisecond, MTRResponseTransit)
+	if state.Generation() != 1 || state.Snapshot().Stats[0].Snt != 1 {
+		t.Fatal("reset did not begin fresh statistics")
+	}
+}
+
+func TestMTRSessionSyncMetadataUsesAccountedHop(t *testing.T) {
+	ClearCaches()
+	defer ClearCaches()
+	var recorded MTRSessionEvent
+	var legacy mtrProbeResult
+	rt, err := newMTRSchedulerRuntime(t.Context(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 1, FillGeo: true,
+		BaseConfig: Config{Lang: "cn", IPGeoSource: func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			return &ipgeo.IPGeoData{Asnumber: "64500", Country: "中国", CountryEn: "China"}, nil
+		}},
+		OnEvent: func(event MTRSessionEvent) error { recorded = event; return nil },
+	}, nil, func(result mtrProbeResult, _ int, _ time.Time) { legacy = result })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.workers.shutdown(nil)
+	completed := time.Now().Add(-time.Second)
+	rt.processProbeSuccess(1, mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("9.9.9.245")}, RTT: time.Nanosecond}, completed)
+	if recorded.Probe == nil || recorded.Probe.Geo == nil || recorded.Probe.Geo.CountryEn != "China" {
+		t.Fatalf("record lost synchronous metadata: %+v", recorded)
+	}
+	if !recorded.Probe.CompletedAt.Equal(completed) || !recorded.At.After(completed) {
+		t.Fatal("completion/application timestamps conflated")
+	}
+	if legacy.Geo != nil {
+		t.Fatal("existing OnProbe payload changed")
+	}
+	state := NewMTRReplayState(false, 1)
+	if err := state.Apply(recorded); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(state.Snapshot().Stats, rt.snapshotStats()) {
+		t.Fatal("recorded synchronous metadata differs from live statistics")
+	}
+}
+
+func TestMTRSessionSyntheticTimeoutAndCausalPathOrder(t *testing.T) {
+	var events []MTRSessionEvent
+	var legacyOrder []string
+	rt, err := newMTRSchedulerRuntime(t.Context(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 2, MaxConsecErrors: 2,
+		OnEvent:   func(event MTRSessionEvent) error { events = append(events, event); return nil },
+		OnPathEnd: func(*StopReason) { legacyOrder = append(legacyOrder, "path_end") },
+	}, nil, func(mtrProbeResult, int, time.Time) { legacyOrder = append(legacyOrder, "probe") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.workers.shutdown(nil)
+	completed := time.Now()
+	rt.processProbeError(1, errors.New("temporary failure"), completed)
+	if len(events) != 0 {
+		t.Fatal("uncounted retry recorded as probe")
+	}
+	rt.processProbeError(1, errors.New("temporary failure"), completed)
+	if len(events) != 1 || events[0].Type != MTRSessionProbeEvent || events[0].Probe.Success || !events[0].Probe.CompletedAt.Equal(completed) {
+		t.Fatalf("missing counted synthetic timeout: %+v", events)
+	}
+	legacyOrder = nil
+	rt.processProbeSuccess(2, mtrProbeResult{TTL: 2, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("192.0.2.2")}, Response: &MTRProbeResponse{Kind: MTRResponseDestination}}, completed)
+	if len(events) != 3 || events[1].Type != MTRSessionProbeEvent || events[2].Type != MTRSessionPathEndEvent {
+		t.Fatalf("wrong causal order: %+v", events)
+	}
+	if !reflect.DeepEqual(legacyOrder, []string{"path_end", "probe"}) {
+		t.Fatalf("legacy callbacks reordered: %v", legacyOrder)
+	}
+	// A tail cut after the cause probe must still rebuild the live boundary.
+	state := NewMTRReplayState(false, 2)
+	for _, event := range events[:2] {
+		if err := state.Apply(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !reflect.DeepEqual(state.Snapshot().Stats, rt.snapshotStats()) || !reflect.DeepEqual(state.PathEnd(), rt.pathTracker.pathEnd()) {
+		t.Fatal("prefix ending at cause probe lost path semantics")
+	}
+}
+
+func TestMTRSessionObserverFailureStopsWorkers(t *testing.T) {
+	for _, eventType := range []string{MTRSessionProbeEvent, MTRSessionPathEndEvent, MTRSessionMetadataEvent, MTRSessionPauseEvent, MTRSessionResetEvent} {
+		t.Run(eventType, func(t *testing.T) {
+			ClearCaches()
+			defer ClearCaches()
+			sentinel := errors.New("recording write failed")
+			var calls atomic.Int32
+			prober := &mockTTLProber{probeFn: func(ctx context.Context, ttl int) (mtrProbeResult, error) {
+				calls.Add(1)
+				if eventType == MTRSessionResetEvent {
+					<-ctx.Done()
+					return mtrProbeResult{}, ctx.Err()
+				}
+				return mtrProbeResult{TTL: ttl, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("9.9.9.244")}}, nil
+			}}
+			cfg := mtrSchedulerConfig{
+				BeginHop: 1, MaxHops: 1, MaxPerHop: 1, ParallelRequests: 1, HopInterval: time.Millisecond,
+				OnEvent: func(event MTRSessionEvent) error {
+					if event.Type == eventType {
+						return sentinel
+					}
+					return nil
+				},
+				IsPaused:         func() bool { return eventType == MTRSessionPauseEvent },
+				IsResetRequested: func() bool { return eventType == MTRSessionResetEvent },
+			}
+			if eventType == MTRSessionMetadataEvent {
+				cfg.FillGeo, cfg.AsyncMetadata = true, true
+				cfg.BaseConfig.IPGeoSource = func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+					return &ipgeo.IPGeoData{Asnumber: "64500"}, nil
+				}
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			err := runMTRScheduler(ctx, prober, NewMTRAggregator(), cfg, nil, nil)
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("error = %v, want write failure", err)
+			}
+			if atomic.LoadInt32(&prober.closeCnt) != 1 {
+				t.Fatal("prober was not closed exactly once")
+			}
+			want := int32(1)
+			if eventType == MTRSessionPauseEvent {
+				want = 0
+			}
+			if calls.Load() != want {
+				t.Fatalf("launched %d probes, want %d", calls.Load(), want)
+			}
+		})
+	}
+}
+
+func TestMTRReplayRejectsInvalidEvents(t *testing.T) {
+	tests := []MTRSessionEvent{
+		{Type: "future_event"},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 256}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, Success: true}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "not-an-ip"}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, RTT: -1}},
+		{Type: MTRSessionProbeEvent, Generation: 1, Probe: &MTRSessionProbe{TTL: 1}},
+		{Type: MTRSessionResetEvent, Generation: 2},
+		{Type: MTRSessionMetadataEvent},
+		{Type: MTRSessionPathEndEvent, PathEnd: &StopReason{Hop: 256, Reason: StopReasonDestination}},
+		{Type: MTRSessionPathEndEvent, PathEnd: &StopReason{Hop: 1, Reason: "unknown"}},
+	}
+	for _, event := range tests {
+		state := NewMTRReplayState(false, 30)
+		if err := state.Apply(event); err == nil {
+			t.Errorf("accepted invalid event: %+v", event)
+		}
+		if len(state.Snapshot().Stats) != 0 || state.Generation() != 0 {
+			t.Errorf("invalid event changed state: %+v", event)
+		}
+	}
+}
+
+func TestMTRSessionBoundedReplayNaturalCompletion(t *testing.T) {
+	state := NewMTRReplayState(true, 3)
+	var lastEvent MTRSessionEvent
+	var final MTRSnapshot
+	prober := &mockTTLProber{probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+		return mtrProbeResult{
+			TTL: ttl, Success: true, Addr: &net.IPAddr{IP: net.IPv4(192, 0, 2, byte(ttl))},
+			RTT:      time.Duration(ttl) * 1234567,
+			Response: &MTRProbeResponse{Kind: MTRResponseTransit, Description: "transit"},
+		}, nil
+	}}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	err := runMTRScheduler(ctx, prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 3, MaxPerHop: 3, ParallelRequests: 1, HopInterval: time.Millisecond,
+		OnEvent: func(event MTRSessionEvent) error { lastEvent = event; return state.Apply(event) },
+	}, func(iteration int, stats []MTRHopStat) { final = MTRSnapshot{Iteration: iteration, Stats: stats} }, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := state.Snapshot(); !reflect.DeepEqual(got, final) {
+		t.Fatalf("bounded replay = %+v, live = %+v", got, final)
+	}
+	if lastEvent.Type != MTRSessionPathEndEvent || state.PathEnd().Reason != StopReasonMaxHops {
+		t.Fatalf("natural completion did not record max_hops: %+v", lastEvent)
+	}
+}
+
+func TestMTRSessionPauseCountsInFlightAndDiscardsDisabledResults(t *testing.T) {
+	paused := true
+	state := NewMTRReplayState(false, 3)
+	var types []string
+	rt, err := newMTRSchedulerRuntime(t.Context(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 3, ParallelRequests: 1,
+		IsPaused: func() bool { return paused },
+		OnEvent:  func(event MTRSessionEvent) error { types = append(types, event.Type); return state.Apply(event) },
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.workers.shutdown(nil)
+	rt.inFlight = 1
+	rt.scheduleReady()
+	rt.processProbeSuccess(2, mtrProbeResult{
+		TTL: 2, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("192.0.2.2")},
+		Response: &MTRProbeResponse{Kind: MTRResponseDestination},
+	}, time.Now())
+	if !state.Paused() || state.Snapshot().Stats[0].Snt != 1 {
+		t.Fatal("pause discarded an in-flight result")
+	}
+	before := len(types)
+	rt.states[3].inFlightCount = 1
+	rt.processResult(mtrCompletedProbe{ttl: 3, result: mtrProbeResult{TTL: 3}})
+	if len(types) != before {
+		t.Fatal("disabled TTL produced a session event")
+	}
+	rt.inFlight = 1
+	paused = false
+	rt.scheduleReady()
+	if state.Paused() || !reflect.DeepEqual(types, []string{MTRSessionPauseEvent, MTRSessionProbeEvent, MTRSessionPathEndEvent, MTRSessionResumeEvent}) {
+		t.Fatalf("pause/resume sequence = %v", types)
+	}
+}
+
+func TestMTRSessionRecordsAppliedProbeDuringCancellation(t *testing.T) {
+	ClearCaches()
+	defer ClearCaches()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	state := NewMTRReplayState(true, 1)
+	var final MTRSnapshot
+	var events []MTRSessionEvent
+	prober := &mockTTLProber{probeFn: func(context.Context, int) (mtrProbeResult, error) {
+		return mtrProbeResult{
+			TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("9.9.9.243")}, RTT: time.Millisecond,
+			Response: &MTRProbeResponse{Kind: MTRResponseDestination},
+		}, nil
+	}}
+	err := runMTRScheduler(ctx, prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 1, MaxPerHop: 1, ParallelRequests: 1, FillGeo: true,
+		BaseConfig: Config{IPGeoSource: func(string, time.Duration, string, bool) (*ipgeo.IPGeoData, error) {
+			// Ctrl-C can arrive after a probe completed but before synchronous
+			// enrichment returns to the scheduler's accounting code.
+			cancel()
+			return &ipgeo.IPGeoData{Asnumber: "64500"}, nil
+		}},
+		OnEvent: func(event MTRSessionEvent) error { events = append(events, event); return state.Apply(event) },
+	}, func(iteration int, stats []MTRHopStat) { final = MTRSnapshot{Iteration: iteration, Stats: stats} }, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want cancellation", err)
+	}
+	if len(final.Stats) != 1 || final.Stats[0].Snt != 1 {
+		t.Fatalf("expected counted in-flight probe: %+v", final)
+	}
+	if !reflect.DeepEqual(state.Snapshot(), final) {
+		t.Fatalf("cancel lost applied probe: replay=%+v live=%+v events=%+v", state.Snapshot(), final, events)
+	}
+	if len(events) != 2 || events[0].Type != MTRSessionProbeEvent || events[1].Type != MTRSessionPathEndEvent {
+		t.Fatalf("cancel lost causal event order: %+v", events)
+	}
+}
+
+func TestMTRSessionRecordsAppliedMetadataDuringCancellation(t *testing.T) {
+	state := NewMTRReplayState(false, 1)
+	rt, err := newMTRSchedulerRuntime(t.Context(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop: 1, MaxHops: 1,
+		OnEvent: state.Apply,
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.workers.shutdown(nil)
+	rt.processProbeSuccess(1, mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("192.0.2.1")}}, time.Now())
+	// Reproduce cancellation racing with an already selected metadata result.
+	rt.workers.cancel(context.Canceled)
+	rt.processMetadataResult(mtrMetadataResult{gen: 0, kind: mtrMetadataKindHost, patch: mtrMetadataPatch{ip: "192.0.2.1", host: "router.example"}})
+	if !reflect.DeepEqual(state.Snapshot().Stats, rt.snapshotStats()) || state.Snapshot().Stats[0].Host != "router.example" {
+		t.Fatalf("cancel lost applied metadata: replay=%+v live=%+v", state.Snapshot(), rt.snapshotStats())
+	}
+}

--- a/trace/mtr_session_events_test.go
+++ b/trace/mtr_session_events_test.go
@@ -244,6 +244,8 @@ func TestMTRReplayRejectsInvalidEvents(t *testing.T) {
 		{Type: "future_event"},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 256}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, Success: true}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, Response: &MTRProbeResponse{Kind: MTRResponseDestination}}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Response: &MTRProbeResponse{Kind: MTRResponseUnreachable}}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "not-an-ip"}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, RTT: -1}},
 		{Type: MTRSessionProbeEvent, Generation: 1, Probe: &MTRSessionProbe{TTL: 1}},
@@ -257,7 +259,7 @@ func TestMTRReplayRejectsInvalidEvents(t *testing.T) {
 		if err := state.Apply(event); err == nil {
 			t.Errorf("accepted invalid event: %+v", event)
 		}
-		if len(state.Snapshot().Stats) != 0 || state.Generation() != 0 {
+		if len(state.Snapshot().Stats) != 0 || state.Generation() != 0 || state.PathEnd() != nil {
 			t.Errorf("invalid event changed state: %+v", event)
 		}
 	}

--- a/trace/mtr_session_events_test.go
+++ b/trace/mtr_session_events_test.go
@@ -246,6 +246,8 @@ func TestMTRReplayRejectsInvalidEvents(t *testing.T) {
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, Success: true}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, Response: &MTRProbeResponse{Kind: MTRResponseDestination}}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Response: &MTRProbeResponse{Kind: MTRResponseUnreachable}}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Success: true, Response: &MTRProbeResponse{Kind: "unknown"}}},
+		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "192.0.2.1", Success: true, Response: &MTRProbeResponse{}}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, IP: "not-an-ip"}},
 		{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 1, RTT: -1}},
 		{Type: MTRSessionProbeEvent, Generation: 1, Probe: &MTRSessionProbe{TTL: 1}},

--- a/trace/mtr_session_events_test.go
+++ b/trace/mtr_session_events_test.go
@@ -268,6 +268,13 @@ func TestMTRReplayRejectsInvalidEvents(t *testing.T) {
 }
 
 func TestMTRReplayPathEndRequiresProbeEvidence(t *testing.T) {
+	empty := NewMTRReplayState(true, 5)
+	if err := empty.Apply(MTRSessionEvent{Type: MTRSessionPathEndEvent, PathEnd: &StopReason{Hop: 5, Reason: StopReasonMaxHops}}); err == nil {
+		t.Fatal("accepted max-hops without probing the maximum TTL")
+	}
+	if empty.PathEnd() != nil {
+		t.Fatal("invalid max-hops event changed the path")
+	}
 	for _, bounded := range []bool{false, true} {
 		for _, kind := range []string{MTRResponseTransit, MTRResponseDestination, MTRResponseUnreachable} {
 			state := NewMTRReplayState(bounded, 5)
@@ -417,5 +424,49 @@ func TestMTRSessionRecordsAppliedMetadataDuringCancellation(t *testing.T) {
 	rt.processMetadataResult(mtrMetadataResult{gen: 0, kind: mtrMetadataKindHost, patch: mtrMetadataPatch{ip: "192.0.2.1", host: "router.example"}})
 	if !reflect.DeepEqual(state.Snapshot().Stats, rt.snapshotStats()) || state.Snapshot().Stats[0].Host != "router.example" {
 		t.Fatalf("cancel lost applied metadata: replay=%+v live=%+v", state.Snapshot(), rt.snapshotStats())
+	}
+}
+
+func TestMTRReplayRejectsUnappliedMetadata(t *testing.T) {
+	for _, scenario := range []string{"before_probe", "unknown_peer", "after_reset", "already_applied", "empty_patch"} {
+		t.Run(scenario, func(t *testing.T) {
+			state := NewMTRReplayState(false, 3)
+			generation := uint64(0)
+			patch := &MTRSessionMetadata{IP: "192.0.2.1", Host: "router.invalid"}
+			if scenario != "before_probe" {
+				for _, ttl := range []int{1, 2} {
+					if err := state.Apply(MTRSessionEvent{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: ttl, IP: patch.IP, Success: true}}); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			switch scenario {
+			case "unknown_peer":
+				patch.IP = "192.0.2.2"
+			case "after_reset":
+				generation = 1
+				if err := state.Apply(MTRSessionEvent{Type: MTRSessionResetEvent, Generation: generation}); err != nil {
+					t.Fatal(err)
+				}
+			case "already_applied":
+				if err := state.Apply(MTRSessionEvent{Type: MTRSessionMetadataEvent, Metadata: patch}); err != nil {
+					t.Fatal(err)
+				}
+				for _, stat := range state.Snapshot().Stats {
+					if stat.Host != patch.Host || stat.Snt != 1 {
+						t.Fatalf("cross-TTL patch: %+v", stat)
+					}
+				}
+			case "empty_patch":
+				patch.Host = ""
+			}
+			before := state.Snapshot()
+			if err := state.Apply(MTRSessionEvent{Type: MTRSessionMetadataEvent, Generation: generation, Metadata: patch}); err == nil {
+				t.Fatal("accepted unapplied metadata")
+			}
+			if !reflect.DeepEqual(before, state.Snapshot()) {
+				t.Fatal("rejected metadata changed statistics")
+			}
+		})
 	}
 }

--- a/trace/mtr_session_events_test.go
+++ b/trace/mtr_session_events_test.go
@@ -267,6 +267,38 @@ func TestMTRReplayRejectsInvalidEvents(t *testing.T) {
 	}
 }
 
+func TestMTRReplayPathEndRequiresProbeEvidence(t *testing.T) {
+	for _, bounded := range []bool{false, true} {
+		for _, kind := range []string{MTRResponseTransit, MTRResponseDestination, MTRResponseUnreachable} {
+			state := NewMTRReplayState(bounded, 5)
+			probe := MTRSessionEvent{Type: MTRSessionProbeEvent, Probe: &MTRSessionProbe{TTL: 3, IP: "192.0.2.3", Success: true, Response: &MTRProbeResponse{Kind: kind, Description: "test response", Marker: "!H"}}}
+			if err := state.Apply(probe); err != nil {
+				t.Fatal(err)
+			}
+			before, edge := state.Snapshot(), state.PathEnd()
+			for _, fabricated := range []*StopReason{
+				{Hop: 1, Reason: StopReasonDestination}, {Hop: 1, Reason: StopReasonUnreachable},
+				{Hop: 3, Reason: StopReasonDestination, Responses: []string{"fabricated"}},
+			} {
+				if err := state.Apply(MTRSessionEvent{Type: MTRSessionPathEndEvent, PathEnd: fabricated}); err == nil {
+					t.Fatalf("accepted fabricated path bound: kind=%s bounded=%v edge=%+v", kind, bounded, fabricated)
+				}
+				if !reflect.DeepEqual(before, state.Snapshot()) || !reflect.DeepEqual(edge, state.PathEnd()) {
+					t.Fatal("rejected path event changed statistics or evidence")
+				}
+			}
+			if edge != nil {
+				if err := state.Apply(MTRSessionEvent{Type: MTRSessionPathEndEvent}); err == nil {
+					t.Fatal("accepted reopening without transit evidence")
+				}
+			}
+			if err := state.Apply(MTRSessionEvent{Type: MTRSessionPathEndEvent, PathEnd: edge}); err != nil {
+				t.Fatalf("rejected matching evidence: %v", err)
+			}
+		}
+	}
+}
+
 func TestMTRSessionBoundedReplayNaturalCompletion(t *testing.T) {
 	state := NewMTRReplayState(true, 3)
 	var lastEvent MTRSessionEvent

--- a/trace/mtr_session_runtime.go
+++ b/trace/mtr_session_runtime.go
@@ -1,0 +1,57 @@
+package trace
+
+import "time"
+
+// Session events are emitted from the scheduler goroutine only. A recorder
+// failure cancels all workers before another probe can be scheduled. Applied
+// changes must still be delivered when cancellation races with their accounting.
+func (rt *mtrSchedulerRuntime) emitSessionEvent(event MTRSessionEvent) bool {
+	if rt.cfg.OnEvent == nil {
+		return true
+	}
+	event.At = time.Now()
+	event.Generation = rt.generation
+	event.Iteration = rt.computeIteration()
+	if err := rt.cfg.OnEvent(event); err != nil {
+		rt.workers.cancel(err)
+		return false
+	}
+	return true
+}
+
+func (rt *mtrSchedulerRuntime) emitSessionProbe(hop Hop, response *MTRProbeResponse, doneAt time.Time) bool {
+	if rt.cfg.OnEvent == nil {
+		return true
+	}
+	return rt.emitSessionEvent(MTRSessionEvent{
+		Type: MTRSessionProbeEvent,
+		Probe: &MTRSessionProbe{
+			TTL: hop.TTL, IP: mtrAddrString(hop.Address), Host: hop.Hostname,
+			Success: hop.Success, RTT: hop.RTT, CompletedAt: doneAt,
+			Geo: cloneMTRGeo(hop.Geo), MPLS: append([]string(nil), hop.MPLS...),
+			Response: cloneMTRProbeResponse(response),
+		},
+	})
+}
+
+// The scheduler observes path evidence before it accounts the cause probe.
+// Persist the cause first while retaining the legacy OnPathEnd callback order.
+func (rt *mtrSchedulerRuntime) flushSessionPath() bool {
+	if !rt.sessionPathChanged {
+		return true
+	}
+	reason := rt.sessionPathEnd
+	rt.sessionPathChanged = false
+	rt.sessionPathEnd = nil
+	return rt.emitSessionEvent(MTRSessionEvent{Type: MTRSessionPathEndEvent, PathEnd: reason})
+}
+
+func (rt *mtrSchedulerRuntime) emitSessionMetadata(ip string, patch mtrMetadataPatch) bool {
+	if rt.cfg.OnEvent == nil {
+		return true
+	}
+	return rt.emitSessionEvent(MTRSessionEvent{
+		Type:     MTRSessionMetadataEvent,
+		Metadata: &MTRSessionMetadata{IP: ip, Host: patch.host, Geo: cloneMTRGeo(patch.geo)},
+	})
+}


### PR DESCRIPTION
### Summary

- 新增 `--mtr-record FILE`，保存 CLI MTR 会话；新增独立 `--mtr-replay FILE`，离线恢复统计、路径状态和三分钟历史视图。
- full、tiny、ntr 均支持；现有 MTR RAW、NDJSON v1 和最终 JSON 报告契约保持不变。

### Motivation

Refs nxtrace/NTrace-core#389。短暂故障恢复后，原有三分钟内存历史不足以留存和复核整次会话。记录已接受的探测、已应用的元数据及控制事件，使统计和重置边界能够离线重建。

### Changes

- 在调度器实际应用事件的位置统一记录 probe、metadata、pause/resume、reset 和 path_end，隔离重置前的在途结果；复用现有统计聚合器。
- 增加独立、带版本的 JSONL 格式，独占创建文件，Unix 权限 0600，限制单行大小；编码、短写、同步和关闭错误返回失败。
- 恢复缺少结束事件或末行截断的有效部分，持续标记不完整并返回非零；非法中间事件、版本和序号异常直接报错。
- 回放在网络初始化之前分流，支持最终报告/JSON、原速播放、暂停、回头及 J 时间定位；流式 O(N) 定位可取消，采用回放时钟维护历史。
- 更新中英文说明及格式/恢复文档，在 Linux、macOS、Windows CI 加入三种 flavor 的 PTY/ConPTY 录制回放测试。

### Testing

- 本地 `go build ./...`、`go test ./...` 通过。
- tiny/ntr 的 `cmd`、`server` 回归，以及 `GOEXPERIMENT=nojsonv2` 的 `cmd`、`trace`、`printer`、`internal/mtrsession` 测试通过。
- `cmd`、`printer`、`internal/mtrsession` 竞态检查和相关 trace 竞态回归通过。
- macOS 三种 flavor 的真实 PTY 测试通过，覆盖录制、定位、播放、暂停、历史、列编辑及终端恢复。
- 本地环回录制与离线 JSON 统计一致；截断恢复返回非零；RAW 下游关闭后及时退出并保留可读取记录。
- 合成长记录：400 秒 / 4000 probes 验证历史窗口和早期定位；当前提交读取 100000 probes、约 55.2 MiB 的旧日期记录，单次本地读取约 4.57 秒、最大 RSS 约 39.7 MiB。该测量不代表跨平台性能承诺。
- 当前提交 `2cd92ac` 已合入主线 `1c142e8`；本地全包、tiny/ntr、相关包竞态及 lint 通过。
- 六种构建（full/tiny/ntr × 默认 JSON/nojsonv2）的 36 组完整互读、36 组截断恢复和 36 组 JSON 短参数互读通过；macOS 三种 flavor 的真实 PTY 与 SIGINT/SIGTERM 回归通过。
- 当前提交的全部适用 CI（含性能证据任务）通过；Codex 和 CodeRabbit 均已覆盖此提交，14 条评审线程全部关闭。
- Linux 实机验收：公网 18 组双栈三协议录制/回放及真实 Geo/PTR 通过；隔离网络 28 项验收通过（路径夹具修正后定向复测），含 195.03 秒真实会话、三分钟前故障定位、受控不可达/重新开放/目的地变化、截断恢复、11 类非法记录及输出失败。
- full/tiny/ntr 实机 PTY 与 SIGINT/SIGTERM 通过；普通用户的报告/JSON/历史及异常文件回放，经 strace 核对网络系统调用均为 0。
- 私有路径夹具补齐中间网段回程路由、调整 ICMP 限速并串行探测后，第二跳不可达 → 重新开放 → 三跳到达 → 重置后一跳的原断言全部通过；应用代码与已测二进制未改变。

### Notes for Reviewers

- 重点核查事件与实际聚合顺序、重置代次、路径隐藏/清理/重新开放，以及不完整文件的退出语义。
- 记录是新格式，不将现有 NDJSON 当作可回放文件；回放不会补查缺失 Geo/PTR。
- 首版不包含 Web/MCP 回放、倍速、HTML 导出、索引、云存储或路由变化检测；文件打开后不追踪新增内容。
- 当前 HEAD 的 CI、AI 评审和最终 Linux 实机验收已完成，尚未执行合并。
- 已审查旧回归跳过项：Linux/macOS 外部 IPv6 与 IPv6 包大小；Windows 外部 IPv6、tshark 包大小及独立 MTU 终端。它们不计为已覆盖；独立 TOS 双栈抓包及本功能九组终端 CI 均实际通过。
