### PR TITLE
修复 TOS 抓包流量混入与 Esc 测试时序误判

### DIFF
--- a/cmd/mtr_column_editor_test.go
+++ b/cmd/mtr_column_editor_test.go
@@ -115,15 +115,36 @@ func TestMTRKeyLoopCancelWhileReadBlocked(t *testing.T) {
 	defer func() { _ = r.Close() }()
 	defer func() { _ = w.Close() }()
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	u := newMTRUI(cancel, 0)
 	done := make(chan struct{})
 	go func() { u.readKeysLoop(ctx, r); close(done) }()
-	_, _ = w.Write([]byte("o\x1b"))
-	time.Sleep(75 * time.Millisecond)
-	_, e := u.columnSnapshot()
-	if e.Active {
-		t.Fatal("bare Esc did not cancel without another read")
+	waitEditor := func(active bool) {
+		t.Helper()
+		timer := time.NewTimer(2 * time.Second)
+		defer timer.Stop()
+		for {
+			_, editor := u.columnSnapshot()
+			if editor.Active == active {
+				return
+			}
+			select {
+			case <-u.redraw:
+			case <-timer.C:
+				t.Fatalf("editor did not become active=%v without another read", active)
+			}
+		}
 	}
+	if _, err := w.Write([]byte("o")); err != nil {
+		t.Fatal(err)
+	}
+	waitEditor(true)
+	if _, err := w.Write([]byte("\x1b")); err != nil {
+		t.Fatal(err)
+	}
+	// Wait for the parser's redraw instead of assuming a scheduler deadline.
+	// Escape timing itself is covered with explicit timestamps above.
+	waitEditor(false)
 	cancel()
 	select {
 	case <-done:

--- a/scripts/regression/test_tos_capture.py
+++ b/scripts/regression/test_tos_capture.py
@@ -84,6 +84,19 @@ class CaptureAssertions(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_rebuild_capture(self.path, output, 6, '::1')
 
+    def test_udp_session_excludes_unrelated_loopback_traffic(self):
+        self.pcap([self.ipv4_udp(16, 1), self.ipv4_udp(16, 2),
+                   self.ipv4_udp(0, 3)])
+        result = assert_capture(self.path, 4, 'udp', 16, '127.0.0.1', '127.0.0.1',
+                                source_ports=(40001, 40002))
+        self.assertEqual(result['packets'], 2)
+        # Matching probe sessions must still fail if any TOS byte is wrong.
+        self.pcap([self.ipv4_udp(16, 1), self.ipv4_udp(0, 2),
+                   self.ipv4_udp(16, 3)])
+        with self.assertRaisesRegex(AssertionError, 'wrong TOS'):
+            assert_capture(self.path, 4, 'udp', 16, '127.0.0.1', '127.0.0.1',
+                           source_ports=(40001, 40002))
+
     def test_all_eight_bits_checked(self):
         self.pcap([self.ipv4_udp(184, 1), self.ipv4_udp(185, 2)])
         with self.assertRaisesRegex(AssertionError, 'wrong TOS'):

--- a/scripts/regression/tos_capture.py
+++ b/scripts/regression/tos_capture.py
@@ -228,7 +228,11 @@ def run_matrix(binary, artifacts):
                     # Fallback MTR repeats the same TCP sequence/UDP payload in
                     # separate one-probe rounds. Distinct session source ports
                     # identify real probes without counting loopback duplicates.
-                    source_ports = (47464, 47465) if mode == "report" and protocol != "icmp" else ()
+                    # Constrain traceroute too: loopback can carry unrelated UDP
+                    # traffic from system services while tcpdump is running.
+                    source_ports = ()
+                    if protocol != "icmp":
+                        source_ports = (47464, 47465) if mode == "report" else (47464,)
                     commands = [(f"{label}-port{port}", args[:-1] + ["--source-port", str(port), target])
                                 for port in source_ports] if source_ports else [(label, args)]
                     with capture_packets(tcpdump, interface, target, capture, log):


### PR DESCRIPTION
### Summary

- 修复 macOS TOS 抓包将系统服务 UDP 日志包误认为探测包的问题。
- 修复 Windows MTR 按键测试依赖 75ms 固定等待产生的偶发失败。

### Motivation

PR #236 合并后，主线 Runtime Regression CI 与 TOS packet acceptance 失败。下载失败抓包确认两个 NextTrace UDP 探测包的 TOS 都为 16；触发断言的是另一源端口发送的 macOS softwareupdated 日志包，TOS 为 0。Windows 失败则出现在仅等待 75ms 的 Esc 异步测试。

### Changes

- traceroute TCP/UDP 与 MTR 一样显式指定源端口，并以该会话端口筛选探测包。
- 增加混入无关 UDP 流量的回归断言；匹配会话的错误 TOS 仍必须失败。
- 按键测试先确认编辑器已打开，再发送 Esc；通过 redraw 通知等待关闭，保留 2 秒失败上限并清理取消函数。
- 不修改生产发包或按键处理逻辑。

### Testing

- `go test ./...`、`go build ./...` 通过。
- `go test -race ./cmd -run '^TestMTRKeyLoopCancelWhileReadBlocked$' -count=100` 通过。
- Python 抓包断言 12 项通过。
- `go test -tags flavor_tiny ./cmd`、`go test -tags flavor_ntr ./cmd` 通过。
- 原始失败 PCAP：复现旧断言失败；筛选实际探测会话后确认两个不同探测包均为 TOS 16。
- Linux、macOS、Windows TOS 抓包 CI 通过；下载并独立复核三平台共 324 组 PCAP 通过。
- 三平台运行时回归及性能证据 CI 通过；提交 `5136332` 的 53 项检查通过。

### Notes for Reviewers

- 保持完整 8 位 TOS、连续探测、重复包去重和会话缺失检查，不通过重试或 SKIP 绕过失败。
- 原失败工作流：[Runtime Regression CI](https://github.com/nxtrace/NTrace-dev/actions/runs/34179678263)、[TOS packet acceptance](https://github.com/nxtrace/NTrace-dev/actions/runs/34179678245)。
